### PR TITLE
Updated to latest ember-cli with 0 deprecations

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -8,6 +8,7 @@ var computed = Ember.computed;
 var observer = Ember.observer;
 var isNone = Ember.isNone;
 var eA = Ember.A;
+var keys = Object.keys || Ember.keys;
 
 var defaultMessages = {
   searchLabel: 'Search:',
@@ -345,11 +346,11 @@ export default Ember.Component.extend(Ember.SortableMixin, {
   _setupMessages: function () {
     var newMessages = {};
     var customMessages = getWithDefault(this, 'customMessages', {});
-    Ember.keys(customMessages).forEach(k => {
+    keys(customMessages).forEach(k => {
       set(newMessages, k, get(customMessages, k));
     });
 
-    Ember.keys(defaultMessages).forEach(k => {
+    keys(defaultMessages).forEach(k => {
       if(isNone(get(newMessages, k))) {
         set(newMessages, k, get(defaultMessages, k));
       }

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import SortableMixin from 'ember-legacy-controllers/utils/sortable-mixin';
 
 var get = Ember.get;
 var getWithDefault = Ember.getWithDefault;
@@ -24,7 +25,7 @@ var defaultMessages = {
 /**
  * data -> filteredContent (and content as its alias) -> arrangedContent -> visibleContent
  */
-export default Ember.Component.extend(Ember.SortableMixin, {
+export default Ember.Component.extend(SortableMixin, {
 
   /**
    * Number of records shown on one table-page (size of the <code>visibleContent</code>)

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import SortableMixin from 'ember-legacy-controllers/utils/sortable-mixin';
+import fmt from '../utils/fmt';
 
 var get = Ember.get;
 var getWithDefault = Ember.getWithDefault;
@@ -274,7 +275,7 @@ export default Ember.Component.extend(SortableMixin, {
     var isLastPage = !get(this, 'gotoForwardEnabled');
     var firstIndex = arrangedContentLength === 0 ? 0 : pageSize * (currentPageNumber - 1) + 1;
     var lastIndex = isLastPage ? arrangedContentLength : currentPageNumber * pageSize;
-    return Ember.String.fmt(get(this, 'messages.tableSummary'), firstIndex, lastIndex, arrangedContentLength);
+    return fmt(get(this, 'messages.tableSummary'), firstIndex, lastIndex, arrangedContentLength);
   }),
 
   /**

--- a/addon/utils/fmt.js
+++ b/addon/utils/fmt.js
@@ -1,0 +1,20 @@
+import Ember from "ember";
+
+export default function fmt(str, formats) {
+  var cachedFormats = formats;
+
+  if (!Ember.isArray(cachedFormats) || arguments.length > 2) {
+    cachedFormats = new Array(arguments.length - 1);
+
+    for (var i = 1, l = arguments.length; i < l; i++) {
+      cachedFormats[i - 1] = arguments[i];
+    }
+  }
+
+  // first, replace any ORDERED replacements.
+  var idx  = 0; // the current index for non-numerical replacements
+  return str.replace(/%@([0-9]+)?/g, function(s, argIndex) {
+    argIndex = (argIndex) ? parseInt(argIndex, 10) - 1 : idx++;
+    return cachedFormats[argIndex];
+  });
+}

--- a/app/helpers/object-property.js
+++ b/app/helpers/object-property.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-function objectProperty(obj, prop) {
+function objectProperty([obj, prop]) {
   return Ember.get(obj, prop);
 }
-export default Ember.Handlebars.makeBoundHelper(objectProperty);
+export default Ember.Helper.helper(objectProperty);

--- a/app/utils/fmt.js
+++ b/app/utils/fmt.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/utils/fmt';

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "1.13.8",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.9",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name": "ember-models-table",
   "dependencies": {
-    "ember": "1.13.5",
+    "ember": "1.13.8",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.7",
+    "ember-data": "1.13.9",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.7",
+    "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "jquery": "^1.11.3",
+    "loader.js": "ember-cli/loader.js#3.2.1",
+    "qunit": "~1.18.0"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -16,7 +16,7 @@ module.exports = {
     {
       name: 'ember-beta',
       dependencies: {
-        'ember': '2.0.0-beta.2'
+        'ember': 'components/ember#beta'
       },
       resolutions: {
         'ember': 'beta'

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember try:testall"
   },
   "repository": "https://github.com/onechiporenko/ember-models-table",
@@ -18,20 +18,20 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.6",
-    "ember-cli-app-version": "0.4.0",
+    "broccoli-asset-rev": "^2.1.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.18",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
-    "ember-cli-sri": "^1.0.1",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.7",
+    "ember-cli-sri": "^1.0.3",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "1.13.9",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
@@ -41,10 +41,9 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "demoURL": "http://onechiporenko.github.io/ember-models-table/"
-  }
-}
+    "demoURL": "http://onechiporenko.github.io/ember-models-table/",
+    "configPath": "tests/dummy/config"
+  }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.9",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "ember-legacy-views": "0.2.0",
     "ember-legacy-controllers": "0.0.1",
     "ember-cli-babel": "^5.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -31,18 +31,20 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
+    "ember-legacy-controllers": "0.0.1",
     "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
     "demoURL": "http://onechiporenko.github.io/ember-models-table/",
     "configPath": "tests/dummy/config"
-  }}
+  }
+}

--- a/tests/unit/components/models-table-test.js
+++ b/tests/unit/components/models-table-test.js
@@ -13,10 +13,10 @@ moduleForComponent('models-table', 'ModelsTable', {
   needs: ['helper:object-property', 'helper:is-equal'],
 
   setup: function () {
-    this.container.register('template:custom/test', resolver.resolve('template:custom/test'));
-    this.container.register('template:custom/action', resolver.resolve('template:custom/action'));
-    this.container.register('template:custom/pagination', resolver.resolve('template:custom/pagination'));
-    this.container.register('template:components/models-table/simple-pagination', resolver.resolve('template:components/models-table/simple-pagination'));
+    this.registry.register('template:custom/test', resolver.resolve('template:custom/test'));
+    this.registry.register('template:custom/action', resolver.resolve('template:custom/action'));
+    this.registry.register('template:custom/pagination', resolver.resolve('template:custom/pagination'));
+    this.registry.register('template:components/models-table/simple-pagination', resolver.resolve('template:components/models-table/simple-pagination'));
   }
 
 });

--- a/tests/unit/utils/fmt-test.js
+++ b/tests/unit/utils/fmt-test.js
@@ -1,0 +1,10 @@
+import fmt from '../../../utils/fmt';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | fmt');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = fmt('Hi %@, I\'m %@', 'John', 'Nico');
+  assert.equal(result, 'Hi John, I\'m Nico');
+});


### PR DESCRIPTION
Ready to work without deprecation also in 2.*
To reach this I had to use [`ember-legacy-controllers`](https://github.com/emberjs/ember-legacy-controllers) because `Ember.SortableMixin` doesn't exist anymore in 2.*
I think that the component could be refactored using `Ember.computed.sort()` and `[].sort()` but I didn't have time to look into it.
Also, `ember-legacy-controllers` depends on `ember-legacy-views` at least by now emberjs/ember-legacy-controllers#8