### PR TITLE
Add div to support Firefox behavior with floating positioning

### DIFF
--- a/app/templates/components/models-table.hbs
+++ b/app/templates/components/models-table.hbs
@@ -29,6 +29,10 @@
       </div>
     </div>
   {{/if}}
+
+  <!-- Div needed by Firefox to reset floating positionning -->
+  <div style="clear:both"/>
+
   <div class="inner-table-wrapper">
     <table class="{{if tableStriped 'table-striped'}} {{if tableBordered 'table-bordered'}} {{if tableCondensed 'table-condensed'}} table">
       <thead>


### PR DESCRIPTION
Current Ember-models-table doesn't behave properly with Forefox du to <div> float positionning. 
This simple patch fix the issue. 
Any chance to get it in a coming version ? 