### PR TITLE
Fixed sorting icons

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -53,8 +53,8 @@ const defaultMessages = {
 };
 
 const defaultIcons = {
-  'sort-asc': 'glyphicon glyphicon-triangle-bottom',
-  'sort-desc': 'glyphicon glyphicon-triangle-top',
+  'sort-asc': 'glyphicon glyphicon-triangle-top',
+  'sort-desc': 'glyphicon glyphicon-triangle-bottom',
   'column-visible': 'glyphicon glyphicon-check',
   'column-hidden': 'glyphicon glyphicon-unchecked',
   'nav-first': 'glyphicon glyphicon-chevron-left',


### PR DESCRIPTION
Sorting icons were in the wrong order: v for ASC and /\ for DESC.
