### PR TITLE
Add models-table-server-paginated component

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -1,0 +1,211 @@
+import Ember from 'ember';
+import ModelsTable from './models-table';
+import layout from 'templates/components/models-table';
+
+var { get, set, computed, observer } = Ember;
+
+export default ModelsTable.extend({
+  layout: layout,
+
+  /**
+   * True if data is currently being loaded from the server.
+   * Can be used in the template to e.g. display a loading spinner.
+   *
+   * @type {boolean}
+   * @name isLoading
+   */
+  isLoading: false,
+
+  /**
+   * The property on meta to load the pages count from.
+   *
+   * @type {string}
+   * @name metaPagesCountProperty
+   */
+  metaPagesCountProperty: 'pagesCount',
+  /**
+   * The property on meta to load the total item count from.
+   *
+   * @type {string}
+   * @name metaItemsCountProperty
+   */
+  metaItemsCountProperty: 'itemsCount',
+
+  /**
+   * The time to wait until new data is actually loaded.
+   * This can be tweaked to avoid making too many server requests.
+   *
+   * @type {number}
+   * @name {debounceDataLoadTime}
+   */
+  debounceDataLoadTime: 500,
+
+  /**
+   * The query parameters to use for server side filtering / querying.
+   *
+   * @type {object}
+   * @name filterQueryParameters
+   */
+  filterQueryParameters: {
+    globalFilter: 'search',
+    sort: 'sort',
+    sortDirection: 'sortDirection',
+    page: 'page',
+    pageSize: 'pageSize'
+  },
+
+  /**
+   * This is set during didReceiveAttr and whenever the page/filters change.
+   */
+  filteredContent: [],
+
+  /**
+   * For server side filtering, these two properties are the same as the filtered content.
+   */
+  visibleContent: computed.alias('arrangedContent'),
+  arrangedContent: computed.alias('filteredContent'),
+
+  /**
+   * The total content length is get from the meta information.
+   * Set metaItemsCountProperty to change from which meta property this is loaded.
+   *
+   * @type {number}
+   * @name arrangedContentLength
+   */
+  arrangedContentLength: computed('filteredContent.meta', function () {
+    var itemsCountProperty = get(this, 'metaItemsCountProperty');
+    var meta = get(this, 'filteredContent.meta');
+    return get(meta, itemsCountProperty) || 0;
+  }),
+
+  /**
+   * The pages count is get from the meta information.
+   * Set metaPagesCountProperty to change from which meta property this is loaded.
+   *
+   * @type {number}
+   * @name pagesCount
+   */
+  pagesCount: computed('filteredContent.meta', function () {
+    var pagesCountProperty = get(this, 'metaPagesCountProperty');
+    var meta = get(this, 'filteredContent.meta');
+    return get(meta, pagesCountProperty) || 1;
+  }),
+
+  /**
+   * The index of the first item that is currently being shown.
+   *
+   * @type {number}
+   * @name firstIndex
+   */
+  firstIndex: computed('pageSize', 'currentPageNumber', function () {
+    return get(this, 'pageSize') * (get(this, 'currentPageNumber') - 1) + 1;
+  }),
+
+  /**
+   * The index of the last item that is currently being shown.
+   *
+   * @type {number}
+   * @name lastIndex
+   */
+  lastIndex: computed('pageSize', 'currentPageNumber', function () {
+    var pageMax = get(this, 'pageSize') * get(this, 'currentPageNumber');
+    var itemsCount = get(this, 'arrangedContentLength');
+    return Math.min(pageMax, itemsCount);
+  }),
+
+  /**
+   * Whenever the current page, sort direction, page size, global filtering or column filtering change,
+   * The actual loading of data is debounced in order to avoid making too many requests to the server.
+   */
+  _loadDataObserver: observer('currentPageNumber', 'sortProperties.[]', 'pageSize', 'filterString', 'processedColumns.@each.filterString', function () {
+    Ember.run.debounce(this, this._loadData, get(this, 'debounceDataLoadTime'));
+  }),
+
+  /**
+   * This function actually loads the data from the server.
+   * It takes the store, modelName and query from the passed in data-object and adds page, sorting & filtering to it.
+   */
+  _loadData: function () {
+    var data = get(this, 'data');
+    var currentPageNumber = get(this, 'currentPageNumber');
+    var pageSize = get(this, 'pageSize');
+    var columns = get(this, 'processedColumns');
+
+    var sortProperties = get(this, 'sortProperties');
+    var filterString = get(this, 'filterString');
+
+    if (!get(data, 'query')) {
+      return;
+    }
+    var query = Ember.$.extend({}, get(data, 'query'));
+    var store = get(data, 'store');
+    var modelName = get(data, 'type.modelName');
+
+    // Add pagination information
+    query[get(this, 'filterQueryParameters.page')] = currentPageNumber;
+    query[get(this, 'filterQueryParameters.pageSize')] = pageSize;
+
+    // Add sorting information
+    var sort = sortProperties && get(sortProperties, 'length') ? sortProperties[0] : null;
+    if (sort) {
+      var sortBy = sort.split(':')[0];
+      var sortDirection = sort.split(':')[1].toUpperCase();
+
+      query[get(this, 'filterQueryParameters.sort')] = sortBy;
+      query[get(this, 'filterQueryParameters.sortDirection')] = sortDirection;
+    } else {
+      delete query[[get(this, 'filterQueryParameters.sort')]];
+      delete query[[get(this, 'filterQueryParameters.sortDirection')]];
+    }
+
+    // Add global filter
+    if (filterString) {
+      query[get(this, 'filterQueryParameters.globalFilter')] = filterString;
+    } else {
+      delete query[get(this, 'filterQueryParameters.globalFilter')];
+    }
+
+    // Add per-column filter
+    columns.forEach((column) => {
+      var filter = get(column, 'filterString');
+      if (filter) {
+        query[get(column, 'filteredBy') || get(column, 'propertyName')] = filter;
+      } else {
+        delete query[get(column, 'filteredBy') || get(column, 'propertyName')];
+      }
+    });
+
+    set(this, 'isLoading', true);
+    store.query(modelName, query).then((newData) => {
+      set(this, 'filteredContent', newData);
+      set(this, 'isLoading', false);
+    });
+  },
+
+  actions: {
+
+    gotoNext () {
+      if (!get(this, 'gotoForwardEnabled')) {
+        return;
+      }
+      var pagesCount = get(this, 'pagesCount');
+      var currentPageNumber = get(this, 'currentPageNumber');
+      if (pagesCount > currentPageNumber) {
+        this.incrementProperty('currentPageNumber');
+      }
+    },
+
+    gotoLast () {
+      if (!get(this, 'gotoForwardEnabled')) {
+        return;
+      }
+      var pagesCount = get(this, 'pagesCount');
+      set(this, 'currentPageNumber', pagesCount);
+    },
+
+  },
+
+  didReceiveAttrs: function () {
+    set(this, 'filteredContent', get(this, 'data'));
+  },
+});

--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ModelsTable from './models-table';
 import layout from 'templates/components/models-table';
 
-var { get, set, computed, observer } = Ember;
+var { get, set, computed, observer, typeOf, run } = Ember;
 
 export default ModelsTable.extend({
   layout: layout,
@@ -118,7 +118,7 @@ export default ModelsTable.extend({
    * The actual loading of data is debounced in order to avoid making too many requests to the server.
    */
   _loadDataObserver: observer('currentPageNumber', 'sortProperties.[]', 'pageSize', 'filterString', 'processedColumns.@each.filterString', function () {
-    Ember.run.debounce(this, this._loadData, get(this, 'debounceDataLoadTime'));
+    run.debounce(this, this._loadData, get(this, 'debounceDataLoadTime'));
   }),
 
   /**
@@ -201,6 +201,26 @@ export default ModelsTable.extend({
       }
       var pagesCount = get(this, 'pagesCount');
       set(this, 'currentPageNumber', pagesCount);
+    },
+
+    sort (column) {
+      const sortMap = {
+        none: 'asc',
+        asc: 'desc',
+        desc: 'none'
+      };
+      var sortedBy = get(column, 'sortedBy');
+      if (typeOf(sortedBy) === 'undefined') {
+        sortedBy = get(column, 'propertyName');
+      }
+      if (!sortedBy) {
+        return;
+      }
+
+      var currentSorting = get(column, 'sorting');
+      var newSorting = sortMap[currentSorting.toLowerCase()];
+      var sortingArgs = [column, sortedBy, newSorting];
+      this._singleColumnSorting(...sortingArgs);
     },
 
   },

--- a/app/components/models-table-server-paginated.js
+++ b/app/components/models-table-server-paginated.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/models-table-server-paginated';

--- a/app/templates/components/models-table/table-footer.hbs
+++ b/app/templates/components/models-table/table-footer.hbs
@@ -10,7 +10,7 @@
 
       <select class="form-control changePageSize" {{action 'changePageSize' on='change'}}>
         {{#each pageSizeValues key="@index" as |item|}}
-          <option value="{{item}}" selected={{is-equal item selectedValue}}>
+          <option value="{{item}}" selected={{is-equal item pageSize}}>
             {{item}}
           </option>
         {{/each}}


### PR DESCRIPTION
While models-table works great for certain amounts of data, it cannot work with server-side paginated data. In order to make this possible, I added a second component, `models-table-server-paginated`, which makes this scenario possible.

This component extends the base `models-table` component. For the end user, it can be used (nearly) the same:

```hbs
{{models-table-server-paginated data=model columns=myColumns}}
```

It expects `myData` to be an ember-data query, eg:

```js
model: function() {
  return this.store.query('my-model', {});
}
```

It will then take this query and extend it with pagination, sorting and filtering information. All other query parameters added in will remain untouched. Everything else works exactly the same - global filters, column filters etc. still use the same properties to control them. A few things to notice:

- When using `filterWithSelect` for a column, you must use `predefinedFilterOptions`, because the automatic loading of possible filter values cannot work here.
- There is a new optional field `filteredBy` for columns, which works much like `sortedBy`: if set, this field will be used as query parameter, otherwise it will use the `propertyName`.
- Sorting will not use multipleColumnSorting, it will only sort by one column.
- If you set `sortedBy: false` on a column, sorting will be disabled for this column.

There are a couple of things which can be configured to adapt to your API:

```js
// The property on meta to load the pages count from.
metaPagesCountProperty: 'pagesCount',

// The property on meta to load the total item count from.
metaItemsCountProperty: 'itemsCount',

// The time to wait until new data is actually loaded.
// This can be tweaked to avoid making too many server requests.
debounceDataLoadTime: 500,

// The query parameters to use for server side filtering / querying.
filterQueryParameters: {
  globalFilter: 'search',
  sort: 'sort',
  sortDirection: 'sortDirection',
  page: 'page',
  pageSize: 'pageSize'
},
```

This default configuration would try to get the total page count from `model.get('meta.pagesCount')` and the total item count from `model.get('meta.itemsCount')`, and would then go on to build the following query:

```js
columns: [
  {
    propertyName: 'name',
    filteredBy: 'model_name'
  }
]

// after searching globally for "searchtexthere" 
// and in the name column for "filterforname",
// and going to page 2,
// the following query would be built:
?page=2&pageSize=50&search=searchtexthere&sort=name&sortDirection=ASC&model_name=filterforname
```