### PR TITLE
Refactor observers

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -73,6 +73,8 @@ const defaultCssClasses = {
   columnsDropdownButtonWrapper: 'btn-group',
   columnsDropdown: 'dropdown-menu pull-right',
   theadCell: 'table-header',
+  theadCellNoSorting: 'table-header-no-sorting',
+  theadCellNoFiltering: 'table-header-no-filtering',
   tfooterWrapper: 'table-footer clearfix',
   footerSummary: 'table-summary',
   footerSummaryNumericPagination: 'col-md-3 col-sm-3',
@@ -696,12 +698,12 @@ export default Component.extend({
 
       let c = O.create(JSON.parse(JSON.stringify(column)));
       let propertyName = get(c, 'propertyName');
-      if (isNone(get(c, 'filterString'))) {
-        setProperties(c, {
-          filterString: '',
-          useFilter: !isNone(propertyName)
-        });
-      }
+      setProperties(c, {
+        filterString: get(c, 'filterString') || '',
+        useFilter: !isNone(propertyName) && !get(c, 'disableFiltering'),
+        useSorting: !isNone(propertyName) && !get(c, 'disableSorting')
+      });
+
       set(c, 'filterFunction', filterFunction);
 
       if (isNone(get(c, 'mayBeHidden'))) {

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -904,9 +904,22 @@ export default Component.extend({
    *
    * @name ModelsTable#userInteractionObserver
    */
-  userInteractionObserver: observer('processedColumns.@each.sort', 'processedColumns.@each.filterString', 'filterString', function () {
+  userInteractionObserver: observer('sortProperties.[]', 'processedColumns.@each.filterString', 'filterString', 'currentPageNumber', 'pageSize', function () {
     if (get(this, 'sendDisplayDataChangedAction')) {
-      this.sendAction('displayDataChangedAction');
+      let columns = get(this, 'processedColumns');
+      let settings = O.create({
+        sort: get(this, 'sortProperties'),
+        currentPageNumber: get(this, 'currentPageNumber'),
+        pageSize: get(this, 'pageSize'),
+        filterString: get(this, 'filterString'),
+        columnFilters: {}
+      });
+      columns.forEach((column) => {
+        if (get(column, 'filterString')) {
+          set(settings.columnFilters, get(column, 'propertyName'), get(column, 'filterString'));
+        }
+      });
+      this.sendAction('displayDataChangedAction', settings);
     }
   }),
 

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -615,25 +615,6 @@ export default Component.extend({
   pageSizeValues: A([10, 25, 50]),
 
   /**
-   * Open first page if user has changed pageSize
-   * @method pageSizeObserver
-   * @name ModelsTable#pageSizeObserver
-   */
-  pageSizeObserver: observer('pageSize', function () {
-    set(this, 'currentPageNumber', 1);
-  }),
-
-  /**
-   * Open first page if user has changed filterString
-   *
-   * @method filterStringObserver
-   * @name ModelsTable#filterStringObserver
-   */
-  filterStringObserver: observer('filterString', 'processedColumns.@each.filterString', function () {
-    set(this, 'currentPageNumber', 1);
-  }),
-
-  /**
    * Show first page if for some reasons there is no content for current page, but table data exists
    *
    * @method visibleContentObserver
@@ -1018,6 +999,7 @@ export default Component.extend({
       else {
         this._singleColumnSorting(...sortingArgs);
       }
+      set(this, 'currentPageNumber', 1);
     },
 
     changePageSize () {
@@ -1025,6 +1007,7 @@ export default Component.extend({
       const pageSizeValues = get(this, 'pageSizeValues');
       const selectedValue = pageSizeValues[selectedIndex];
       set(this, 'pageSize', selectedValue);
+      set(this, 'currentPageNumber', 1);
     },
 
     /**
@@ -1033,6 +1016,11 @@ export default Component.extend({
     changeFilterForColumn (column) {
       let val = this.$(`.changeFilterForColumn.${get(column, 'propertyName')}`)[0].value;
       set(column, 'filterString', val);
+      set(this, 'currentPageNumber', 1);
+    },
+
+    changeFilterString () {
+      set(this, 'currentPageNumber', 1);
     }
 
   }

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -7,6 +7,11 @@ import fmt from '../utils/fmt';
  * @property {string} title column's title
  * @property {string} template custom template used in the column's cells
  * @property {string} sortedBy custom data's property that is used to sort column
+ * @property {string} sortDirection the default sorting direction of the column, asc or desc - only in effect if sortPrecedence is set!
+ * @property {number} sortPrecedence the sort presedence for this column - needs to be larger than -1 for sortDirection to take effect
+ * @property {boolean} disableSorting if sorting should be disabled for this column
+ * @property {boolean} disableFiltering if filtering should be disabled for this column
+ * @property {string} filterString a default filtering for this column
  * @property {string} sorting is column sorted now
  * @property {boolean} isHidden is column hidden now
  * @property {boolean} mayBeHidden may this column be hidden
@@ -711,9 +716,9 @@ export default Component.extend({
       }
 
       const { sortDirection, sortPrecedence } = column;
-      const defaultSorting = sortDirection ? sortDirection.toLowerCase() : 'none';
       const hasSortPrecedence = (!isNone(sortPrecedence)) && (sortPrecedence > NOT_SORTED);
       const defaultSortPrecedence = hasSortPrecedence ? sortPrecedence : NOT_SORTED;
+      const defaultSorting = sortDirection && (sortPrecedence > NOT_SORTED) ? sortDirection.toLowerCase() : 'none';
 
       defineProperty(c, 'isVisible', computed.not('isHidden'));
       defineProperty(c, 'sortAsc', computed.equal('sorting', 'asc'));
@@ -753,6 +758,7 @@ export default Component.extend({
     this._updateFiltersWithSelect();
 
     // Apply initial sorting
+    this.set('sortProperties', A());
     const filteredOrderedColumns = nColumns.sortBy('sortPrecedence').filter((col) => isSortedByDefault(col));
     filteredOrderedColumns.forEach((column) => {
       this.send('sort', column);

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -352,7 +352,7 @@ export default Component.extend({
    * Action-name sent on user interaction
    *
    * @type {string}
-   * @default 'displayDataChanged
+   * @default 'displayDataChanged'
    * @name ModelsTable#displayDataChangedAction
    */
   displayDataChangedAction: 'displayDataChanged',
@@ -365,6 +365,24 @@ export default Component.extend({
    * @name ModelsTable#sendDisplayDataChangedAction
    */
   sendDisplayDataChangedAction: false,
+
+  /**
+   * Action-name sent on change of visible columns
+   *
+   * @type {string}
+   * @default 'columnsVisibilityChanged'
+   * @name ModelsTable#columnsVisibilityChangedAction
+   */
+  columnsVisibilityChangedAction: 'columnsVisibilityChanged',
+
+  /**
+   * Determines if action on change of visible columns should be sent
+   *
+   * @default false
+   * @type {boolean}
+   * @name ModelsTable#sendColumnsVisibilityChangedAction
+   */
+  sendColumnsVisibilityChangedAction: false,
 
   /**
    * True if all processedColumns are hidden by <code>isHidden</code>
@@ -929,6 +947,23 @@ export default Component.extend({
     }
   },
 
+  /**
+   * send <code>columnsVisibilityChangedAction</code>-action when user changes which columns are visible
+   * action is sent only if <code>sendColumnsVisibilityChangedAction</code> is true (default false)
+   */
+  _sendColumnsVisibilityChangedAction() {
+    if (get(this, 'sendColumnsVisibilityChangedAction')) {
+      let columns = get(this, 'processedColumns');
+      let columnsVisibility = {};
+      columnsVisibility = columns.map((column) => {
+        let options = getProperties(column, 'isHidden', 'mayBeHidden', 'propertyName');
+        options.isHidden = !!options.isHidden;
+        return options;
+      });
+      this.sendAction('columnsVisibilityChangedAction', columnsVisibility);
+    }
+  },
+
   actions: {
 
     sendAction () {
@@ -938,20 +973,24 @@ export default Component.extend({
     toggleHidden (column) {
       if (get(column, 'mayBeHidden')) {
         column.toggleProperty('isHidden');
+        this._sendColumnsVisibilityChangedAction();
       }
     },
 
     showAllColumns () {
       get(this, 'processedColumns').setEach('isHidden', false);
+      this._sendColumnsVisibilityChangedAction();
     },
 
     hideAllColumns () {
       get(this, 'processedColumns').setEach('isHidden', true);
+      this._sendColumnsVisibilityChangedAction();
     },
 
     restoreDefaultVisibility() {
       get(this, 'processedColumns').forEach(c => {
         set(c, 'isHidden', !get(c, 'defaultVisible'));
+        this._sendColumnsVisibilityChangedAction();
       });
     },
 

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -904,7 +904,7 @@ export default Component.extend({
    *
    * @name ModelsTable#userInteractionObserver
    */
-  userInteractionObserver: observer('sortProperties.[]', 'processedColumns.@each.filterString', 'filterString', 'currentPageNumber', 'pageSize', function () {
+  _sendDisplayDataChangedAction() {
     if (get(this, 'sendDisplayDataChangedAction')) {
       let columns = get(this, 'processedColumns');
       let settings = O.create({
@@ -921,7 +921,7 @@ export default Component.extend({
       });
       this.sendAction('displayDataChangedAction', settings);
     }
-  }),
+  },
 
   actions: {
 
@@ -954,6 +954,7 @@ export default Component.extend({
         return;
       }
       set(this, 'currentPageNumber', 1);
+      this._sendDisplayDataChangedAction();
     },
 
     gotoPrev () {
@@ -962,6 +963,7 @@ export default Component.extend({
       }
       if (get(this, 'currentPageNumber') > 1) {
         this.decrementProperty('currentPageNumber');
+        this._sendDisplayDataChangedAction();
       }
     },
 
@@ -974,6 +976,7 @@ export default Component.extend({
       var arrangedContentLength = get(this, 'arrangedContent.length');
       if (arrangedContentLength > pageSize * (currentPageNumber - 1)) {
         this.incrementProperty('currentPageNumber');
+        this._sendDisplayDataChangedAction();
       }
     },
 
@@ -986,10 +989,12 @@ export default Component.extend({
       var pageNumber = arrangedContentLength / pageSize;
       pageNumber = (0 === pageNumber % 1) ? pageNumber : (Math.floor(pageNumber) + 1);
       set(this, 'currentPageNumber', pageNumber);
+      this._sendDisplayDataChangedAction();
     },
 
     gotoCustomPage (pageNumber) {
       set(this, 'currentPageNumber', pageNumber);
+      this._sendDisplayDataChangedAction();
     },
 
     /**
@@ -1015,6 +1020,7 @@ export default Component.extend({
         this._singleColumnSorting(...sortingArgs);
       }
       set(this, 'currentPageNumber', 1);
+      this._sendDisplayDataChangedAction();
     },
 
     changePageSize () {
@@ -1023,6 +1029,7 @@ export default Component.extend({
       const selectedValue = pageSizeValues[selectedIndex];
       set(this, 'pageSize', selectedValue);
       set(this, 'currentPageNumber', 1);
+      this._sendDisplayDataChangedAction();
     },
 
     /**
@@ -1032,10 +1039,12 @@ export default Component.extend({
       let val = this.$(`.changeFilterForColumn.${get(column, 'propertyName')}`)[0].value;
       set(column, 'filterString', val);
       set(this, 'currentPageNumber', 1);
+      this._sendDisplayDataChangedAction();
     },
 
     changeFilterString () {
       set(this, 'currentPageNumber', 1);
+      this._sendDisplayDataChangedAction();
     }
 
   }

--- a/app/templates/components/models-table.hbs
+++ b/app/templates/components/models-table.hbs
@@ -48,7 +48,7 @@
                       {{/each}}
                     </select>
                   {{else}}
-                    {{input type="text" value=column.filterString class="form-control"}}
+                    {{input type="text" value=column.filterString class="form-control" focus-out='changeFilterString'}}
                   {{/if}}
                 {{else}}
                   &nbsp;

--- a/app/templates/components/models-table.hbs
+++ b/app/templates/components/models-table.hbs
@@ -20,10 +20,16 @@
       <tr>
         {{#each processedColumns as |column|}}
           {{#if column.isVisible}}
-            <th class="{{classes.theadCell}}" {{action "sort" column}}>
-              {{column.title}}
-              <span class="{{if column.sortAsc icons.sort-asc}} {{if column.sortDesc icons.sort-desc}}"></span>
-            </th>
+            {{#if column.useSorting}}
+              <th class="{{classes.theadCell}}" {{action "sort" column}}>
+                {{column.title}}
+                <span class="{{if column.sortAsc icons.sort-asc}} {{if column.sortDesc icons.sort-desc}}"></span>
+              </th>
+            {{else}}
+              <th class="{{classes.theadCell}} {{classes.theadCellNoSorting}}">
+                {{column.title}}
+              </th>
+            {{/if}}
           {{/if}}
         {{/each}}
       </tr>
@@ -31,7 +37,7 @@
         <tr>
           {{#each processedColumns as |column|}}
             {{#if column.isVisible}}
-              <th class="{{classes.theadCell}}">
+              <th class="{{classes.theadCell}} {{unless column.useFilter classes.theadCellNoFiltering}}">
                 {{#if column.useFilter}}
                   {{#if column.filterWithSelect}}
                     <select class="form-control changeFilterForColumn {{column.propertyName}}" {{action 'changeFilterForColumn' column on='change'}}>

--- a/app/templates/components/models-table/global-filter.hbs
+++ b/app/templates/components/models-table/global-filter.hbs
@@ -1,7 +1,7 @@
 <div class="{{classes.globalFilterWrapper}}">
   <form class="form-inline globalSearch" action="">
     <div class="form-group">
-      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString" action='changeFilterString' on='change'}}
+      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString" focus-out='changeFilterString'}}
     </div>
   </form>
 </div>

--- a/app/templates/components/models-table/global-filter.hbs
+++ b/app/templates/components/models-table/global-filter.hbs
@@ -1,7 +1,7 @@
 <div class="{{classes.globalFilterWrapper}}">
   <form class="form-inline globalSearch" action="">
     <div class="form-group">
-      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString"}}
+      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString" action='changeFilterString' on='change'}}
     </div>
   </form>
 </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -54,6 +54,17 @@
                     <td><p>If this is true, sorting will be disabled for this column.</p></td>
                   </tr>
                   <tr>
+                    <td><code>sortDirection</code></td>
+                    <td>String</td>
+                    <td><p>The default sorting for this column. Can be either <code>asc</code> or <code>desc</code>. Needs to be set in conjunction with <code>sortPrecedence</code>,
+                    otherwise it will not have any effect.</p></td>
+                  </tr>
+                  <tr>
+                    <td><code>sortPrecedence</code></td>
+                    <td>Number</td>
+                    <td><p>If this is bigger than -1, this column will be sorted by default by the specified <code>sortDirection</code>.</p></td>
+                  </tr>
+                  <tr>
                     <td><code>isHidden</code></td>
                     <td>Boolean</td>
                     <td><p>Is current column hidden by default</p></td>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -163,6 +163,18 @@
             <td><p>Determines if action on user interaction should be sent</p></td>
           </tr>
           <tr>
+            <td><code>columnsVisibilityChangedAction</code></td>
+            <td>String</td>
+            <td><pre>{{c.columnsVisibilityChangedAction}}</pre></td>
+            <td><p>Action-name sent on change of visible columns. The action will receive an array of objects as parameter, where every object looks like this: <code>{ propertyName: 'firstName', isHidden: true, mayBeHidden: false }</code>.</p></td>
+          </tr>
+          <tr>
+            <td><code>sendColumnsVisibilityChangedAction</code></td>
+            <td>Boolean</td>
+            <td><pre>{{c.sendColumnsVisibilityChangedAction}}</pre></td>
+            <td><p>Determines if action on change of visible columns should be sent</p></td>
+          </tr>
+          <tr>
             <td><code>columnsAreUpdateable</code></td>
             <td>Boolean</td>
             <td><pre>{{c.columnsAreUpdateable}}</pre></td>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -49,6 +49,11 @@
                     <td><p>Field-name for sorting by current column. If it isn't provided, <code>propertyName</code> is used</p></td>
                   </tr>
                   <tr>
+                    <td><code>disableSorting</code></td>
+                    <td>Boolean</td>
+                    <td><p>If this is true, sorting will be disabled for this column.</p></td>
+                  </tr>
+                  <tr>
                     <td><code>isHidden</code></td>
                     <td>Boolean</td>
                     <td><p>Is current column hidden by default</p></td>
@@ -57,6 +62,16 @@
                     <td><code>mayBeHidden</code></td>
                     <td>Boolean</td>
                     <td><p>Is current column me be hidden. This field determines, if column appears in the columns-dropdown. If <code>mayBeHidden</code> is <code>true</code> and <code>isHidden</code> is also <code>true</code> for current column, this column always be hidden</p></td>
+                  </tr>
+                  <tr>
+                    <td><code>disableFiltering</code></td>
+                    <td>Boolean</td>
+                    <td><p>If this is true, filtering will be disabled for this column.</p></td>
+                  </tr>
+                  <tr>
+                    <td><code>filterString</code></td>
+                    <td>String</td>
+                    <td><p>This will be set as default filter value for this column.</p></td>
                   </tr>
                   <tr>
                     <td><code>filterWithSelect</code></td>
@@ -128,7 +143,7 @@
             <td><code>displayDataChangedAction</code></td>
             <td>String</td>
             <td><pre>{{c.displayDataChangedAction}}</pre></td>
-            <td><p>Action-name sent on user interaction</p></td>
+            <td><p>Action-name sent on user interaction. The action will receive the current settings of the table as parameter.</p></td>
           </tr>
           <tr>
             <td><code>sendDisplayDataChangedAction</code></td>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -884,7 +884,7 @@ test('event on user interaction (filtering by column)', function (assert) {
 
   this.render(hbs`{{models-table columns=columns data=data displayDataChangedAction=displayDataChangedAction useFilteringByColumns=useFilteringByColumns targetObject=targetObject sendDisplayDataChangedAction=sendDisplayDataChangedAction}}`);
   this.$(selectors.theadSecondRowSecondColumnFilter).val('One');
-  this.$(selectors.theadSecondRowSecondColumnFilter).change();
+  this.$(selectors.theadSecondRowSecondColumnFilter).blur();
 });
 
 test('event on user interaction (global filtering)', function (assert) {
@@ -905,7 +905,7 @@ test('event on user interaction (global filtering)', function (assert) {
 
   this.render(hbs`{{models-table columns=columns data=data displayDataChangedAction=displayDataChangedAction targetObject=targetObject sendDisplayDataChangedAction=sendDisplayDataChangedAction}}`);
   this.$(selectors.filterString).val('One');
-  this.$(selectors.filterString).change();
+  this.$(selectors.filterString).blur();
 });
 
 test('event on user interaction (sorting)', function (assert) {


### PR DESCRIPTION
This PR improves various things without changing existing behaviour:

1.) Most observers have been removed, instead `currentPageNumber` is now reset directly in the actions.
2.) `displayDataChangedAction` now receives an object as parameter containing the filter/sorting settings currently in use
3.) A new action `columnsVisibilityChangedAction` has been added, which is called whenever a column is toggled. It receives an array of columns with their current visibility as parameter.
4.) `disableSorting` and `disableFiltering` have been added as options for columns
5.) The behaviour of `sortDirection` and `sortPrecedence` has been slightly improved (`sortDirection` is now completly ignored if no `sortPrecedence` is set), and documented in the dummy app
6.) Allow setting of `filterString` on columns as default filter value