### PR TITLE
Fix issue with nested propertyNames for filters

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -968,7 +968,7 @@ export default Component.extend({
       });
       columns.forEach((column) => {
         if (get(column, 'filterString')) {
-          set(settings.columnFilters, get(column, 'propertyName'), get(column, 'filterString'));
+          settings.columnFilters[get(column, 'propertyName')] = get(column, 'filterString');
         }
       });
       this.sendAction('displayDataChangedAction', settings);


### PR DESCRIPTION
If you use a nested propertyName, e.g. `author.name`, an error is thrown when using `Ember.set()`.