### PR TITLE
Add placeholder for search input field

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -56,6 +56,7 @@ const NOT_SORTED = -1;
 
 const defaultMessages = {
   searchLabel: 'Search:',
+  searchPlaceholder: '',
   'columns-title': 'Columns',
   'columns-showAll': 'Show All',
   'columns-hideAll': 'Hide All',

--- a/app/templates/components/models-table/global-filter.hbs
+++ b/app/templates/components/models-table/global-filter.hbs
@@ -1,7 +1,7 @@
 <div class="{{classes.globalFilterWrapper}}">
   <form class="form-inline globalSearch" {{action "" on="submit"}}>
     <div class="form-group">
-      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString" focus-out="changeFilterString" enter=""}}
+      <label>{{messages.searchLabel}}</label> {{input type="text" value=filterString class="form-control filterString" focus-out="changeFilterString" enter="" placeholder=messages.searchPlaceholder}}
     </div>
   </form>
 </div>


### PR DESCRIPTION
Something like this could be a nice improvement.
Users can already define the label with `customMessages` and `searchLabel`, and it would be nice to expose the `placeholder` attribute as well.

Feel free to comment about possible additional requirements / if this PR requires any further work.