### PR TITLE
Passing 3rd argument (row) to filterFunction()

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -630,7 +630,7 @@ export default Component.extend({
                 cellValue = cellValue.toLowerCase();
                 filterString = filterString.toLowerCase();
               }
-              return c.filterFunction(cellValue, filterString);
+              return c.filterFunction(cellValue, filterString, row);
             }
           }
           return true;


### PR DESCRIPTION
The 3rd argument represents current row. It enables user to create more fine-tuned customization of filterFunction().
Like for example filter by multiple properties at once when columns shows only one value (eg: localized names but only current locale name is visible)