### PR TITLE
Fix #152 - expose original column properties on column model

### DIFF
--- a/addon/-private/column.js
+++ b/addon/-private/column.js
@@ -22,7 +22,7 @@ const {
  * @property {string} componentForSortCell custom component used in the header cell with sorting and column title. It receives 4 attributes - table (this component), record, column (one of the processedColumns) and all data
  * @property {string} sortedBy custom data's property that is used to sort column
  * @property {string} sortDirection the default sorting direction of the column, asc or desc - only in effect if sortPrecedence is set!
- * @property {number} sortPrecedence the sort presedence for this column - needs to be larger than -1 for sortDirection to take effect
+ * @property {number} sortPrecedence the sort precedence for this column - needs to be larger than -1 for sortDirection to take effect
  * @property {boolean} disableSorting if sorting should be disabled for this column
  * @property {boolean} disableFiltering if filtering should be disabled for this column
  * @property {string} filterString a default filtering for this column
@@ -33,9 +33,10 @@ const {
  * @property {boolean} filterWithSelect should select-box be used as filter for this column
  * @property {boolean} sortFilterOptions should options in the select-box be sorted (<code>false</code> by default)
  * @property {string[]|number[]} predefinedFilterOptions list of option to the filter-box (used if <code>filterWithSelect</code> is true)
- * @property {string} className custom classnames for column
+ * @property {string} className custom classNames for column
  * @property {function} filterFunction custom function used to filter rows (used if <code>filterWithSelect</code> is false)
  * @property {string} filterPlaceholder placeholder for filter-input
+ * @property {object} originalDefinition object containing the definition of the column passed into the component.
  */
 export default O.extend({
 

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -962,7 +962,8 @@ export default Component.extend({
         data: get(this, 'data'),
         filterString: get(c, 'filterString') || '',
         useFilter: !isNone(filteredBy || propertyName) && !get(c, 'disableFiltering'),
-        useSorting: !isNone(sortedBy || propertyName) && !get(c, 'disableSorting')
+        useSorting: !isNone(sortedBy || propertyName) && !get(c, 'disableSorting'),
+        originalDefinition: column
       });
 
       set(c, 'filterFunction', filterFunction);

--- a/tests/dummy/app/templates/custom/sort-cell-original-definition.hbs
+++ b/tests/dummy/app/templates/custom/sort-cell-original-definition.hbs
@@ -1,0 +1,3 @@
+{{column.originalDefinition.CustomColumString}}|{{column.originalDefinition.CustomColumObject.name}}|{{column.originalDefinition.CustomColumBool}}|{{column.originalDefinition.CustomColumNumber}}
+
+{{partial headerSortingIconsTemplate}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -1687,3 +1687,24 @@ test('row-expand should trigger select/deselect row', function (assert) {
   assert.ok(this.firstRowIsSelected(), 'First row is selected');
 
 });
+
+test('columns column contains original definition as a nested property', function (assert) {
+
+  var columns = generateColumns(['index1', 'index2']);
+  columns[0].templateForSortCell = 'custom/sort-cell-original-definition';
+  columns[0].CustomColumString = 'custom-column-string';
+  columns[0].CustomColumObject = { name: 'custom-column-object' };
+  columns[0].CustomColumBool = true;
+  columns[0].CustomColumNumber = 1;
+
+  this.setProperties({
+    columns: columns,
+    data: generateContent(10, 1)
+  });
+  this.render(hbs`{{models-table columns=columns data=data multipleColumnsSorting=false}}`);
+
+  assert.equal(
+    this.getEachAsString(selectors.theadFirstRowFirstCell),
+    'custom-column-string|custom-column-object|true|1',
+    'Custom column properties present in originalDefinition property in processedColumns');
+});


### PR DESCRIPTION
With this fix, implementors could have access within the template overrides to the original column object passed into the component.

You could override the _setupColumns function, but this would be 70 extra lines for a one-line change.