### PR TITLE
Fix table-server-paginated: catch rejected store.query

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -18,6 +18,15 @@ export default ModelsTable.extend({
   isLoading: false,
 
   /**
+   * True if last data query promise has been rejected.
+   * Can be used in the template to e.g. indicate stale data or to e.g. show error state.
+   *
+   * @type {boolean}
+   * @name isError
+   */
+  isError: false,
+
+  /**
    * The property on meta to load the pages count from.
    *
    * @type {string}
@@ -173,9 +182,14 @@ export default ModelsTable.extend({
     });
 
     set(this, 'isLoading', true);
+    set(this, 'isError', false);
     store.query(modelName, query).then((newData) => {
       set(this, 'filteredContent', newData);
       set(this, 'isLoading', false);
+      set(this, 'isError', false);
+    }).catch(() => {
+      set(this, 'isLoading', false);
+      set(this, 'isError', true);
     });
   },
 


### PR DESCRIPTION
When store.query is rejected the state of the component isn't accurate because ```ModelsTableServerPaginated.isLoading``` remains true.  Adding a catch to the data.store's query to set false and add additional ```ModelsTableServerPaginated.isError``` boolean to surface error state in the templates.  

This addition or ```ModelsTableServerPaginated.isError``` is useful when you'd like to indicate to the user that their data might be less than fresh.