### PR TITLE
Fix #128 - provide default values when filteredContent.meta is empty.

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -86,7 +86,7 @@ export default ModelsTable.extend({
    */
   arrangedContentLength: computed('filteredContent.meta', function () {
     var itemsCountProperty = get(this, 'metaItemsCountProperty');
-    var meta = get(this, 'filteredContent.meta');
+    var meta = get(this, 'filteredContent.meta') || {};
     return get(meta, itemsCountProperty) || 0;
   }),
 
@@ -99,7 +99,7 @@ export default ModelsTable.extend({
    */
   pagesCount: computed('filteredContent.meta', function () {
     var pagesCountProperty = get(this, 'metaPagesCountProperty');
-    var meta = get(this, 'filteredContent.meta');
+    var meta = get(this, 'filteredContent.meta') || {};
     return get(meta, pagesCountProperty) || 1;
   }),
 
@@ -214,9 +214,9 @@ export default ModelsTable.extend({
    * @param {object} column
    * @return {string} title
    */
-   getCustomFilterTitle(column) {
-     return get(column, 'filteredBy') || get(column, 'propertyName');
-   },
+  getCustomFilterTitle(column) {
+    return get(column, 'filteredBy') || get(column, 'propertyName');
+  },
 
   actions: {
 

--- a/tests/integration/components/models-table-server-paginated-test.js
+++ b/tests/integration/components/models-table-server-paginated-test.js
@@ -1,0 +1,27 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+import hbs from 'htmlbars-inline-precompile';
+
+import {
+  generateColumns
+} from '../../helpers/f';
+
+
+moduleForComponent('models-table-server-paginated', 'ModelsTableServerPaginated | Integration', {
+  integration: true
+});
+
+test('should render without data', function (assert) {
+
+  let data = {};
+  this.setProperties({
+    data: data,
+    columns: generateColumns(['index'])
+  });
+
+  this.render(hbs`{{models-table-server-paginated data=data columns=columns}}`);
+  assert.ok(this.$().text());
+});


### PR DESCRIPTION
I ran into this issue as well when extending models-table-server-paginated but decided to PR the change proposed by @gossi