### PR TITLE
allow use of column.routeName and column.template together

### DIFF
--- a/app/templates/components/models-table/row.hbs
+++ b/app/templates/components/models-table/row.hbs
@@ -4,7 +4,9 @@
       <td class={{column.className}}>
         {{#if column.routeName}}
           {{#link-to column.routeName record.id}}
-            {{#if column.propertyName}}
+            {{#if column.template}}
+              {{partial column.template}}
+            {{else if column.propertyName}}
               {{get record column.propertyName}}
             {{else}}
               {{record.id}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -170,7 +170,7 @@
                   <tr>
                     <td><code>routeName</code></td>
                     <td>String</td>
-                    <td><p>If this property is defined, link to the route will be rendered in the cell. <code>propertyName</code> is used as an anchor. If it's not declared, <code>id</code> will be used. <br /> Main idea for <code>routeName</code> is to provide a simple way to generate links for each model in the <code>data</code>. It should not be used for any other purposes. See {{link-to "route-cells" "examples.route-cells"}} example.</p></td>
+                    <td><p>If this property is defined, link to the route will be rendered in the cell. The <code>template</code>'s content or the <code>propertyName</code> will be used as an anchor. If neither is declared, <code>id</code> will be used. <br /> Main idea for <code>routeName</code> is to provide a simple way to generate links for each model in the <code>data</code>. It should not be used for any other purposes. See {{link-to "route-cells" "examples.route-cells"}} example.</p></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
`column.routeName` is a great addition to model-table, but I have two use cases where it does not quite fit yet:

1. when a button ("edit this") at the end of each row should link to the record's subroute
2. when a possibly lengthy description should Iink there and I use a template with a helper that shortens too long strings

This is easily alleviated by allowing the template to be rendered between the a tags/inside the link-to.