### PR TITLE
Test models-table-server with "should render with data"

### DIFF
--- a/tests/integration/components/models-table-server-paginated-test.js
+++ b/tests/integration/components/models-table-server-paginated-test.js
@@ -6,6 +6,7 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 
 import {
+  generateContent,
   generateColumns
 } from '../../helpers/f';
 
@@ -15,7 +16,6 @@ moduleForComponent('models-table-server-paginated', 'ModelsTableServerPaginated 
 });
 
 test('should render without data', function (assert) {
-
   let data = {};
   this.setProperties({
     data: data,
@@ -24,4 +24,19 @@ test('should render without data', function (assert) {
 
   this.render(hbs`{{models-table-server-paginated data=data columns=columns}}`);
   assert.ok(this.$().text());
+});
+
+test('should render with data', function (assert) {
+  let data = generateContent(10, 1);
+  let columns = generateColumns(['index', 'indexWithHtml']);
+
+  this.setProperties({
+    data: data,
+    columns: generateColumns(['index'])
+  });
+
+  this.render(hbs`{{models-table-server-paginated data=data columns=columns}}`);
+
+  let text = this.$().text();
+  assert.ok(text.match(/Show 1 - 10 of 10/));
 });


### PR DESCRIPTION
Currently this fails, this test proves that the footer always shows 0 - 0 results found.

Let's find out why!