### PR TITLE
remove #-link and invisible class

### DIFF
--- a/app/templates/components/models-table/component-footer.hbs
+++ b/app/templates/components/models-table/component-footer.hbs
@@ -2,9 +2,9 @@
   {{! table summary start }}
   <div class="{{if useNumericPagination classes.footerSummaryNumericPagination classes.footerSummaryDefaultPagination}} {{classes.footerSummary}}">
     {{summary}}
-    <a href="#" {{action "clearFilters"}} class="btn btn-link clearFilters {{unless anyFilterUsed "invisible"}}">
-      <span class="{{classes.clearAllFiltersIcon}}"></span>
-    </a>
+    {{#if anyFilterUsed}}
+      <span onclick={{action "clearFilters"}} class="btn btn-link clearFilters {{classes.clearAllFiltersIcon}}"></span>
+    {{/if}}
   </div>
   {{! table summary end }}
   {{! pagesize selection start }}


### PR DESCRIPTION
I think it's much better to hide the complete button from template, not with the invisible-class. Also the #-link isn't needed.