### PR TITLE
Silence template-lint when building

### DIFF
--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -34,9 +34,11 @@
           {{partial allColumnsHiddenTemplate}}
         {{else}}
           {{#if visibleContent.length}}
+            {{! template-lint-disable unused-block-params}}
             {{#each visibleContent as |record index|}}
               {{partial rowTemplate}}
             {{/each}}
+            {{! template-lint-enable unused-block-params}}
           {{else}}
             {{partial noDataShowTemplate}}
           {{/if}}


### PR DESCRIPTION
Provides a clean build. Disabled the linter for unused-block-params.