### PR TITLE
Return promise in _loadData

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -179,9 +179,11 @@ export default ModelsTable.extend({
     });
 
     setProperties(this, {isLoading: true, isError: false});
-    store.query(modelName, query)
-      .then(newData => setProperties(this, {isLoading: false, isError: false, filteredContent: newData}))
+
+    let promise = store.query(modelName, query);
+    promise.then(newData => setProperties(this, {isLoading: false, isError: false, filteredContent: newData}))
       .catch(() => setProperties(this, {isLoading: false, isError: true}));
+    return promise;
   },
 
   /**


### PR DESCRIPTION
This small change makes it possible to easily extend models-table-server-paginated and hook into the `_loadData()` function for custom functionality.