### PR TITLE
Remove inline styles for clearing div & add userInteractionObserver to paginated sort action

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -250,6 +250,7 @@ export default ModelsTable.extend({
       let newSorting = sortMap[currentSorting.toLowerCase()];
       let sortingArgs = [column, sortedBy, newSorting];
       this._singleColumnSorting(...sortingArgs);
+      this.userInteractionObserver();
     }
 
   },

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -13,7 +13,7 @@
   </div>
 
   <!-- Div needed by Firefox to reset floating positioning -->
-  <div style="clear:both"/>
+  <div class='models-table-clear'></div>
 
   <div class="{{classes.innerTableWrapper}}">
     <table class="{{classes.table}}">

--- a/vendor/style.css
+++ b/vendor/style.css
@@ -9,3 +9,7 @@
 .models-table-wrapper .globalSearch {
   position: relative;
 }
+
+.models-table-clear {
+  clear: both;
+}


### PR DESCRIPTION
This PR replaces the div in model-table's template that has `style='clear:both;'` with a class, making it possible to overwrite this in certain cases. Currently, the div sometimes breaks the layout, and there is no (easy) way to prevent that on a case-by-case basis.

Additionally, the PR fixes a minor bug, where `this.userInteractionObserver()` wasn't called in the paginated table's `sort` action.