### PR TITLE
Add a better compare function for sorting

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import fmt from '../utils/fmt';
 import assignPoly from '../utils/assign-poly';
+import betterCompare from '../utils/better-compare';
 
 import layout from '../templates/components/models-table';
 import ModelsTableColumn from '../-private/column';
@@ -809,7 +810,7 @@ export default Component.extend({
     return sortProperties.length ? A(_filteredContent.sort((row1, row2) => {
       for (let i = 0; i < sortProperties.length; i++) {
         let [prop, direction] = sortProperties[i];
-        let result = compare(get(row1, prop), get(row2, prop));
+        let result = betterCompare(get(row1, prop), get(row2, prop));
         if (result !== 0) {
           return (direction === 'desc') ? (-1 * result) : result;
         }

--- a/addon/utils/better-compare.js
+++ b/addon/utils/better-compare.js
@@ -1,0 +1,43 @@
+import Ember from 'ember';
+
+const {
+  typeOf,
+  compare,
+  Comparable
+} = Ember;
+
+/**
+ * This is a better version of Ember.compare.
+ * Sadly, Ember.compare() will always return 0 when comparing two instances of JavaScript objects that do not
+ * implement the Comparable-mixin.
+ * This function will compare instances via their `valueOf()` method if available.
+ *
+ * @param {Mixed} v
+ * @param {Mixed} w
+ * @return {number}
+ */
+export default function betterCompare(v, w) {
+  let type1 = typeOf(v);
+  let type2 = typeOf(w);
+
+  if (Comparable) {
+    if (type1 === 'instance' && Comparable.detect(v) && v.constructor.compare) {
+      return v.constructor.compare(v, w);
+    }
+
+    if (type2 === 'instance' && Comparable.detect(w) && w.constructor.compare) {
+      return w.constructor.compare(w, v) * -1;
+    }
+  }
+
+  if ((type1 === 'instance' && type2 === 'instance') || (type1 === 'object' && type2 === 'object')) {
+    if (typeOf(v.compare) === 'function' && typeOf(w.compare) === 'function') {
+      return v.compare(v, w);
+    }
+    if (typeOf(v.valueOf) === 'function' && typeOf(w.valueOf) === 'function') {
+      return compare(v.valueOf(), w.valueOf());
+    }
+  }
+
+  return compare(v, w);
+}

--- a/tests/unit/utils/better-compare-test.js
+++ b/tests/unit/utils/better-compare-test.js
@@ -1,0 +1,53 @@
+import betterCompare from 'ember-models-table/utils/better-compare';
+import { module, test } from 'qunit';
+import Ember from 'ember';
+
+const {
+  Object: EmberObject
+} = Ember;
+
+module('Unit | Utility | better compare');
+
+test('it works', function(assert) {
+  let result = betterCompare(1, 2);
+  assert.equal(result, -1, 'it works with numbers');
+
+  result = betterCompare(2, 1);
+  assert.equal(result, 1, 'it works with equal numbers');
+
+  result = betterCompare(0, 0);
+  assert.equal(result, 0, 'it works with equal numbers');
+
+  result = betterCompare('aa', 'bb');
+  assert.equal(result, -1, 'it works with strings');
+
+  result = betterCompare('aa', 'aa');
+  assert.equal(result, 0, 'it works with equal strings');
+
+  result = betterCompare(true, false);
+  assert.equal(result, 1, 'it works with booleans');
+
+  result = betterCompare(true, true);
+  assert.equal(result, 0, 'it works with equal booleans');
+
+  result = betterCompare({}, {});
+  assert.equal(result, 0, 'it works with empty objects');
+
+  let a = EmberObject.create({});
+  let b = EmberObject.create({});
+  result = betterCompare(a, b);
+  assert.equal(result, 0, 'it works with objects without valueOf method');
+
+  a = EmberObject.create({
+    valueOf() {
+      return 2;
+    }
+  });
+  b = EmberObject.create({
+    valueOf() {
+      return 1;
+    }
+  });
+  result = betterCompare(a, b);
+  assert.equal(result, 1, 'it works with objects with valueOf method');
+});


### PR DESCRIPTION
`Ember.compare()` is really bad at comparing objects/instances like moment.js dates. 

This is especially an problem when using moment-instances as properties. Sorting them doesn't work at all, since they are regular JS-instances and do not implement the Ember.Compareable mixin - `Ember.compare(moment1, moment2)` will simply always return 0, no matter what the dates are.

This PR adds a better-compare method which takes these cases into account, and otherwise falls back to the regular `Ember.compare()` functionality.