### PR TITLE
Add rebuildTable() method to force a complete re-render

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1336,6 +1336,30 @@ export default Component.extend({
     set(this, '_expandedRowIndexes', A([]));
   }),
 
+  /**
+   * Rebuild the whole table.
+   * This can be called to force a complete re-render of the table.
+   *
+   * @method rebuildTable
+   * @private
+   */
+  rebuildTable() {
+    set(this, 'currentPageNumber', 1);
+    this._clearFilters();
+    this.setup();
+  },
+
+  /**
+   * Clear all filters.
+   *
+   * @method _clearFilters
+   * @private
+   */
+  _clearFilters() {
+    set(this, 'filterString', '');
+    get(this, 'processedColumns').setEach('filterString', '');
+  },
+
   actions: {
 
     sendAction () {
@@ -1519,8 +1543,7 @@ export default Component.extend({
      * Clear all column filters and global filter
      */
     clearFilters() {
-      set(this, 'filterString', '');
-      get(this, 'processedColumns').setEach('filterString', '');
+      this._clearFilters();
     },
 
     /**


### PR DESCRIPTION
This PR adds a `rebuildTable()` method to the component. This can be used to manually force a complete re-build of the table, resetting all filters/sorting/pagination settings.

This helps to solve  https://github.com/onechiporenko/ember-models-table/issues/131.

A usage example would be to extend the component, and then add something like this:

```js
didReceiveAttrs() {
  if (get(this, 'propertyThatIndicatesForceReload')) {
    this.rebuildTable();
  }
}
```