### PR TITLE
Check if value/filter is string before applying toLowerCase()

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -781,8 +781,8 @@ export default Component.extend({
               return true;
             }
             if (filteringIgnoreCase) {
-              cellValue = cellValue.toLowerCase();
-              filterString = filterString.toLowerCase();
+              cellValue = typeOf(cellValue) === 'string' ? cellValue.toLowerCase() : cellValue;
+              filterString = typeOf(filterString) === 'string' ? filterString.toLowerCase() : filterString;
             }
             return 'function' === typeOf(c.filterFunction) ? c.filterFunction(cellValue, filterString, row) : 0 === compare(cellValue, filterString);
           }


### PR DESCRIPTION
When using a custom filtering option, using `filteringIgnoreCase` can sometimes break.

E.g. I have a custom `filterFunction` that works with an array, it breaks if I don't deactivate `filteringIgnoreCase`. However, I do want to use that functionality for other, regular filters. 

This PR just checks if `filterString` and `cellValue` are strings before applying `toLowerCase()`, else it will just use the existing value.