### PR TITLE
Column sets

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -200,7 +200,9 @@ export default Component.extend({
    * @name ModelsTable#sortProperties
    * @default []
    */
-  sortProperties: A([]),
+  sortProperties: computed(function() {
+    return A([]);
+  }),
 
   /**
    * Determines if multi-columns sorting should be used
@@ -310,7 +312,9 @@ export default Component.extend({
    * @name ModelsTable#columnFieldsToCheckUpdate
    * @default ['propertyName', 'template']
    */
-  columnFieldsToCheckUpdate: A(['propertyName', 'template']),
+  columnFieldsToCheckUpdate: computed(function() {
+    return A(['propertyName', 'template']);
+  }),
 
   /**
    * All table records
@@ -319,7 +323,9 @@ export default Component.extend({
    * @name ModelsTable#data
    * @default []
    */
-  data: A([]),
+  data: computed(function() {
+    return A([]);
+  }),
 
   /**
    * Table columns
@@ -328,32 +334,42 @@ export default Component.extend({
    * @name ModelsTable#columns
    * @default []
    */
-  columns: A([]),
+  columns: computed(function() {
+    return A([]);
+  }),
 
   /**
    * @type {Ember.Object[]}
    * @name ModelsTable#processedColumns
    * @default []
    */
-  processedColumns: A([]),
+  processedColumns: computed(function() {
+    return A([]);
+  }),
 
   /**
    * @type {Object}
    * @name ModelsTable#messages
    */
-  messages: O.create({}),
+  messages: computed(function() {
+    return O.create({});
+  }),
 
   /**
    * @type {Object}
    * @name ModelsTable#classes
    */
-  classes: O.create({}),
+  classes: computed(function() {
+    return O.create({});
+  }),
 
   /**
    * @type {Object}
    * @name ModelsTable#icons
    */
-  icons: O.create({}),
+  icons: computed(function() {
+    return O.create({});
+  }),
 
   /**
    * List of the additional headers
@@ -362,7 +378,9 @@ export default Component.extend({
    * @type {groupedHeader[][]}
    * @name ModelsTable#groupedHeaders
    */
-  groupedHeaders: A([]),
+  groupedHeaders: computed(function() {
+    return A([]);
+  }),
 
   /**
    * Template with First|Prev|Next|Last buttons
@@ -534,7 +552,7 @@ export default Component.extend({
    * @name ModelsTable#_selectedItems
    */
   _selectedItems: null,
-  
+
   /**
    * Allow or disallow to select rows on click
    * If `false` - no row can be selected
@@ -634,7 +652,7 @@ export default Component.extend({
   anyFilterUsed: computed('globalFilterUsed', 'processedColumns.@each.filterUsed', function () {
     return get(this, 'globalFilterUsed') || get(this, 'processedColumns').isAny('filterUsed');
   }),
-  
+
   /**
    * True if all processedColumns dosn't use filtering and sorting
    *
@@ -911,7 +929,9 @@ export default Component.extend({
    * @default [10, 25, 50]
    * @name ModelsTable#pageSizeValues
    */
-  pageSizeValues: A([10, 25, 50]),
+  pageSizeValues: computed(function() {
+    return A([10, 25, 50]);
+  }),
 
   /**
    * List of options for pageSize-selectBox
@@ -922,7 +942,9 @@ export default Component.extend({
    * @default []
    * @private
    */
-  pageSizeOptions: A([]),
+  pageSizeOptions: computed(function() {
+    return A([]);
+  }),
 
   /**
    * Show first page if for some reasons there is no content for current page, but table data exists

--- a/app/templates/components/models-table/columns-dropdown.hbs
+++ b/app/templates/components/models-table/columns-dropdown.hbs
@@ -5,15 +5,36 @@
       {{messages.columns-title}} <span class="{{icons.caret}}"></span>
     </button>
     <ul class="{{classes.columnsDropdown}}">
-      <li><a {{action "showAllColumns" column bubbles=false}} href="#">{{messages.columns-showAll}}</a></li>
-      <li><a {{action "hideAllColumns" column bubbles=false}} href="#">{{messages.columns-hideAll}}</a></li>
-      <li><a {{action "restoreDefaultVisibility" column bubbles=false}} href="#">{{messages.columns-restoreDefaults}}</a></li>
+
+      {{#if columnDropdownOptions.showAll}}
+        <li>
+          <a {{action "showAllColumns" column bubbles=false}} href="#">{{messages.columns-showAll}}</a>
+        </li>
+      {{/if}}
+      {{#if columnDropdownOptions.hideAll}}
+        <li>
+          <a {{action "hideAllColumns" column bubbles=false}} href="#">{{messages.columns-hideAll}}</a>
+        </li>
+      {{/if}}
+      {{#if columnDropdownOptions.restoreDefaults}}
+        <li>
+          <a {{action "restoreDefaultVisibility" column bubbles=false}} href="#">{{messages.columns-restoreDefaults}}</a>
+        </li>
+      {{/if}}
+
+      {{#each columnDropdownOptions.columnSets as |columnSet|}}
+        <li>
+          <a {{action "toggleColumnSet" columnSet bubbles=false}} href="#">{{columnSet.label}}</a>
+        </li>
+      {{/each}}
+
       <li class="divider"></li>
+
       {{#each processedColumns as |column|}}
         {{#if column.mayBeHidden}}
           <li>
             <a {{action "toggleHidden" column bubbles=false}} href="#">
-                <span class="{{if column.isVisible icons.column-visible icons.column-hidden}}"></span> {{column.title}}
+              <span class="{{if column.isVisible icons.column-visible icons.column-hidden}}"></span> {{column.title}}
             </a>
           </li>
         {{/if}}

--- a/tests/dummy/app/controllers/examples/column-sets.js
+++ b/tests/dummy/app/controllers/examples/column-sets.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+import generateContent from '../../utils/c';
+
+const { A } = Ember;
+
+export default Ember.Controller.extend({
+
+  title: 'Column sets',
+  model: generateContent(10),
+  columns: A([
+    {
+      propertyName: 'id',
+      title: 'ID'
+    },
+    {
+      propertyName: 'firstName',
+      title: 'First Name'
+    },
+    {
+      propertyName: 'lastName',
+      title: 'Last Name'
+    },
+    {
+      propertyName: 'city',
+      title: 'City'
+    },
+    {
+      propertyName: 'age',
+      title: 'Age'
+    }
+  ]),
+  columnSets: [
+    {
+      label: 'Only Name',
+      showColumns: ['firstName', 'lastName']
+    },
+    {
+      label: 'Random',
+      showColumns(columns) {
+        columns.forEach((column) => {
+          column.set('isHidden', Math.random() > 0.5);
+        });
+        this._sendColumnsVisibilityChangedAction();
+      }
+    },
+    {
+      label: 'Add Name',
+      showColumns: ['firstName', 'lastName'],
+      hideOtherColumns: false
+    },
+    {
+      label: 'Toggle Name',
+      showColumns: ['firstName', 'lastName'],
+      toggleSet: true
+    }
+  ]
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -27,6 +27,7 @@ Router.map(function() {
     this.route('expandable-rows');
     this.route('display-data-changed-action');
     this.route('select-rows-with-checkboxes');
+    this.route('column-sets');
   });
 
   this.route('users', function() {

--- a/tests/dummy/app/templates/examples/column-sets.hbs
+++ b/tests/dummy/app/templates/examples/column-sets.hbs
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="col-md-12">
+    <h4>{{title}}</h4>
+  </div>
+  <div class="col-md-8">
+    {{models-table data=model columns=columns columnSets=columnSets}}
+  </div>
+  <div class="col-md-4">
+    <p>Component usage:</p>
+        <pre><code class="handlebars">&lbrace;&lbrace;models-table
+          data=model
+          columns=columns
+          columnSets=columnSets&rbrace;&rbrace;</code></pre>
+
+    <p><code>columns</code>:</p>
+    <pre><code class="javascript">{{to-string this 'columns'}}</code></pre>
+  </div>
+</div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -177,6 +177,48 @@
             </td>
           </tr>
           <tr>
+            <td><code>columnSets</code></td>
+            <td>Object[]</td>
+            <td><pre>[]</pre></td>
+            <td>
+              <p>Sets of columns that can be toggled together.</p>
+              <p>Each object should have:</p>
+              <table class="table table-condensed table-column-options">
+                <tbody>
+                  <tr>
+                    <td><code>label</code></td>
+                    <td>String</td>
+                    <td>The label for the set. This will be displayed in the columns dropdown.</td>
+                  </tr>
+                  <tr>
+                    <td><code>showColumns</code></td>
+                    <td>Array|Function</td>
+                    <td>
+                      This should either be an array of <code>propertyNames</code> to show, or a function.
+                      If it is a function, the function will be called with the <code>processedColumns</code> as attribute.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><code>hideOtherColumns</code></td>
+                    <td>Boolean</td>
+                    <td>
+                      If this is true (default), all columns not specified in <code>showColumns</code> will be hidden.
+                      If this is set to false, other columns will be left at whatever visibility they were before.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td><code>toggleSet</code></td>
+                    <td>Boolean</td>
+                    <td>
+                      If this is true (default is false), the set columns will be shown if one of them is currently hidden,
+                      else they will all be hidden. Settings this will result in a default of <code>hideOtherColumns=false</code>.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+          <tr>
             <td><code>groupedHeaders</code></td>
             <td>Object[][]</td>
             <td><pre>[]</pre></td>

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -176,6 +176,10 @@ export function toggleSecondColumnVisibility() {
   _columnsDropdownClick.bind(this)(5);
 }
 
+export function toggleColumnsDropdownItem(i) {
+  _columnsDropdownClick.bind(this)(i);
+}
+
 export function hideAllColumns() {
   _columnsDropdownClick.bind(this)(1);
 }


### PR DESCRIPTION
This PR adds the option to specify `columnSets`. These, if specified, will be rendered below the "Show All"...  options in the dropdown.

A column set takes the following configuration:

```js
columnSets: [
  {
    label: "Name",
    showColumns: ['firstName', 'lastName']
  }
]
```

By default, if the "Name" button is clicked, it will then show these two columns and hide all other columns (that don't have `mayBeHidden=false`).

You can also modify this behaviour:

```js
 {
  label: "Name",
  showColumns: ['firstName', 'lastName'],
  hideOtherColumns: false
}
```

Which will then only show these columns, but leave all other columns as they were before (e.g. visible/hidden).

Then there is also an option to toggle them:

```js
 {
  label: "Name",
  showColumns: ['firstName', 'lastName'],
  toggleSet: true
}
```

Which will show all specified columns if one of them was previously hidden, else hide all of them.

And finally, you can also specify a function for custom functionality:

```js
 {
  label: "Name",
  showColumns(allProcessedColumns) {
    // Do something custom here
  }
}
```

I also added tests and added it to the docs.