### PR TITLE
Improve setting of filters for paginated table

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -5,6 +5,7 @@ import layout from '../templates/components/models-table';
 const {
   get,
   set,
+  isBlank,
   setProperties,
   computed,
   typeOf,
@@ -171,12 +172,7 @@ export default ModelsTable.extend({
       columns.forEach(column => {
         let filter = get(column, 'filterString');
         let filterTitle = this.getCustomFilterTitle(column);
-
-        if (filter) {
-          query[filterTitle] = filter;
-        } else {
-          delete query[filterTitle];
-        }
+        this._setQueryFilter(query, column, filterTitle, filter);
       });
     }
 
@@ -186,6 +182,25 @@ export default ModelsTable.extend({
     promise.then(newData => setProperties(this, {isLoading: false, isError: false, filteredContent: newData}))
       .catch(() => setProperties(this, {isLoading: false, isError: true}));
     return promise;
+  },
+
+  /**
+   * Actually set the filter on a query.
+   * This can be overwritten for special case handling.
+   * Note that this will mutate the given query object!
+   *
+   * @param {object} query the query to mutate
+   * @param {object} column the column that is filtering
+   * @param {string} filterTitle the query param name for filtering
+   * @param {mixed} filter the actual filter value
+   * @private
+   */
+  _setQueryFilter(query, column, filterTitle, filter) {
+    if (!isBlank(filter)) {
+      query[filterTitle] = filter;
+    } else {
+      delete query[filterTitle];
+    }
   },
 
   /**

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -26,6 +26,7 @@ const {
   computed,
   observer,
   isNone,
+  isBlank,
   A,
   on,
   compare,
@@ -1320,7 +1321,7 @@ export default Component.extend({
         columnFilters: {}
       });
       columns.forEach(column => {
-        if (get(column, 'filterString')) {
+        if (!isBlank(get(column, 'filterString'))) {
           settings.columnFilters[get(column, 'propertyName')] = get(column, 'filterString');
         }
       });


### PR DESCRIPTION
This commit will allow to set filters explicitly to false. 
Additionally, it allows to overwrite the function which actually mutates the query for easier customization.

In our app, we have a boolean filter that can be true/false. However, currently, it will always strip out the filter if it is set to false, which is not necessarily the same semantic.

The newly added `_setQueryFilter` method can be overwritten to do custom stuff. E.g. you could check for column/filterTitle and do some custom transformations if required.