### PR TITLE
add className specified for a column also to header and column filter

### DIFF
--- a/app/templates/components/models-table/header-row-filtering.hbs
+++ b/app/templates/components/models-table/header-row-filtering.hbs
@@ -1,7 +1,7 @@
 <tr>
   {{#each processedColumns as |column|}}
     {{#if column.isVisible}}
-      <th class="{{classes.theadCell}} {{unless column.useFilter classes.theadCellNoFiltering}}">
+      <th class="{{classes.theadCell}} {{unless column.useFilter classes.theadCellNoFiltering}} {{column.className}}">
         {{#if column.templateForFilterCell}}
           {{partial column.templateForFilterCell}}
         {{else}}

--- a/app/templates/components/models-table/header-row-sorting.hbs
+++ b/app/templates/components/models-table/header-row-sorting.hbs
@@ -2,7 +2,7 @@
   {{#each processedColumns as |column|}}
     {{#if column.isVisible}}
       {{#if column.useSorting}}
-        <th class="{{classes.theadCell}}" {{action "sort" column}}>
+        <th class="{{classes.theadCell}} {{column.className}}" {{action "sort" column}}>
           {{#if column.templateForSortCell}}
             {{partial column.templateForSortCell}}
           {{else}}
@@ -15,7 +15,7 @@
           {{/if}}
         </th>
       {{else}}
-        <th class="{{classes.theadCell}} {{classes.theadCellNoSorting}}">
+        <th class="{{classes.theadCell}} {{classes.theadCellNoSorting}} {{column.className}}">
           {{#if column.templateForSortCell}}
             {{partial column.templateForSortCell}}
           {{else}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -155,7 +155,7 @@
                   <tr>
                     <td><code>className</code></td>
                     <td>String</td>
-                    <td><p>Custom class-name for cells in the current column</p></td>
+                    <td><p>Custom class-name for cells in the current column. This class-name will also be added to the header and filter of the column</p></td>
                   </tr>
                   <tr>
                     <td><code>filterFunction</code></td>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -1191,6 +1191,7 @@ test('columns column cell classes', function (assert) {
   this.render(hbs`{{models-table columns=columns data=data}}`);
 
   assert.equal(this.getCount('tbody .custom-column-class'), 10, 'Custom column class exists on each column cell');
+  assert.equal(this.getCount('thead .custom-column-class'), 2, 'Custom column class exists on column title and filter');
 
 });
 


### PR DESCRIPTION
This PR will extends the feature of custom CSS classes for columns by also assigning this classes to the title and filter of this column.

I want to use these custom class to specify a fixed width for some columns. In the current version I have the following problem: In case the table is empty there aren't any cells that get the custom class, so the width is set to some calculated value. In case a user types into the filter input and gets an empty table for some of the inputs, the table columns therefore change there width dynamically, which I would like to avoid.