### PR TITLE
Safely escape message strings containing html

### DIFF
--- a/app/templates/components/models-table/all-columns-hidden.hbs
+++ b/app/templates/components/models-table/all-columns-hidden.hbs
@@ -1,1 +1,1 @@
-<tr><td colspan={{processedColumns.length}} class="{{classes.noDataCell}}">{{{messages.allColumnsAreHidden}}}</td></tr>
+<tr><td colspan={{processedColumns.length}} class="{{classes.noDataCell}}">{{html-safe messages.allColumnsAreHidden}}</td></tr>

--- a/app/templates/components/models-table/no-data.hbs
+++ b/app/templates/components/models-table/no-data.hbs
@@ -1,1 +1,1 @@
-<tr><td colspan="{{visibleProcessedColumns.length}}">{{{messages.noDataToShow}}}</td></tr>
+<tr><td colspan="{{visibleProcessedColumns.length}}">{{html-safe messages.noDataToShow}}</td></tr>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.8.1",
-    "ember-cli-htmlbars": "^2.0.1"
+    "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-string-helpers": "^1.4.0",
+    "install": "^0.10.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
For rationale, see https://gist.github.com/jamesarosen/478db5faef370eac43fb 

It's simple enough to roll your own html-safe helper in lieu of the added dependencies... up to you.