### PR TITLE
Pass array to filteredBy for models-table-server-paginated

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -6,6 +6,7 @@ const {
   get,
   set,
   isBlank,
+  isArray,
   setProperties,
   computed,
   typeOf,
@@ -172,7 +173,11 @@ export default ModelsTable.extend({
       columns.forEach(column => {
         let filter = get(column, 'filterString');
         let filterTitle = this.getCustomFilterTitle(column);
-        this._setQueryFilter(query, column, filterTitle, filter);
+        if(isArray(filterTitle)){
+          filterTitle.forEach(title => { this._setQueryFilter(query, column, title, filter)});
+        } else {
+          this._setQueryFilter(query, column, filterTitle, filter);
+        }
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-models-table",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Table with pagination, sorting and filtering",
   "keywords": [
     "ember-addon"

--- a/vendor/ember-models-table/register-version.js
+++ b/vendor/ember-models-table/register-version.js
@@ -1,1 +1,1 @@
-Ember.libraries.register('Ember Models Table', '1.13.0');
+Ember.libraries.register('Ember Models Table', '1.13.1');


### PR DESCRIPTION
Adds the ability to pass an array of properties to filterBy for the models-table-server-paginated. This is especially useful for computed properties when we would like to query more than one fields.