### PR TITLE
Allow re-use of components in templates

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1,6 +1,6 @@
 import {assign as emberAssign} from '@ember/polyfills';
 import {on} from '@ember/object/evented';
-import {typeOf, compare, isBlank, isNone} from '@ember/utils';
+import {typeOf, compare, isBlank, isNone, isPresent} from '@ember/utils';
 import {run} from '@ember/runloop';
 import Component from '@ember/component';
 import {assert, warn} from '@ember/debug';
@@ -356,6 +356,24 @@ export default Component.extend({
    */
   columns: computed(function() {
     return A([]);
+  }),
+
+  /**
+   * Hash of components to be used for columns.
+   *
+   * See [ModelsTableColumn](Utils.ModelsTableColumn.html), property component and componentEdit
+   *
+   * @type Object
+   * @porperty columnComponents
+   * @default {}
+   */
+  columnComponents: computed({
+    get() {
+      return {};
+    },
+    set(k,v) {
+      return v;
+    }
   }),
 
   /**
@@ -1032,6 +1050,25 @@ export default Component.extend({
         filterString: get(c, 'filterString') || '',
         originalDefinition: column
       });
+
+      let columnComponents = get(this, "columnComponents");
+      if (isPresent(columnComponents)) {
+        let componentName = get(column, "component");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'component', hashComponent);
+          }
+        }
+
+        componentName = get(column, "componentEdit");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'componentEdit', hashComponent);
+          }
+        }
+      }
 
       set(c, 'filterFunction', filterFunction);
 

--- a/addon/components/named-components.js
+++ b/addon/components/named-components.js
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+import layout from '../templates/components/named-components';
+
+export default Component.extend({
+  layout,
+
+  tagName: "",
+
+  components: null
+});

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -1,90 +1,16 @@
-{{#if hasBlock}}
-  {{yield
+{{#named-components
+  components =
     (hash
       global-filter=(
-        component themeInstance.components.global-filter
-        value=filterString
-        globalFilterUsed=globalFilterUsed
-        themeInstance=themeInstance
-        messages=messages
-        sendAction=(action "sendAction")
-      )
-      columns-dropdown=(
-        component themeInstance.components.columns-dropdown
-        processedColumns=processedColumns
-        columnDropdownOptions=columnDropdownOptions
-        themeInstance=themeInstance
-        messages=messages
-        showAllColumns=(action "showAllColumns")
-        hideAllColumns=(action "hideAllColumns")
-        restoreDefaultVisibility=(action "restoreDefaultVisibility")
-        toggleColumnSet=(action "toggleColumnSet")
-        toggleHidden=(action "toggleHidden")
-        sendAction=(action "sendAction")
-      )
-      table=(
-        component themeInstance.components.table
-        noHeaderFilteringAndSorting=noHeaderFilteringAndSorting
-        groupedHeaders=groupedHeaders
-        sort=(action "sort")
-        visibleContent=visibleContent
-        selectedItems=_selectedItems
-        expandedItems=_expandedItems
-        expandedRowComponent=expandedRowComponent
-        visibleProcessedColumns=visibleProcessedColumns
-        useFilteringByColumns=useFilteringByColumns
-        allColumnsAreHidden=allColumnsAreHidden
-        clickOnRow=(action "clickOnRow")
-        doubleClickOnRow=(action "doubleClickOnRow")
-        hoverOnRow=(action "hoverOnRow")
-        outRow=(action "outRow")
-        data=data
-        themeInstance=themeInstance
-        messages=messages
-        sendAction=(action "sendAction")
-        expandRow=(action "expandRow")
-        collapseRow=(action "collapseRow")
-        expandAllRows=(action "expandAllRows")
-        collapseAllRows=(action "collapseAllRows")
-        toggleAllSelection=(action "toggleAllSelection")
-      )
-      footer=(
-        component themeInstance.components.footer
-        firstIndex=firstIndex
-        lastIndex=lastIndex
-        recordsCount=arrangedContentLength
-        anyFilterUsed=anyFilterUsed
-        pageSizeOptions=pageSizeOptions
-        pageSize=pageSize
-        currentPageNumber=currentPageNumber
-        pagesCount=pagesCount
-        showPageSize=showPageSize
-        useNumericPagination=useNumericPagination
-        goToPage=(action "gotoCustomPage")
-        clearFilters=(action "clearFilters")
-        themeInstance=themeInstance
-        messages=messages
-        sendAction=(action "sendAction")
-      )
-      isLoading=isLoading
-      isError=isError
-    )
-  }}
-{{else}}
-  {{! global filter start }}
-  {{#if showGlobalFilter}}
-    {{component themeInstance.components.global-filter
+      component themeInstance.components.global-filter
       value=filterString
       globalFilterUsed=globalFilterUsed
       themeInstance=themeInstance
       messages=messages
       sendAction=(action "sendAction")
-    }}
-  {{/if}}
-  {{! global filter end }}
-  {{! columns dropdown start }}
-  {{#if showColumnsDropdown}}
-    {{component themeInstance.components.columns-dropdown
+    )
+    columns-dropdown=(
+      component themeInstance.components.columns-dropdown
       processedColumns=processedColumns
       columnDropdownOptions=columnDropdownOptions
       themeInstance=themeInstance
@@ -95,41 +21,35 @@
       toggleColumnSet=(action "toggleColumnSet")
       toggleHidden=(action "toggleHidden")
       sendAction=(action "sendAction")
-    }}
-  {{/if}}
-  {{! columns dropdown end }}
-
-  {{! Div needed by Firefox to reset floating positioning }}
-  <div class='models-table-clear'></div>
-
-  {{component themeInstance.components.table
-    noHeaderFilteringAndSorting=noHeaderFilteringAndSorting
-    groupedHeaders=groupedHeaders
-    sort=(action "sort")
-    visibleContent=visibleContent
-    selectedItems=_selectedItems
-    useFilteringByColumns=useFilteringByColumns
-    expandedItems=_expandedItems
-    visibleProcessedColumns=visibleProcessedColumns
-    allColumnsAreHidden=allColumnsAreHidden
-    clickOnRow=(action "clickOnRow")
-    doubleClickOnRow=(action "doubleClickOnRow")
-    hoverOnRow=(action "hoverOnRow")
-    outRow=(action "outRow")
-    sendAction=(action "sendAction")
-    data=data
-    themeInstance=themeInstance
-    messages=messages
-    expandedRowComponent=expandedRowComponent
-    expandRow=(action "expandRow")
-    collapseRow=(action "collapseRow")
-    expandAllRows=(action "expandAllRows")
-    collapseAllRows=(action "collapseAllRows")
-    toggleAllSelection=(action "toggleAllSelection")
-  }}
-  {{! table footer start }}
-  {{#if showComponentFooter}}
-    {{component themeInstance.components.footer
+    )
+    table=(
+      component themeInstance.components.table
+      noHeaderFilteringAndSorting=noHeaderFilteringAndSorting
+      groupedHeaders=groupedHeaders
+      sort=(action "sort")
+      visibleContent=visibleContent
+      selectedItems=_selectedItems
+      expandedItems=_expandedItems
+      expandedRowComponent=expandedRowComponent
+      visibleProcessedColumns=visibleProcessedColumns
+      useFilteringByColumns=useFilteringByColumns
+      allColumnsAreHidden=allColumnsAreHidden
+      clickOnRow=(action "clickOnRow")
+      doubleClickOnRow=(action "doubleClickOnRow")
+      hoverOnRow=(action "hoverOnRow")
+      outRow=(action "outRow")
+      data=data
+      themeInstance=themeInstance
+      messages=messages
+      sendAction=(action "sendAction")
+      expandRow=(action "expandRow")
+      collapseRow=(action "collapseRow")
+      expandAllRows=(action "expandAllRows")
+      collapseAllRows=(action "collapseAllRows")
+      toggleAllSelection=(action "toggleAllSelection")
+    )
+    footer=(
+      component themeInstance.components.footer
       firstIndex=firstIndex
       lastIndex=lastIndex
       recordsCount=arrangedContentLength
@@ -141,11 +61,45 @@
       showPageSize=showPageSize
       useNumericPagination=useNumericPagination
       goToPage=(action "gotoCustomPage")
-      themeInstance=themeInstance
       clearFilters=(action "clearFilters")
-      sendAction=(action "sendAction")
+      themeInstance=themeInstance
       messages=messages
-    }}
+      sendAction=(action "sendAction")
+      )
+    )
+  as | mt |
+}}
+{{#if hasBlock}}
+  {{yield
+    (hash
+      global-filter=mt.global-filter
+      columns-dropdown=mt.columns-dropdown
+      table=mt.table
+      footer=footer
+      isLoading=isLoading
+      isError=isError
+    )
+  }}
+{{else}}
+  {{! global filter start }}
+  {{#if showGlobalFilter}}
+    {{component mt.global-filter}}
+  {{/if}}
+  {{! global filter end }}
+  {{! columns dropdown start }}
+  {{#if showColumnsDropdown}}
+    {{component mt.columns-dropdown}}
+  {{/if}}
+  {{! columns dropdown end }}
+
+  {{! Div needed by Firefox to reset floating positioning }}
+  <div class='models-table-clear'></div>
+
+  {{component mt.table}}
+  {{! table footer start }}
+  {{#if showComponentFooter}}
+    {{component mt.footer}}
   {{/if}}
   {{! table footer end }}
 {{/if}}
+{{/named-components}}

--- a/addon/templates/components/named-components.hbs
+++ b/addon/templates/components/named-components.hbs
@@ -1,0 +1,1 @@
+{{yield components}}

--- a/app/components/named-components.js
+++ b/app/components/named-components.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/named-components';

--- a/tests/dummy/app/components/delete-row-comp.js
+++ b/tests/dummy/app/components/delete-row-comp.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import {get} from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  record: null,
+
+  click(event){
+    let onClick = get(this, "onClick");
+    if (onClick) {
+      onClick(get(this, "record"));
+      event.stopPropagation();
+    }
+  }
+
+});

--- a/tests/dummy/app/controllers/examples/custom-components-in-cell.js
+++ b/tests/dummy/app/controllers/examples/custom-components-in-cell.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  actions: {
+    deleteRecord (record) {
+      record.destroyRecord();
+    }
+  }
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('examples', function () {
     this.route('common-table');
     this.route('custom-actions');
+    this.route('custom-components-in-cell');
     this.route('custom-messages');
     this.route('custom-column-classes');
     this.route('grouped-headers');

--- a/tests/dummy/app/routes/examples/custom-components-in-cell.js
+++ b/tests/dummy/app/routes/examples/custom-components-in-cell.js
@@ -1,0 +1,16 @@
+import ExampleRoute from './example';
+import {set, get} from '@ember/object';
+import {A} from '@ember/array';
+
+export default ExampleRoute.extend({
+
+  setupController(controller) {
+    this._super(...arguments);
+    set(controller, 'data', A(get(this, 'store').peekAll('user')));
+    get(controller, 'columns').pushObject({
+      title: 'Delete',
+      component: 'deleteRow'
+    });
+  }
+
+});

--- a/tests/dummy/app/templates/components/delete-row-comp.hbs
+++ b/tests/dummy/app/templates/components/delete-row-comp.hbs
@@ -1,0 +1,3 @@
+<button class="btn btn-default">
+    Delete
+</button>

--- a/tests/dummy/app/templates/examples/custom-components-in-cell.hbs
+++ b/tests/dummy/app/templates/examples/custom-components-in-cell.hbs
@@ -1,0 +1,52 @@
+<h4>Custom component in a cell with closure actions
+    <small>simple table</small>
+</h4>
+<p class="alert alert-info">Some records may be deleted from both tables in the same time.</p>
+{{models-table data=data columns=columns columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))}}
+<div class="row">
+    <div class="col-md-6">
+        <p>Component usage</p>
+    <pre><code class="language-handlebars">\{{models-table
+        data=data
+        columns=columns
+        columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))
+        }}</code></pre>
+        <p><code>columns</code></p>
+        <pre><code class="language-javascript">{{to-string this "columns"}}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <p><code>delete-row-comp</code> component</p>
+    <pre><code class="language-handlebars">&lt;button class="btn btn-default"&gt;Delete&lt;/button&gt;
+    </code></pre>
+    <pre><code class="language-javascript">import Component from '@ember/component';
+import {get} from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  click(){
+    let onClick = get(this, "onClick");
+    if (onClick) {
+      onClick(get(this, "record"));
+      event.stopPropagation();
+    }
+  }
+};
+    </code></pre>
+        <p>Controller</p>
+<pre><code class="language-javascript">import Controller from '@ember/controller';
+export default Controller.extend({
+  actions: {
+    deleteRecord (record) {
+      record.destroyRecord();
+    }
+  }
+});</code></pre>
+    </div>
+</div>
+
+<h4>Custom component in a cell with closure actions
+    <small>server paginated table</small>
+</h4>
+{{models-table-server-paginated data=model columns=columns columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -280,6 +280,20 @@ test('render custom component in the table cell', function (assert) {
 
 });
 
+test('render custom component in the table cell as a composable component', function (assert) {
+
+  const columns = generateColumns(['index', 'someWord']);
+  columns[1].component = 'cellComp';
+  this.setProperties({
+    data: generateContent(20, 1),
+    columns
+  });
+
+  this.render(hbs`{{models-table columns=columns data=data columnComponents=(hash cellComp=(component "cell-component"))}}`);
+  assert.deepEqual(ModelsTableBs.getColumnCells(1), oneTenArray, 'Content is valid');
+
+});
+
 test('render custom component (input) in the filter cell', function (assert) {
 
   const columns = generateColumns(['index', 'someWord']);

--- a/tests/integration/components/named-components-test.js
+++ b/tests/integration/components/named-components-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('named-components', 'Integration | Component | named components', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{named-components}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#named-components}}
+      template block text
+    {{/named-components}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
This is NOT intended to be a merged request, but to give you an example of what you might do. I created a component called named-components and using hash and yeild allow the re-use of the same component multiple times in the same template. Look at the models-table.hbs for use of the named-component. Figured it would make your templates easier to maintain.