### PR TITLE
Allow cell level components to be passed into the component

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1,6 +1,6 @@
 import {assign as emberAssign} from '@ember/polyfills';
 import {on} from '@ember/object/evented';
-import {typeOf, compare, isBlank, isNone} from '@ember/utils';
+import {typeOf, compare, isBlank, isNone, isPresent} from '@ember/utils';
 import {run} from '@ember/runloop';
 import Component from '@ember/component';
 import {assert, warn} from '@ember/debug';
@@ -356,6 +356,24 @@ export default Component.extend({
    */
   columns: computed(function() {
     return A([]);
+  }),
+
+  /**
+   * Hash of components to be used for columns.
+   *
+   * See [ModelsTableColumn](Utils.ModelsTableColumn.html), property component
+   *
+   * @type Object
+   * @porperty columnComponents
+   * @default {}
+   */
+  columnComponents: computed({
+    get() {
+      return {};
+    },
+    set(k,v) {
+      return v;
+    }
   }),
 
   /**
@@ -1032,6 +1050,17 @@ export default Component.extend({
         filterString: get(c, 'filterString') || '',
         originalDefinition: column
       });
+
+      let columnComponents = get(this, "columnComponents");
+      if (isPresent(columnComponents)) {
+        let componentName = get(column, "component");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'component', hashComponent);
+          }
+        }
+      }
 
       set(c, 'filterFunction', filterFunction);
 

--- a/tests/dummy/app/components/delete-row-comp.js
+++ b/tests/dummy/app/components/delete-row-comp.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import {get} from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  record: null,
+
+  click(event){
+    let onClick = get(this, "onClick");
+    if (onClick) {
+      onClick(get(this, "record"));
+      event.stopPropagation();
+    }
+  }
+
+});

--- a/tests/dummy/app/controllers/examples/custom-components-in-cell.js
+++ b/tests/dummy/app/controllers/examples/custom-components-in-cell.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  actions: {
+    deleteRecord (record) {
+      record.destroyRecord();
+    }
+  }
+
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
   this.route('examples', function () {
     this.route('common-table');
     this.route('custom-actions');
+    this.route('custom-components-in-cell');
     this.route('custom-messages');
     this.route('custom-column-classes');
     this.route('grouped-headers');

--- a/tests/dummy/app/routes/examples/custom-components-in-cell.js
+++ b/tests/dummy/app/routes/examples/custom-components-in-cell.js
@@ -1,0 +1,16 @@
+import ExampleRoute from './example';
+import {set, get} from '@ember/object';
+import {A} from '@ember/array';
+
+export default ExampleRoute.extend({
+
+  setupController(controller) {
+    this._super(...arguments);
+    set(controller, 'data', A(get(this, 'store').peekAll('user')));
+    get(controller, 'columns').pushObject({
+      title: 'Delete',
+      component: 'deleteRow'
+    });
+  }
+
+});

--- a/tests/dummy/app/templates/components/delete-row-comp.hbs
+++ b/tests/dummy/app/templates/components/delete-row-comp.hbs
@@ -1,0 +1,3 @@
+<button class="btn btn-default">
+    Delete
+</button>

--- a/tests/dummy/app/templates/examples/custom-components-in-cell.hbs
+++ b/tests/dummy/app/templates/examples/custom-components-in-cell.hbs
@@ -1,0 +1,52 @@
+<h4>Custom component in a cell with closure actions
+    <small>simple table</small>
+</h4>
+<p class="alert alert-info">Some records may be deleted from both tables in the same time.</p>
+{{models-table data=data columns=columns columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))}}
+<div class="row">
+    <div class="col-md-6">
+        <p>Component usage</p>
+    <pre><code class="language-handlebars">\{{models-table
+        data=data
+        columns=columns
+        columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))
+        }}</code></pre>
+        <p><code>columns</code></p>
+        <pre><code class="language-javascript">{{to-string this "columns"}}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <p><code>delete-row-comp</code> component</p>
+    <pre><code class="language-handlebars">&lt;button class="btn btn-default"&gt;Delete&lt;/button&gt;
+    </code></pre>
+    <pre><code class="language-javascript">import Component from '@ember/component';
+import {get} from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  click(){
+    let onClick = get(this, "onClick");
+    if (onClick) {
+      onClick(get(this, "record"));
+      event.stopPropagation();
+    }
+  }
+};
+    </code></pre>
+        <p>Controller</p>
+<pre><code class="language-javascript">import Controller from '@ember/controller';
+export default Controller.extend({
+  actions: {
+    deleteRecord (record) {
+      record.destroyRecord();
+    }
+  }
+});</code></pre>
+    </div>
+</div>
+
+<h4>Custom component in a cell with closure actions
+    <small>server paginated table</small>
+</h4>
+{{models-table-server-paginated data=model columns=columns columnComponents=(hash deleteRow=(component "delete-row-comp" onClick=(action "deleteRecord")))}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -280,6 +280,20 @@ test('render custom component in the table cell', function (assert) {
 
 });
 
+test('render custom component in the table cell as a composable component', function (assert) {
+
+  const columns = generateColumns(['index', 'someWord']);
+  columns[1].component = 'cellComp';
+  this.setProperties({
+    data: generateContent(20, 1),
+    columns
+  });
+
+  this.render(hbs`{{models-table columns=columns data=data columnComponents=(hash cellComp=(component "cell-component"))}}`);
+  assert.deepEqual(ModelsTableBs.getColumnCells(1), oneTenArray, 'Content is valid');
+
+});
+
 test('render custom component (input) in the filter cell', function (assert) {
 
   const columns = generateColumns(['index', 'someWord']);


### PR DESCRIPTION
Same request with componentEdit removed.

This will allow components specified at the column level to be passed in, giving you complete access to the component. This will allow for direct closure actions as well as additional properties to be set on the component.

Additionally the ground work has been laid to implement in-line editing fairly easily.

I did not see where I had the ability to update the documentation

This pull request should solve #270