### PR TITLE
Allow displayDataChangedAction to be a closureAction

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -651,7 +651,7 @@ export default Component.extend({
   groupingRowComponent: '',
 
   /**
-   * Action-name sent on user interaction
+   * Action-name or closure action sent on user interaction
    *
    * Action will send one parameter - object with fields:
    *
@@ -664,7 +664,7 @@ export default Component.extend({
    * * `expandedItems` - list with expanded row items
    * * `columnFilters` - hash with fields equal to filtered propertyName and values equal to filter values
    *
-   * @type string
+   * @type string || function
    * @property displayDataChangedAction
    * @default 'displayDataChanged'
    */
@@ -672,6 +672,7 @@ export default Component.extend({
 
   /**
    * Determines if action on user interaction should be sent
+   * required only if displayDataChangedAction is not a closure action.
    *
    * @default false
    * @property sendDisplayDataChangedAction
@@ -1479,7 +1480,10 @@ export default Component.extend({
    * @private
    */
   userInteractionObserverOnce() {
-    if (get(this, 'sendDisplayDataChangedAction')) {
+    let action = get(this, "displayDataChangedAction");
+    let actionIsFunction = typeof action === 'function';
+
+    if (actionIsFunction || get(this, 'sendDisplayDataChangedAction')) {
       let columns = get(this, 'processedColumns');
       let settings = O.create({
         sort: get(this, 'sortProperties'),
@@ -1497,7 +1501,12 @@ export default Component.extend({
           settings.columnFilters[get(column, 'propertyName')] = get(column, 'filterString');
         }
       });
-      this.sendAction('displayDataChangedAction', settings);
+
+      if (actionIsFunction) {
+        action(settings);
+      } else {
+        this.sendAction('displayDataChangedAction', settings);
+      }
     }
   },
 

--- a/tests/dummy/app/templates/examples/display-data-changed-action.hbs
+++ b/tests/dummy/app/templates/examples/display-data-changed-action.hbs
@@ -1,15 +1,29 @@
+<p>{{input type="checkbox" name="actionAsClosure" checked=useClosureAction}} Use closure action for (<code>displayDataChangedAction</code>)</p>
+
 <h4>Handle user interaction with a component
   <small>simple table</small>
 </h4>
-{{models-table data=data columns=columns displayDataChangedAction="myAction" sendDisplayDataChangedAction=true}}
+{{#if useClosureAction}}
+  {{models-table data=data columns=columns displayDataChangedAction=(action "myAction")}}
+{{else}}
+  {{models-table data=data columns=columns displayDataChangedAction="myAction" sendDisplayDataChangedAction=true}}
+{{/if}}
 <div class="row">
   <div class="col-md-6">
     <p>Component usage:</p>
+    {{#if useClosureAction}}
+    <pre><code class="language-handlebars">&lbrace;&lbrace;models-table
+data=data
+columns=columns
+displayDataChangedAction=(action "myAction")
+&rbrace;&rbrace;</code></pre>
+    {{else}}
     <pre><code class="language-handlebars">&lbrace;&lbrace;models-table
 data=data
 columns=columns
 displayDataChangedAction="myAction"
 sendDisplayDataChangedAction=true&rbrace;&rbrace;</code></pre>
+    {{/if}}
   </div>
   <div class="col-md-6">
     <p><code>actionData</code>:</p>
@@ -20,15 +34,27 @@ sendDisplayDataChangedAction=true&rbrace;&rbrace;</code></pre>
 <h4>Handle user interaction with a component
   <small>server paginated table</small>
 </h4>
-{{models-table-server-paginated data=model columns=columns displayDataChangedAction="myAction" sendDisplayDataChangedAction=true}}
+{{#if useClosureAction}}
+  {{models-table-server-paginated data=model columns=columns displayDataChangedAction=(action "myAction")}}
+{{else}}
+  {{models-table-server-paginated data=model columns=columns displayDataChangedAction="myAction" sendDisplayDataChangedAction=true}}
+{{/if}}
 <div class="row">
   <div class="col-md-6">
     <p>Component usage:</p>
+  {{#if useClosureAction}}
+    <pre><code class="language-handlebars">&lbrace;&lbrace;models-table-server-paginated
+data=model
+columns=columns
+displayDataChangedAction=(action "myAction")
+&rbrace;&rbrace;</code></pre>
+  {{else}}
     <pre><code class="language-handlebars">&lbrace;&lbrace;models-table-server-paginated
 data=model
 columns=columns
 displayDataChangedAction="myAction"
 sendDisplayDataChangedAction=true&rbrace;&rbrace;</code></pre>
+  {{/if}}
   </div>
   <div class="col-md-6">
     <p><code>actionData</code>:</p>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -1477,6 +1477,30 @@ test('event on user interaction (filtering by column)', function (assert) {
 
 });
 
+test('event on user interaction (filtering by column) (Closure Action)', function (assert) {
+
+  this.setProperties({
+    columns: generateColumns(['index', 'someWord']),
+    data: generateContent(10, 1),
+    displayDataChangedAction: 'displayDataChanged'
+  });
+
+  this.set("actions", {
+    displayDataChangedAction(data) {
+      assert.deepEqual(data.columnFilters, {someWord: 'One'});
+      assert.deepEqual(data.columns, [
+        {propertyName: 'index', filterField: 'index', sortField: 'index', filterString: '', sorting: 'none'},
+        {propertyName: 'someWord', filterField: 'someWord', sortField: 'someWord', filterString: 'One', sorting: 'none'}
+      ]);
+    }
+  });
+
+  this.render(hbs`{{models-table columns=columns data=data displayDataChangedAction=(action "displayDataChangedAction")}}`);
+  filters(1).inputFilter('One');
+
+});
+
+
 test('event on user interaction (global filtering)', function (assert) {
 
   this.setProperties({
@@ -2273,7 +2297,7 @@ test('#grouped-rows #row group value is shown', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2295,7 +2319,7 @@ test('#grouped-rows #row grouping-field dropdown has valid options', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2316,7 +2340,7 @@ test('#grouped-rows #row cells have valid colspan', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2339,7 +2363,7 @@ test('#grouped-rows #row clicking on grouped values hide grouped', function (ass
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2364,7 +2388,7 @@ test('#grouped-rows #row sorting is done for each group separately', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2392,7 +2416,7 @@ test('#grouped-rows #row grouped property may be changed', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2416,7 +2440,7 @@ test('#grouped-rows #row order of grouped values may be changed', function (asse
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2440,7 +2464,7 @@ test('#grouped-rows #row filtered out groups are hidden', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2464,7 +2488,7 @@ test('#grouped-rows #row only message about no data is shown if all rows are fil
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2490,7 +2514,7 @@ test('#grouped-rows #row only message about hidden columns is shown if all colum
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2519,7 +2543,7 @@ test('#grouped-rows #row custom group-cell component content', function (assert)
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2556,7 +2580,7 @@ test('#grouped-rows #row custom group-cell component actions', function (assert)
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2594,7 +2618,7 @@ test('#grouped-rows #column group value is shown', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2616,7 +2640,7 @@ test('#grouped-rows #column grouping-field dropdown has valid options', function
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2637,7 +2661,7 @@ test('#grouped-rows #column cells have valid rowspan', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2663,7 +2687,7 @@ test('#grouped-rows #column clicking on grouped values hide grouped', function (
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2688,7 +2712,7 @@ test('#grouped-rows #column sorting is done for each group separately', function
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2716,7 +2740,7 @@ test('#grouped-rows #column grouped property may be changed', function (assert) 
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2740,7 +2764,7 @@ test('#grouped-rows #column order of grouped values may be changed', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2764,7 +2788,7 @@ test('#grouped-rows #column filtered out groups are hidden', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2788,7 +2812,7 @@ test('#grouped-rows #column only message about no data is shown if all rows are 
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2814,7 +2838,7 @@ test('#grouped-rows #column only message about hidden columns is shown if all co
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2848,7 +2872,7 @@ test('#grouped-rows #column row expands update rowspan for grouping cells', func
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2880,7 +2904,7 @@ test('#grouped-rows #column thead has extra cell in the each row', function (ass
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2907,7 +2931,7 @@ test('#grouped-rows #column custom group-cell component content', function (asse
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2944,7 +2968,7 @@ test('#grouped-rows #column custom group-cell component actions', function (asse
     assert.ok(true);
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true


### PR DESCRIPTION
This will allow the displayDataChangedAction accept a closureAction. SendDisplayDataChangeAction is not required in this mode.

Note: Backward compatibility is preserved. You can still assign a string and set the send variable to true.