### PR TITLE
inline edit

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1301,16 +1301,7 @@ export default Component.extend({
         originalDefinition: column
       });
 
-      let columnComponents = get(this, "columnComponents");
-      if (isPresent(columnComponents)) {
-        let componentName = get(column, "component");
-        if (isPresent(componentName)) {
-          let hashComponent = get(columnComponents, componentName);
-          if (isPresent(hashComponent)) {
-            set(c, 'component', hashComponent);
-          }
-        }
-      }
+      this._setupColumnsComponent(c, column);
 
       set(c, 'filterFunction', filterFunction);
 
@@ -1385,6 +1376,40 @@ export default Component.extend({
       }
     });
   },
+
+  /**
+   * Create new properties for <code>columns</code> for compoenents
+   *
+   * @method _setupColumnsComponent
+   * @param {object} c
+   * @param {object} column
+   * @returns {undefined}
+   * @private
+   */
+    _setupColumnsComponent(c, column) {
+      let columnComponents = get(this, "columnComponents");
+      if (isPresent(columnComponents)) {
+
+        // display component
+        let componentName = get(column, "component");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'component', hashComponent);
+          }
+        }
+
+        // edit component
+        componentName = get(column, "componentForEdit");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'componentForEdit', hashComponent);
+          }
+        }
+
+      }
+    },
 
   /**
    * Update messages used by widget with custom values provided by user in the <code>customMessages</code>

--- a/addon/components/models-table/cell-content-display.js
+++ b/addon/components/models-table/cell-content-display.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/models-table/cell-content-display';
+import { get, set } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  init() {
+    set(this, "tagName", get(this, "themeInstance.tagNames.cell-content"));
+    this._super(...arguments);
+  }
+});

--- a/addon/components/models-table/cell-content-edit.js
+++ b/addon/components/models-table/cell-content-edit.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/models-table/cell-content-edit';
+import { get, set } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  init() {
+    set(this, "tagName", get(this, "themeInstance.tagNames.cell-content"));
+    this._super(...arguments);
+  }
+});

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import layout from '../../templates/components/models-table/row';
 import HoverSupport from '../../mixins/hover-support';
+
 
 /**
  * Table body row is used within [models-table/table-body](Components.ModelsTableTableBody.html).
@@ -277,6 +278,23 @@ export default Component.extend(HoverSupport, {
    */
   themeInstance: null,
 
+  /**
+   * Is the row in edit mode
+   *
+   * @property isEditRow
+   * @type boolean
+   * @default false
+   */
+  isEditRow: computed({
+    get() {
+      return false;
+    },
+    set(k, v) {
+      return v;
+    }
+
+  }),
+
   click() {
     get(this, 'clickOnRow')(get(this, 'index'), get(this, 'record'));
   },
@@ -293,8 +311,49 @@ export default Component.extend(HoverSupport, {
     get(this, 'outRow')(get(this, 'index'), get(this, 'record'));
   },
 
+  /**
+   * Place a row into edit mode
+   *
+   * @returns {undefined}
+   * @method actions.editRow
+   */
+  editRow() {
+    set(this, "isEditRow", true);
+  },
+
+  /**
+   * Indicate a row has been saved, the row is no longer in edit mode
+   *
+   * @returns {undefined}
+   * @method actions.saveRow
+   */
+  saveRow() {
+    set(this, "isEditRow", false);
+  },
+
+  /**
+   * Indicate the edit on the row has been cancelled, the row is no longer in edit mode
+   *
+   * @returns {undefined}
+   * @method actions.saveRow
+   */
+  cancelEditRow() {
+    set(this, "isEditRow", false);
+  },
+
+  publicRowApi: computed("isEditRow", {
+    get() {
+      return {
+        isEditRow: get(this, "isEditRow"),
+        editRow: () => this.editRow(),
+        saveRow: () => this.saveRow(),
+        cancelEditRow: () => this.cancelEditRow()
+      };
+    }
+  }),
+
   actions: {
-    toggleGroupedRows() {
+	toggleGroupedRows() {
       get(this, 'toggleGroupedRows')(get(this, 'groupedValue'));
     }
   }

--- a/addon/templates/components/models-table/cell-content-display.hbs
+++ b/addon/templates/components/models-table/cell-content-display.hbs
@@ -1,0 +1,1 @@
+{{get record column.propertyName}}

--- a/addon/templates/components/models-table/cell-content-edit.hbs
+++ b/addon/templates/components/models-table/cell-content-edit.hbs
@@ -1,0 +1,1 @@
+{{input type="text" class=themeInstance.input value=(get record column.propertyName)}}

--- a/addon/templates/components/models-table/cell.hbs
+++ b/addon/templates/components/models-table/cell.hbs
@@ -4,31 +4,40 @@
       record=record
       index=index
       column=column
+      componentToRender=componentToRender
       sendAction=sendAction
       expandRow=expandRow
       collapseRow=collapseRow
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
+      editRow=editRow
+      cancelEditRow=cancelEditRow
       themeInstance=themeInstance
       clickOnRow=clickOnRow
       isExpanded=isExpanded
       isSelected=isSelected
+      publicRowApi=publicRowApi
+      isColumnEditable=isColumnEditable
     )
   }}
 {{else}}
-  {{component
-    column.component
+  {{#if componentToRender}}
+    {{component
+    componentToRender
     record=record
     index=index
     column=column
+    publicRowApi=publicRowApi
     sendAction=sendAction
     expandRow=expandRow
     collapseRow=collapseRow
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     clickOnRow=clickOnRow
-    themeInstance=themeInstance
     isExpanded=isExpanded
     isSelected=isSelected
-  }}
+    isColumnEditable=isColumnEditable
+    themeInstance=themeInstance
+    }}
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -1,7 +1,11 @@
 {{#with (hash
   cell=(
     component themeInstance.components.cell
+    cellContentComponent=themeInstance.components.cell-content
     record=record
+    publicRowApi=publicRowApi
+    isExpanded=isExpanded
+    isSelected=isSelected
     sendAction=sendAction
     expandRow=expandRow
     collapseRow=collapseRow
@@ -29,6 +33,7 @@
     toggleGroupedRowsExpands=toggleGroupedRowsExpands
     sendAction=sendAction
   )
+  publicRowApi=publicRowApi
   visibleProcessedColumns=visibleProcessedColumns
   themeInstance=themeInstance
 ) as |r|}}
@@ -50,15 +55,7 @@
           {{/link-to}}
         </td>
       {{else}}
-        {{#if column.component}}
-          {{component r.cell index=index column=column isExpanded=isExpanded isSelected=isSelected}}
-        {{else}}
-          <td class={{column.className}}>
-            {{#if column.propertyName}}
-              {{get record column.propertyName}}
-            {{/if}}
-          </td>
-        {{/if}}
+          {{component r.cell index=index column=column}}
       {{/if}}
     {{/each}}
   {{/if}}

--- a/addon/themes/default.js
+++ b/addon/themes/default.js
@@ -21,6 +21,8 @@ export default EmberObject.extend({
    */
   components: {
     'cell': 'models-table/cell',
+    'cell-content-display': 'models-table/cell-content-display',
+    'cell-content-edit': 'models-table/cell-content-edit',
     'columns-dropdown': 'models-table/columns-dropdown',
     'columns-hidden': 'models-table/columns-hidden',
     'data-group-by-select': 'models-table/data-group-by-select',
@@ -45,6 +47,11 @@ export default EmberObject.extend({
     'table-body': 'models-table/table-body',
     'table-footer': 'models-table/table-footer',
     'table-header': 'models-table/table-header'
+  },
+
+  tagNames: {
+    /* blank for backward compatibility */
+    'cell-content': ''
   },
 
   /**
@@ -296,6 +303,20 @@ export default EmberObject.extend({
    * @default 'expand-all-rows'
    */
   expandAllRows: 'expand-all-rows',
+
+  /**
+   * @type string
+   * @property cellContentDisplay
+   * @default ''
+   */
+  cellContentDisplay: '',
+
+  /**
+   * @type string
+   * @property cellContentEdit
+   * @default ''
+   */
+  cellContentEdit: '',
 
   /**
    * @type string

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -58,15 +58,57 @@ export default O.extend({
    *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
    *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
    *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
+   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
    *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *  * `isExpanded` - is current row expanded
    *  * `isSelected` - is current row selected
+   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isColumnEditable` - is the column currently editable
    *
    * @type string
    * @property component
    * @default ''
    */
   component: '',
+
+  /**
+   * Custom component used in the column's cells when the row is in edit mode
+   *
+   * It will receive several options:
+   *
+   *  * `data` - whole dataset passed to the `models-table`
+   *  * `record` - current row
+   *  * `index` - current row index
+   *  * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
+   *  * `sendAction` - closure action {{#crossLink "Components.ModelsTable/actions.sendAction:method"}}ModelsTable.actions.sendAction{{/crossLink}}
+   *  * `expandRow` - closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   *  * `collapseRow` - closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
+   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
+   *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   *  * `isExpanded` - is current row expanded
+   *  * `isSelected` - is current row selected
+   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isColumnEditable` - is the column currently editable
+   *
+   * @type string
+   * @property component
+   * @default ''
+   */
+  componentForEdit: '',
+
+  /**
+   * Is this column allowed to be editable
+   *
+   * @default rue
+   * @property editable
+   * @type boolean
+   */
+  editable: true,
 
   /**
    * Custom component used in the header cell with filter

--- a/app/components/models-table/cell-content-display.js
+++ b/app/components/models-table/cell-content-display.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/models-table/cell-content-display';

--- a/app/components/models-table/cell-content-edit.js
+++ b/app/components/models-table/cell-content-edit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/models-table/cell-content-edit';

--- a/tests/dummy/app/components/edit-row.js
+++ b/tests/dummy/app/components/edit-row.js
@@ -1,0 +1,64 @@
+import Component from '@ember/component';
+import {get, set } from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  record: null,
+
+  onEditRow: null,
+
+
+  publicRowApi: null,
+
+  editLabel: "Edit",
+  cancelLabel: "Cancel",
+  saveLabel: "Save",
+
+  _eventHash(event) {
+    let modelTableApi = this.modelTableApi();
+    set(modelTableApi, "event", event);
+    return modelTableApi;
+  },
+
+  click(event) {
+    event.stopPropagation();
+  },
+
+  actions: {
+    saveClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onSave");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.saveRow();
+      }
+    },
+    editClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onEdit");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.editRow();
+      }
+    },
+    cancelClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onCancel");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.cancelEditRow();
+      }
+    }
+  }
+});

--- a/tests/dummy/app/controllers/examples/in-line-edit.js
+++ b/tests/dummy/app/controllers/examples/in-line-edit.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  actions: {
+    onSaveRow(record) {
+      record.save();
+    },
+
+    onCancelRow(record) {
+      record.rollbackAttributes();
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,7 @@ Router.map(function() {
     this.route('sort-by-filter-by');
     this.route('filtering');
     this.route('grouped-rows');
+    this.route('in-line-edit');
   });
 
   this.route('users', function() {

--- a/tests/dummy/app/routes/examples/in-line-edit.js
+++ b/tests/dummy/app/routes/examples/in-line-edit.js
@@ -1,0 +1,20 @@
+import ExampleRoute from './example';
+import {set, get} from '@ember/object';
+import {A} from '@ember/array';
+
+export default ExampleRoute.extend({
+
+  setupController(controller) {
+    this._super(...arguments);
+    set(controller, 'data', A(get(this, 'store').peekAll('user')));
+
+    let columns = get(controller, "columns");
+    columns.pushObject({
+      title: 'Edit',
+      component: 'editRow'
+    });
+
+    columns.objectAt(0).editable = false;
+  }
+
+});

--- a/tests/dummy/app/templates/components/edit-row.hbs
+++ b/tests/dummy/app/templates/components/edit-row.hbs
@@ -1,0 +1,12 @@
+{{#if publicRowApi.isEditRow}}
+    <button class="btn btn-default" onclick={{action "cancelClicked"}}>
+      {{cancelLabel}}
+    </button>
+    <button class="btn btn-default" onclick={{action "saveClicked"}}>
+      {{saveLabel}}
+    </button>
+{{else}}
+    <button class="btn btn-default" onclick={{action "editClicked"}}>
+      {{editLabel}}
+    </button>
+{{/if}}

--- a/tests/dummy/app/templates/examples/in-line-edit.hbs
+++ b/tests/dummy/app/templates/examples/in-line-edit.hbs
@@ -1,0 +1,62 @@
+<h4>In-line edit
+    <small>simple table</small>
+</h4>
+<p class="alert alert-info">Some records may be deleted from both tables in the same time.</p>
+{{models-table
+  data=data
+  columns=columns
+  columnComponents=(hash
+    editRow=(component "edit-row" onSave=(action "onSaveRow") onCancel=(action "onCancelRow"))
+  )
+}}
+<div class="row">
+    <div class="col-md-6">
+        <p>Component usage</p>
+    <pre><code class="language-handlebars">\{{models-table
+    data=data
+    columns=columns
+    columnComponents=(hash
+      editRow=(component "edit-row" onSave=(action "onSaveRow") onCancel=(action "onCancelRow"))
+    )
+  }}</code></pre>
+        <p><code>columns</code></p>
+        <pre><code class="language-javascript">{{to-string this "columns"}}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <p><code>edit-row</code> component</p>
+    <pre><code class="language-handlebars">&lt;button class="btn btn-default"&gt;Edit&lt;/button&gt;
+    </code></pre>
+    <pre><code class="language-javascript">import Component from '@ember/component';
+        import {get} from '@ember/object';
+        import layout from '../templates/components/edit-row';
+
+        export default Component.extend({
+        layout,
+
+        click(){
+          let onClick = get(this, "onClick");
+          if (onClick) {
+            onClick(get(this, "record"));
+            event.stopPropagation();
+          }
+          }
+        };
+    </code></pre>
+        <p>Controller</p>
+<pre><code class="language-javascript">import Controller from '@ember/controller';
+    import {get} from '@ember/object';
+
+    export default Controller.extend({
+    actions: {
+      editRecord (record) {
+        get(this, 'edtRow)();
+      }
+    }
+    });</code></pre>
+    </div>
+</div>
+
+<h4>Custom component in a cell with closure actions
+    <small>server paginated table</small>
+</h4>
+{{models-table-server-paginated data=model columns=columns columnComponents=(hash editRow=(component "edit-row"))}}

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -82,5 +82,6 @@ export default function() {
 
   this.get('/users/:id');
   this.delete('/users/:id');
+  this.patch('/users/:id');
 
 }

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -2,6 +2,8 @@ import { A } from '@ember/array';
 import O from '@ember/object';
 import BootstrapTheme from 'ember-models-table/themes/bootstrap3';
 
+import Component from '@ember/component';
+
 import {
   moduleForComponent,
   test
@@ -2273,7 +2275,7 @@ test('#grouped-rows #row group value is shown', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2295,7 +2297,7 @@ test('#grouped-rows #row grouping-field dropdown has valid options', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2316,7 +2318,7 @@ test('#grouped-rows #row cells have valid colspan', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2339,7 +2341,7 @@ test('#grouped-rows #row clicking on grouped values hide grouped', function (ass
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2364,7 +2366,7 @@ test('#grouped-rows #row sorting is done for each group separately', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2392,7 +2394,7 @@ test('#grouped-rows #row grouped property may be changed', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2416,7 +2418,7 @@ test('#grouped-rows #row order of grouped values may be changed', function (asse
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2440,7 +2442,7 @@ test('#grouped-rows #row filtered out groups are hidden', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2464,7 +2466,7 @@ test('#grouped-rows #row only message about no data is shown if all rows are fil
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2490,7 +2492,7 @@ test('#grouped-rows #row only message about hidden columns is shown if all colum
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2519,7 +2521,7 @@ test('#grouped-rows #row custom group-cell component content', function (assert)
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2556,7 +2558,7 @@ test('#grouped-rows #row custom group-cell component actions', function (assert)
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2594,7 +2596,7 @@ test('#grouped-rows #column group value is shown', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2616,7 +2618,7 @@ test('#grouped-rows #column grouping-field dropdown has valid options', function
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2637,7 +2639,7 @@ test('#grouped-rows #column cells have valid rowspan', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2663,7 +2665,7 @@ test('#grouped-rows #column clicking on grouped values hide grouped', function (
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2688,7 +2690,7 @@ test('#grouped-rows #column sorting is done for each group separately', function
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2716,7 +2718,7 @@ test('#grouped-rows #column grouped property may be changed', function (assert) 
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2740,7 +2742,7 @@ test('#grouped-rows #column order of grouped values may be changed', function (a
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2764,7 +2766,7 @@ test('#grouped-rows #column filtered out groups are hidden', function (assert) {
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2788,7 +2790,7 @@ test('#grouped-rows #column only message about no data is shown if all rows are 
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2814,7 +2816,7 @@ test('#grouped-rows #column only message about hidden columns is shown if all co
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2848,7 +2850,7 @@ test('#grouped-rows #column row expands update rowspan for grouping cells', func
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2880,7 +2882,7 @@ test('#grouped-rows #column thead has extra cell in the each row', function (ass
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2907,7 +2909,7 @@ test('#grouped-rows #column custom group-cell component content', function (asse
     columns
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2944,7 +2946,7 @@ test('#grouped-rows #column custom group-cell component actions', function (asse
     assert.ok(true);
   });
 
-  this.render(hbs`{{models-table 
+  this.render(hbs`{{models-table
     data=data
     columns=columns
     useDataGrouping=true
@@ -2970,4 +2972,73 @@ test('#grouped-rows #column custom group-cell component actions', function (asse
   groupingRowsByColumn(1).getIndex();
   assert.ok(ModelsTableBs.getRowsFromGroupColumn(0).every(r => r.expanded), 'All rows for rows group become expanded');
   assert.equal(groupingRowsByColumn(0).expandedCountText, firstGroupRowsCount);
+});
+
+test('in-line edit: row is editable, column displays default edit component ', function(assert) {
+
+  assert.expect(13);
+
+  this.register('component:stub-comp-edit',
+    Component.extend({
+      classNames: ['cellInput'],
+      layout: hbs`{{get record propertyName}}`
+    })
+  );
+
+  const columns = generateColumns(['index', 'firstName', 'lastName']);
+  columns[0].editable = false; // Index is not editable
+  columns[1].componentForEdit = "stub-comp-edit"; // Index is not editable
+
+  this.setProperties({
+    data: generateContent(5, 1),
+    columns
+  });
+
+  this.render(hbs`
+    {{#models-table data=data columns=columns as |c|}}
+      {{#c.table as |table|}}
+        {{#table.body as |body|}}
+          {{#each body.visibleContent as |record index|}}
+            {{#body.row record=record index=index as |row|}}
+            {{log row}}
+                <div class="isEditRow">{{if row.publicRowApi.isEditRow "yes" "no"}}</div>
+                <div class="actionEdit" {{action row.publicRowApi.editRow}}>Edit</div>
+                <div class="actionSave" {{action row.publicRowApi.saveRow}}>Save</div>
+                <div class="actionCancel" {{action row.publicRowApi.cancelEditRow}}>Cancel</div>
+              {{#each row.visibleProcessedColumns as |column|}}
+                {{component row.cell class="cell" index=index column=column}}
+              {{/each}}
+            {{/body.row}}
+          {{/each}}
+        {{/table.body}}
+      {{/c.table}}
+    {{/models-table}}
+    `);
+
+  assert.equal(this.$('.isEditRow').first().text(), "no", "Row is not editable");
+  assert.equal(this.$('input').length, 0, "There are no input fields");
+  assert.equal(this.$('.cellInput').length, 0, "There are no custom input fields");
+
+  this.$('.actionEdit').first().click();
+
+  assert.equal(this.$('.isEditRow').first().text(), "yes", "Row is editable");
+  assert.equal(this.$('input').length, 1, "There are input fields");
+  assert.equal(this.$('.cellInput').length, 1, "Uses a custom Edit component");
+
+  this.$('.actionCancel').first().click();
+
+  assert.equal(this.$('.isEditRow').first().text(), "no", "Row is not editable");
+  assert.equal(this.$('input').length, 0, "There are no input fields");
+  assert.equal(this.$('.cellInput').length, 0, "There are no custom input fields");
+
+  this.$('.actionEdit').first().click();
+
+  assert.equal(this.$('.isEditRow').first().text(), "yes", "Row is editable");
+
+  this.$('.actionSave').first().click();
+
+  assert.equal(this.$('.isEditRow').first().text(), "no", "Row is not editable");
+  assert.equal(this.$('input').length, 0, "There are no input fields");
+  assert.equal(this.$('.cellInput').length, 0, "There are no custom input fields");
+
 });

--- a/tests/integration/components/models-table/cell-content-display-test.js
+++ b/tests/integration/components/models-table/cell-content-display-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('models-table/cell-content-display', 'Integration | Component | models table/cell content display', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.setProperties({
+    record: {
+      title: "Hello"
+    },
+    column: {
+      propertyName: "title"
+    }
+  });
+
+  this.render(hbs`{{models-table/cell-content-display record=record column=column}}`);
+
+  assert.equal(this.$().text().trim(), this.get("record.title"));
+
+});

--- a/tests/integration/components/models-table/cell-content-edit-test.js
+++ b/tests/integration/components/models-table/cell-content-edit-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('models-table/cell-content-edit', 'Integration | Component | models table/cell content edit', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.setProperties({
+    record: {
+      title: "Hello"
+    },
+    column: {
+      propertyName: "title"
+    }
+  });
+
+  this.render(hbs`{{models-table/cell-content-edit record=record column=column}}`);
+
+  assert.equal(this.$("input")[0].value, this.get("record.title"));
+
+});


### PR DESCRIPTION
This is the basis for in-line editing.

The user still has to supply a component that will toggle the edit row state. User must handle save and rollback if a model, or any other logic it not.

Once this is merged, work can proceed on a model-table supplied component for handling the edit/save/cancel buttons and cleanup. 