### PR TITLE
inline edit

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1302,16 +1302,7 @@ export default Component.extend({
         originalDefinition: column
       });
 
-      let columnComponents = get(this, "columnComponents");
-      if (isPresent(columnComponents)) {
-        let componentName = get(column, "component");
-        if (isPresent(componentName)) {
-          let hashComponent = get(columnComponents, componentName);
-          if (isPresent(hashComponent)) {
-            set(c, 'component', hashComponent);
-          }
-        }
-      }
+      this._setupColumnsComponent(c, column);
 
       set(c, 'filterFunction', filterFunction);
 
@@ -1386,6 +1377,40 @@ export default Component.extend({
       }
     });
   },
+
+  /**
+   * Create new properties for <code>columns</code> for compoenents
+   *
+   * @method _setupColumnsComponent
+   * @param {object} c
+   * @param {object} column
+   * @returns {undefined}
+   * @private
+   */
+    _setupColumnsComponent(c, column) {
+      let columnComponents = get(this, "columnComponents");
+      if (isPresent(columnComponents)) {
+
+        // display component
+        let componentName = get(column, "component");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'component', hashComponent);
+          }
+        }
+
+        // edit component
+        componentName = get(column, "componentForEdit");
+        if (isPresent(componentName)) {
+          let hashComponent = get(columnComponents, componentName);
+          if (isPresent(hashComponent)) {
+            set(c, 'componentForEdit', hashComponent);
+          }
+        }
+
+      }
+    },
 
   /**
    * Update messages used by widget with custom values provided by user in the <code>customMessages</code>

--- a/addon/components/models-table/cell-content-display.js
+++ b/addon/components/models-table/cell-content-display.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/models-table/cell-content-display';
+import { get, set } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  init() {
+    set(this, "tagName", get(this, "themeInstance.tagNames.cell-content"));
+    this._super(...arguments);
+  }
+});

--- a/addon/components/models-table/cell-content-edit.js
+++ b/addon/components/models-table/cell-content-edit.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import layout from '../../templates/components/models-table/cell-content-edit';
+import { get, set } from '@ember/object';
+
+export default Component.extend({
+  layout,
+
+  init() {
+    set(this, "tagName", get(this, "themeInstance.tagNames.cell-content"));
+    this._super(...arguments);
+  }
+});

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
-import { get, computed } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import layout from '../../templates/components/models-table/row';
 import HoverSupport from '../../mixins/hover-support';
+
 
 /**
  * Table body row is used within [models-table/table-body](Components.ModelsTableTableBody.html).
@@ -277,6 +278,23 @@ export default Component.extend(HoverSupport, {
    */
   themeInstance: null,
 
+  /**
+   * Is the row in edit mode
+   *
+   * @property isEditRow
+   * @type boolean
+   * @default false
+   */
+  isEditRow: computed({
+    get() {
+      return false;
+    },
+    set(k, v) {
+      return v;
+    }
+
+  }),
+
   click() {
     get(this, 'clickOnRow')(get(this, 'index'), get(this, 'record'));
   },
@@ -293,8 +311,49 @@ export default Component.extend(HoverSupport, {
     get(this, 'outRow')(get(this, 'index'), get(this, 'record'));
   },
 
+  /**
+   * Place a row into edit mode
+   *
+   * @returns {undefined}
+   * @method actions.editRow
+   */
+  editRow() {
+    set(this, "isEditRow", true);
+  },
+
+  /**
+   * Indicate a row has been saved, the row is no longer in edit mode
+   *
+   * @returns {undefined}
+   * @method actions.saveRow
+   */
+  saveRow() {
+    set(this, "isEditRow", false);
+  },
+
+  /**
+   * Indicate the edit on the row has been cancelled, the row is no longer in edit mode
+   *
+   * @returns {undefined}
+   * @method actions.saveRow
+   */
+  cancelEditRow() {
+    set(this, "isEditRow", false);
+  },
+
+  publicRowApi: computed("isEditRow", {
+    get() {
+      return {
+        isEditRow: get(this, "isEditRow"),
+        editRow: () => this.editRow(),
+        saveRow: () => this.saveRow(),
+        cancelEditRow: () => this.cancelEditRow()
+      };
+    }
+  }),
+
   actions: {
-    toggleGroupedRows() {
+	toggleGroupedRows() {
       get(this, 'toggleGroupedRows')(get(this, 'groupedValue'));
     }
   }

--- a/addon/templates/components/models-table/cell-content-display.hbs
+++ b/addon/templates/components/models-table/cell-content-display.hbs
@@ -1,0 +1,1 @@
+{{get record column.propertyName}}

--- a/addon/templates/components/models-table/cell-content-edit.hbs
+++ b/addon/templates/components/models-table/cell-content-edit.hbs
@@ -1,0 +1,1 @@
+{{input type="text" class=themeInstance.input value=(get record column.propertyName)}}

--- a/addon/templates/components/models-table/cell.hbs
+++ b/addon/templates/components/models-table/cell.hbs
@@ -4,31 +4,40 @@
       record=record
       index=index
       column=column
+      componentToRender=componentToRender
       sendAction=sendAction
       expandRow=expandRow
       collapseRow=collapseRow
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
+      editRow=editRow
+      cancelEditRow=cancelEditRow
       themeInstance=themeInstance
       clickOnRow=clickOnRow
       isExpanded=isExpanded
       isSelected=isSelected
+      publicRowApi=publicRowApi
+      isColumnEditable=isColumnEditable
     )
   }}
 {{else}}
-  {{component
-    column.component
+  {{#if componentToRender}}
+    {{component
+    componentToRender
     record=record
     index=index
     column=column
+    publicRowApi=publicRowApi
     sendAction=sendAction
     expandRow=expandRow
     collapseRow=collapseRow
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     clickOnRow=clickOnRow
-    themeInstance=themeInstance
     isExpanded=isExpanded
     isSelected=isSelected
-  }}
+    isColumnEditable=isColumnEditable
+    themeInstance=themeInstance
+    }}
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -1,7 +1,11 @@
 {{#with (hash
   cell=(
     component themeInstance.components.cell
+    cellContentComponent=themeInstance.components.cell-content
     record=record
+    publicRowApi=publicRowApi
+    isExpanded=isExpanded
+    isSelected=isSelected
     sendAction=sendAction
     expandRow=expandRow
     collapseRow=collapseRow
@@ -29,6 +33,7 @@
     toggleGroupedRowsExpands=toggleGroupedRowsExpands
     sendAction=sendAction
   )
+  publicRowApi=publicRowApi
   visibleProcessedColumns=visibleProcessedColumns
   themeInstance=themeInstance
 ) as |r|}}
@@ -50,15 +55,7 @@
           {{/link-to}}
         </td>
       {{else}}
-        {{#if column.component}}
-          {{component r.cell index=index column=column isExpanded=isExpanded isSelected=isSelected}}
-        {{else}}
-          <td class={{column.className}}>
-            {{#if column.propertyName}}
-              {{get record column.propertyName}}
-            {{/if}}
-          </td>
-        {{/if}}
+          {{component r.cell index=index column=column}}
       {{/if}}
     {{/each}}
   {{/if}}

--- a/addon/themes/default.js
+++ b/addon/themes/default.js
@@ -21,6 +21,8 @@ export default EmberObject.extend({
    */
   components: {
     'cell': 'models-table/cell',
+    'cell-content-display': 'models-table/cell-content-display',
+    'cell-content-edit': 'models-table/cell-content-edit',
     'columns-dropdown': 'models-table/columns-dropdown',
     'columns-hidden': 'models-table/columns-hidden',
     'data-group-by-select': 'models-table/data-group-by-select',
@@ -45,6 +47,11 @@ export default EmberObject.extend({
     'table-body': 'models-table/table-body',
     'table-footer': 'models-table/table-footer',
     'table-header': 'models-table/table-header'
+  },
+
+  tagNames: {
+    /* blank for backward compatibility */
+    'cell-content': ''
   },
 
   /**
@@ -296,6 +303,20 @@ export default EmberObject.extend({
    * @default 'expand-all-rows'
    */
   expandAllRows: 'expand-all-rows',
+
+  /**
+   * @type string
+   * @property cellContentDisplay
+   * @default ''
+   */
+  cellContentDisplay: '',
+
+  /**
+   * @type string
+   * @property cellContentEdit
+   * @default ''
+   */
+  cellContentEdit: '',
 
   /**
    * @type string

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -58,15 +58,57 @@ export default O.extend({
    *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
    *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
    *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
+   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
    *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *  * `isExpanded` - is current row expanded
    *  * `isSelected` - is current row selected
+   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isColumnEditable` - is the column currently editable
    *
    * @type string
    * @property component
    * @default ''
    */
   component: '',
+
+  /**
+   * Custom component used in the column's cells when the row is in edit mode
+   *
+   * It will receive several options:
+   *
+   *  * `data` - whole dataset passed to the `models-table`
+   *  * `record` - current row
+   *  * `index` - current row index
+   *  * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
+   *  * `sendAction` - closure action {{#crossLink "Components.ModelsTable/actions.sendAction:method"}}ModelsTable.actions.sendAction{{/crossLink}}
+   *  * `expandRow` - closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   *  * `collapseRow` - closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
+   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
+   *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   *  * `isExpanded` - is current row expanded
+   *  * `isSelected` - is current row selected
+   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isColumnEditable` - is the column currently editable
+   *
+   * @type string
+   * @property component
+   * @default ''
+   */
+  componentForEdit: '',
+
+  /**
+   * Is this column allowed to be editable
+   *
+   * @default rue
+   * @property editable
+   * @type boolean
+   */
+  editable: true,
 
   /**
    * Custom component used in the header cell with filter

--- a/app/components/models-table/cell-content-display.js
+++ b/app/components/models-table/cell-content-display.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/models-table/cell-content-display';

--- a/app/components/models-table/cell-content-edit.js
+++ b/app/components/models-table/cell-content-edit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-models-table/components/models-table/cell-content-edit';

--- a/tests/dummy/app/components/edit-row.js
+++ b/tests/dummy/app/components/edit-row.js
@@ -1,0 +1,64 @@
+import Component from '@ember/component';
+import {get, set } from '@ember/object';
+import layout from '../templates/components/delete-row-comp';
+
+export default Component.extend({
+  layout,
+
+  record: null,
+
+  onEditRow: null,
+
+
+  publicRowApi: null,
+
+  editLabel: "Edit",
+  cancelLabel: "Cancel",
+  saveLabel: "Save",
+
+  _eventHash(event) {
+    let modelTableApi = this.modelTableApi();
+    set(modelTableApi, "event", event);
+    return modelTableApi;
+  },
+
+  click(event) {
+    event.stopPropagation();
+  },
+
+  actions: {
+    saveClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onSave");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.saveRow();
+      }
+    },
+    editClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onEdit");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.editRow();
+      }
+    },
+    cancelClicked() {
+      let actionResult = false;
+      let api = get(this, "publicRowApi");
+      let action = get(this, "onCancel");
+      if (action) {
+        actionResult = action(get(this, "record"), api)
+      }
+      if (actionResult !== true) {
+        api.cancelEditRow();
+      }
+    }
+  }
+});

--- a/tests/dummy/app/controllers/examples/in-line-edit.js
+++ b/tests/dummy/app/controllers/examples/in-line-edit.js
@@ -1,0 +1,14 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  actions: {
+    onSaveRow(record) {
+      record.save();
+    },
+
+    onCancelRow(record) {
+      record.rollbackAttributes();
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,7 @@ Router.map(function() {
     this.route('sort-by-filter-by');
     this.route('filtering');
     this.route('grouped-rows');
+    this.route('in-line-edit');
   });
 
   this.route('users', function() {

--- a/tests/dummy/app/routes/examples/in-line-edit.js
+++ b/tests/dummy/app/routes/examples/in-line-edit.js
@@ -1,0 +1,20 @@
+import ExampleRoute from './example';
+import {set, get} from '@ember/object';
+import {A} from '@ember/array';
+
+export default ExampleRoute.extend({
+
+  setupController(controller) {
+    this._super(...arguments);
+    set(controller, 'data', A(get(this, 'store').peekAll('user')));
+
+    let columns = get(controller, "columns");
+    columns.pushObject({
+      title: 'Edit',
+      component: 'editRow'
+    });
+
+    columns.objectAt(0).editable = false;
+  }
+
+});

--- a/tests/dummy/app/templates/components/edit-row.hbs
+++ b/tests/dummy/app/templates/components/edit-row.hbs
@@ -1,0 +1,12 @@
+{{#if publicRowApi.isEditRow}}
+    <button class="btn btn-default" onclick={{action "cancelClicked"}}>
+      {{cancelLabel}}
+    </button>
+    <button class="btn btn-default" onclick={{action "saveClicked"}}>
+      {{saveLabel}}
+    </button>
+{{else}}
+    <button class="btn btn-default" onclick={{action "editClicked"}}>
+      {{editLabel}}
+    </button>
+{{/if}}

--- a/tests/dummy/app/templates/examples/in-line-edit.hbs
+++ b/tests/dummy/app/templates/examples/in-line-edit.hbs
@@ -1,0 +1,62 @@
+<h4>In-line edit
+    <small>simple table</small>
+</h4>
+<p class="alert alert-info">Some records may be deleted from both tables in the same time.</p>
+{{models-table
+  data=data
+  columns=columns
+  columnComponents=(hash
+    editRow=(component "edit-row" onSave=(action "onSaveRow") onCancel=(action "onCancelRow"))
+  )
+}}
+<div class="row">
+    <div class="col-md-6">
+        <p>Component usage</p>
+    <pre><code class="language-handlebars">\{{models-table
+    data=data
+    columns=columns
+    columnComponents=(hash
+      editRow=(component "edit-row" onSave=(action "onSaveRow") onCancel=(action "onCancelRow"))
+    )
+  }}</code></pre>
+        <p><code>columns</code></p>
+        <pre><code class="language-javascript">{{to-string this "columns"}}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <p><code>edit-row</code> component</p>
+    <pre><code class="language-handlebars">&lt;button class="btn btn-default"&gt;Edit&lt;/button&gt;
+    </code></pre>
+    <pre><code class="language-javascript">import Component from '@ember/component';
+        import {get} from '@ember/object';
+        import layout from '../templates/components/edit-row';
+
+        export default Component.extend({
+        layout,
+
+        click(){
+          let onClick = get(this, "onClick");
+          if (onClick) {
+            onClick(get(this, "record"));
+            event.stopPropagation();
+          }
+          }
+        };
+    </code></pre>
+        <p>Controller</p>
+<pre><code class="language-javascript">import Controller from '@ember/controller';
+    import {get} from '@ember/object';
+
+    export default Controller.extend({
+    actions: {
+      editRecord (record) {
+        get(this, 'edtRow)();
+      }
+    }
+    });</code></pre>
+    </div>
+</div>
+
+<h4>Custom component in a cell with closure actions
+    <small>server paginated table</small>
+</h4>
+{{models-table-server-paginated data=model columns=columns columnComponents=(hash editRow=(component "edit-row"))}}

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -82,5 +82,6 @@ export default function() {
 
   this.get('/users/:id');
   this.delete('/users/:id');
+  this.patch('/users/:id');
 
 }

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -3024,7 +3024,6 @@ test('in-line edit: row is editable, column displays default edit component ', f
         {{#table.body as |body|}}
           {{#each body.visibleContent as |record index|}}
             {{#body.row record=record index=index as |row|}}
-            {{log row}}
                 <div class="isEditRow">{{if row.publicRowApi.isEditRow "yes" "no"}}</div>
                 <div class="actionEdit" {{action row.publicRowApi.editRow}}>Edit</div>
                 <div class="actionSave" {{action row.publicRowApi.saveRow}}>Save</div>

--- a/tests/integration/components/models-table/cell-content-display-test.js
+++ b/tests/integration/components/models-table/cell-content-display-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('models-table/cell-content-display', 'Integration | Component | models table/cell content display', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.setProperties({
+    record: {
+      title: "Hello"
+    },
+    column: {
+      propertyName: "title"
+    }
+  });
+
+  this.render(hbs`{{models-table/cell-content-display record=record column=column}}`);
+
+  assert.equal(this.$().text().trim(), this.get("record.title"));
+
+});

--- a/tests/integration/components/models-table/cell-content-edit-test.js
+++ b/tests/integration/components/models-table/cell-content-edit-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('models-table/cell-content-edit', 'Integration | Component | models table/cell content edit', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.setProperties({
+    record: {
+      title: "Hello"
+    },
+    column: {
+      propertyName: "title"
+    }
+  });
+
+  this.render(hbs`{{models-table/cell-content-edit record=record column=column}}`);
+
+  assert.equal(this.$("input")[0].value, this.get("record.title"));
+
+});


### PR DESCRIPTION
This is the basis for in-line editing.

The user still has to supply a component that will toggle the edit row state. User must handle save and rollback if a model, or any other logic it not.

Once this is merged, work can proceed on a model-table supplied component for handling the edit/save/cancel buttons and cleanup.