### PR TITLE
Allow add/remove/clear of selected Items

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -1379,6 +1379,11 @@ export default Component.extend({
    *
    * {
    *  refilter() - Invalidates the filteredContent property, causing the table to be re-filtered.
+   *  selectedItems: {
+   *    clear() - Clears all selected Items
+   *    add(item) - Adds the item to the selected Items (will not add if its already selected)
+   *    remove(item) - Removes the item from the selected Items
+   *  }
    * }
    *
    * @type object
@@ -1391,6 +1396,29 @@ export default Component.extend({
       return {
         refilter: () => {
           this.notifyPropertyChange('filteredContent');
+        },
+        resort: () => {
+          this.notifyPropertyChange('arrangedContent');
+        },
+        selectedItems: {
+          clear: () => {
+            get(this, 'selectedItems').clear();
+            this.userInteractionObserver();
+          },
+          add: (dataItem) => {
+            let selectedItems = get(this, 'selectedItems');
+            if (selectedItems.includes(dataItem) === false) {
+              selectedItems.pushObject(dataItem);
+              this.userInteractionObserver();
+            }
+          },
+          remove: (dataItem) => {
+            let selectedItems = get(this, 'selectedItems');
+            if (selectedItems.includes(dataItem)) {
+              selectedItems.removeObject(dataItem);
+              this.userInteractionObserver();
+            }
+          }
         }
       };
     }

--- a/tests/dummy/app/controllers/examples/public-api.js
+++ b/tests/dummy/app/controllers/examples/public-api.js
@@ -1,0 +1,30 @@
+import Controller from '@ember/controller';
+import { get } from '@ember/object';
+
+export default Controller.extend({
+  showComponentFooter: true,
+  showColumnsDropdown: true,
+  useFilteringByColumns: true,
+  showGlobalFilter: true,
+  useNumericPagination: false,
+  doFilteringByHiddenColumns: false,
+  filteringIgnoreCase: false,
+  multipleColumnsSorting: true,
+  showPageSize: true,
+
+  modelsTablePubicApi: null,
+
+  actions: {
+    selectFirstRecord() {
+      let record = get(this, 'data.firstObject');
+      get(this, 'modelsTablePubicAPI.selectedItems').add(record);
+    },
+    unselectFirstRecord() {
+      let record = get(this, 'data.firstObject');
+      get(this, 'modelsTablePubicAPI.selectedItems').remove(record);
+    },
+    clearSelectedRecords() {
+      get(this, 'modelsTablePubicAPI.selectedItems').clear();
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -25,6 +25,7 @@ Router.map(function() {
     this.route('filtering');
     this.route('grouped-rows');
     this.route('in-line-edit');
+    this.route('public-api');
   });
 
   this.route('users', function() {

--- a/tests/dummy/app/routes/examples/public-api.js
+++ b/tests/dummy/app/routes/examples/public-api.js
@@ -1,0 +1,3 @@
+import ExampleRoute from './example';
+
+export default ExampleRoute.extend({});

--- a/tests/dummy/app/templates/examples/public-api.hbs
+++ b/tests/dummy/app/templates/examples/public-api.hbs
@@ -1,0 +1,58 @@
+<h4>Common table
+    <small>simple table</small>
+</h4>
+
+<div class="row">
+    <div class="col-md-3">
+        <p>Public API</p>
+      <pre><code class="language-handlebars">\{{models-table data=data columns=columns multipleSelect=true
+  registerApi=(action (mut "modelsTablePubicApi"))
+}}</code></pre>
+    </div>
+    <div class="col-md-3">
+        <button class="btn btn-default" {{action "selectFirstRecord"}}>Select First Record</button>
+        <button class="btn btn-default" {{action "unselectFirstRecord"}}>Unselect First Record</button>
+        <button class="btn btn-default" {{action "clearSelectedRecords"}}>Clear Selected</button>
+      <pre><code class="language-handlebars">
+&lt;button class="btn btn-default" \{{action "selectFirstRecord"}}&gt;
+  Select First Record
+&lt;/button&gt;
+&lt;button class="btn btn-default" \{{action "unselectFirstRecord"}}&gt;
+  Unselect First Record
+&lt;/button&gt;
+&lt;button class="btn btn-default" \{{action "clearSelectedRecords"}}&gt;
+  Clear Selected
+&lt;/button&gt;</code></pre>
+    </div>
+    <div class="col-md-3">
+        <pre><code class="language-javascript">actions: {
+  selectFirstRecord() {
+    let record = get(this, "data.firstObject");
+    get(this, 'modelsTablePubicAPI.selectedItems').add(record);
+  },
+  unselectFirstRecord() {
+    let record = get(this, "data.firstObject");
+    get(this, 'modelsTablePubicAPI.selectedItems').remove(record);
+  },
+  clearSelectedRecords() {
+    get(this, 'modelsTablePubicAPI.selectedItems').clear();
+  }
+}</code></pre>
+    </div>
+
+</div>
+{{models-table data=data columns=columns multipleSelect=true
+  registerAPI=(action (mut modelsTablePubicAPI))
+}}
+
+<div class="row">
+    <div class="col-md-6">
+        <p>Component usage:</p>
+    <pre><code class="language-handlebars">\{{models-table data=data columns=columns
+        }}</code></pre>
+    </div>
+    <div class="col-md-6">
+        <p><code>columns</code>:</p>
+        <pre><code class="language-javascript">{{to-string this "columns"}}</code></pre>
+    </div>
+</div>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -4,6 +4,8 @@ import BootstrapTheme from 'ember-models-table/themes/bootstrap3';
 
 import Component from '@ember/component';
 
+import { get } from '@ember/object';
+
 import {
   moduleForComponent,
   test
@@ -2196,6 +2198,53 @@ test('selectable rows (multipleSelect = false)', function (assert) {
   rows(1).click();
   assert.notOk(rows(0).selected, 'First row is not selected');
   assert.ok(rows(1).selected, 'Second row is selected');
+
+});
+
+test('selectable rows via publicAPI (multipleSelect = true)', function (assert) {
+
+  this.setProperties({
+    data: generateContent(30, 1),
+    columns: generateColumns(['id']),
+  });
+
+  this.on('add', () => {
+    let publicAPI = get(this, 'publicAPI');
+    get(publicAPI, 'selectedItems').add(get(this, 'data.firstObject'));
+  });
+
+  this.on('remove', () => {
+    let publicAPI = get(this, 'publicAPI');
+    get(publicAPI, 'selectedItems').remove(get(this, 'data.firstObject'));
+  });
+
+ this.on('clear', () => {
+    let publicAPI = get(this, 'publicAPI');
+   get(publicAPI, 'selectedItems').clear();
+  });
+
+  this.render(hbs`<div class="select" {{action "add"}}>select</div>
+  <div class="unselect" {{action "remove"}}>unselect</div><div class="clear" {{action "clear"}}>clear</div>
+  {{models-table data=data column=columns multipleSelect=true registerAPI=(action (mut publicAPI))}}`);
+
+  assert.equal(rows().filterBy('selected').length, 0, 'No selected rows by default');
+
+  this.$('.select').click();
+  assert.ok(rows(0).selected, 'First row is selected');
+
+  this.$('.unselect').click();
+  assert.notOk(rows(0).selected, 'First row is not selected');
+
+  rows(0).click();
+  rows(1).click();
+
+  assert.ok(rows(0).selected, 'First row is selected');
+  assert.ok(rows(1).selected, 'Second row is selected');
+
+  this.$('.clear').click();
+
+  assert.notOk(rows(0).selected, 'First row is not selected');
+  assert.notOk(rows(1).selected, 'Second row is not selected');
 
 });
 


### PR DESCRIPTION
I see the changes that you made for the pre-selected items. I am assuming that maybe clearing that array is what you had in mind for clearing the selected items, that may work for clearing, but doesnt work for adding/removing unless they keep track of the array through displayDataChangeActions. The clickOnRow function replaces the array, so the array they pass in is NOT kept up to date. It also exposes the internals that the selectedItems is maintained as an array, you would not be able to change the way selectedItems is maintained.

I had been working on this. This pull will allow them to add / remove / clear selectedItems without exposing the internals. I did not do this, but methods like clickOnRow should call the same methods in publicAPI so the code is maintained once (ie use the same API you provide for others).

The pre-selected was kinda nice the way it was. I can also update the add / remove methods to accept arrays so they wouldnt have to call add several times.