### PR TITLE
rows can be sorted by isSelected property

### DIFF
--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -27,6 +27,7 @@
     sort=(action "sort")
     visibleContent=visibleContent
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     expandedRowComponent=expandedRowComponent
     processedColumns=processedColumns
@@ -59,6 +60,7 @@
     expandAllRows=(action "expandAllRows")
     collapseAllRows=(action "collapseAllRows")
     toggleAllSelection=(action "toggleAllSelection")
+    toggleSelectedFirst=(action "toggleSelectedFirst")
   )
   data-group-by-select=(
     component themeInstance.components.data-group-by-select

--- a/addon/templates/components/models-table/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/row-filtering-cell.hbs
@@ -3,12 +3,14 @@
     (hash
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     )
   }}
 {{else}}
@@ -17,12 +19,14 @@
       column.componentForFilterCell
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     }}
   {{else}}
     {{#if column.useFilter}}

--- a/addon/templates/components/models-table/row-filtering.hbs
+++ b/addon/templates/components/models-table/row-filtering.hbs
@@ -7,10 +7,12 @@
     themeInstance=themeInstance
     sendAction=sendAction
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     toggleAllSelection=toggleAllSelection
+    toggleSelectedFirst=toggleSelectedFirst
   )
 ) as |rf|}}
   {{#if hasBlock}}

--- a/addon/templates/components/models-table/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/row-sorting-cell.hbs
@@ -3,12 +3,14 @@
     (hash
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       data=data
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
       collapseAllRows=collapseAllRows
     )
   }}
@@ -18,12 +20,14 @@
       column.componentForSortCell
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       data=data
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
       collapseAllRows=collapseAllRows
     }}
   {{else}}

--- a/addon/templates/components/models-table/row-sorting.hbs
+++ b/addon/templates/components/models-table/row-sorting.hbs
@@ -6,6 +6,7 @@
     themeInstance.components.row-sorting-cell
     themeInstance=themeInstance
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     sort=sort
     data=data
@@ -13,6 +14,7 @@
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     toggleAllSelection=toggleAllSelection
+    toggleSelectedFirst=toggleSelectedFirst
   )
 ) as |rs|}}
   {{#if hasBlock}}

--- a/addon/templates/components/models-table/table-footer.hbs
+++ b/addon/templates/components/models-table/table-footer.hbs
@@ -8,6 +8,7 @@
   collapseAllRows=collapseAllRows
   themeInstance=themeInstance
   selectedItems=selectedItems
+  selectedFirst=selectedFirst
   expandedItems=expandedItems
   clearFilters=clearFilters
   visibleProcessedColumns=visibleProcessedColumns

--- a/addon/templates/components/models-table/table-header.hbs
+++ b/addon/templates/components/models-table/table-header.hbs
@@ -5,6 +5,7 @@
     visibleProcessedColumns=visibleProcessedColumns
     themeInstance=themeInstance
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     useDataGrouping=useDataGrouping
     displayGroupedValueAs=displayGroupedValueAs
@@ -14,6 +15,7 @@
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     toggleAllSelection=toggleAllSelection
+    toggleSelectedFirst=toggleSelectedFirst
   )
   row-filtering=(
     component themeInstance.components.row-filtering
@@ -21,6 +23,7 @@
     visibleProcessedColumns=visibleProcessedColumns
     themeInstance=themeInstance
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     useDataGrouping=useDataGrouping
     displayGroupedValueAs=displayGroupedValueAs
@@ -28,6 +31,7 @@
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     toggleAllSelection=toggleAllSelection
+    toggleSelectedFirst=toggleSelectedFirst
   )
   grouped-header=(
     component themeInstance.components.grouped-header

--- a/addon/templates/components/models-table/table.hbs
+++ b/addon/templates/components/models-table/table.hbs
@@ -10,6 +10,7 @@
     sort=sort
     data=data
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     useDataGrouping=useDataGrouping
     displayGroupedValueAs=displayGroupedValueAs
@@ -19,12 +20,14 @@
     expandAllRows=expandAllRows
     collapseAllRows=collapseAllRows
     toggleAllSelection=toggleAllSelection
+    toggleSelectedFirst=toggleSelectedFirst
   )
   body=(
     component themeInstance.components.table-body
     columnsCount=columnsCount
     visibleContent=visibleContent
     selectedItems=selectedItems
+    selectedFirst=selectedFirst
     expandedItems=expandedItems
     useDataGrouping=useDataGrouping
     toggleGroupedRows=toggleGroupedRows

--- a/addon/templates/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
@@ -3,12 +3,14 @@
     (hash
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     )
   }}
 {{else}}
@@ -17,12 +19,14 @@
       column.componentForFilterCell
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     }}
   {{else}}
     {{#if column.useFilter}}

--- a/addon/templates/components/models-table/themes/semanticui/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/row-filtering-cell.hbs
@@ -3,12 +3,14 @@
     (hash
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     )
   }}
 {{else}}
@@ -17,12 +19,14 @@
       column.componentForFilterCell
       column=column
       selectedItems=selectedItems
+      selectedFirst=selectedFirst
       expandedItems=expandedItems
       sendAction=sendAction
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
       toggleAllSelection=toggleAllSelection
+      toggleSelectedFirst=toggleSelectedFirst
     }}
   {{else}}
     {{#if column.useFilter}}

--- a/addon/themes/bootstrap3.js
+++ b/addon/themes/bootstrap3.js
@@ -365,6 +365,25 @@ export default DefaultTheme.extend({
   'deselect-all-rows': 'glyphicon glyphicon-unchecked',
 
   /**
+   * Icon for selected items placed at first place
+   *
+   * @type string
+   * @property selected-first
+   * @default 'glyphicon glyphicon-check'
+   */
+  'selected-first': 'glyphicon glyphicon-arrow-up',
+
+  /**
+   * Icon for selected items placed as the user selected them
+   *
+   * @type string
+   * @property selected-not-first
+   * @default 'glyphicon glyphicon-check'
+   */
+  'selected-not-first': 'glyphicon glyphicon-random',
+
+
+  /**
    * Icon for selection row (used in the tbody tr internally)
    *
    * @type string

--- a/addon/themes/bootstrap4.js
+++ b/addon/themes/bootstrap4.js
@@ -53,6 +53,8 @@ export default Bootstrap3Theme.extend({
   'collapse-all-rows': 'fa fa-minus',
   'select-all-rows': 'fa fa-check-square-o',
   'deselect-all-rows': 'fa fa-square-o',
+  'selected-first': 'fa fa-long-arrow-alt-up',
+  'selected-not-first': 'fa fa-random',
   'select-row': 'fa fa-check-square-o',
   'deselect-row': 'fa fa-square-o'
 });

--- a/addon/themes/default.js
+++ b/addon/themes/default.js
@@ -366,7 +366,7 @@ export default EmberObject.extend({
 
   /**
    * CSS-class for table header
-   * 
+   *
    * @type string
    * @property thead
    * @default ''
@@ -540,6 +540,20 @@ export default EmberObject.extend({
    * @default ''
    */
   'deselect-all-rows': '',
+
+  /**
+   * @type string
+   * @property selected-first
+   * @default ''
+   */
+  'selected-first': '',
+
+  /**
+   * @type string
+   * @property selected-not-first
+   * @default ''
+   */
+  'selected-not-first': '',
 
   /**
    * @type string

--- a/addon/themes/semanticui.js
+++ b/addon/themes/semanticui.js
@@ -49,6 +49,8 @@ export default DefaultTheme.extend({
   'collapse-all-rows': 'icon minus',
   'select-all-rows': 'toggle on icon',
   'deselect-all-rows': 'toggle off icon',
+  'selected-first': 'level up alternate icon',
+  'selected-not-first': 'random icon',
   'select-row': 'toggle on icon',
   'deselect-row': 'toggle off icon',
   paginationBlock: 'ui icon buttons right floated',

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -129,12 +129,14 @@ export default O.extend({
    * * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
    * * `data` - whole dataset passed to the `models-table`
    * * `selectedItems` - bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * * `selectedFirst` - bound from {{#crossLink "Components.ModelsTable/selectedFirst:property"}}ModelsTable.selectedFirst{{/crossLink}}
    * * `expandedItems` - bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    * * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    * * `sendAction` - closure action {{#crossLink "Components.ModelsTable/actions.sendAction:method"}}ModelsTable.actions.sendAction{{/crossLink}}
    * * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
    * * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
    * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * * `toggleSelectedFirst` - closure action {{#crossLink "Components.ModelsTable/actions.toggleSelectedFirst:method"}}ModelsTable.actions.toggleSelectedFirst{{/crossLink}}
    *
    * @type string
    * @property componentForFilterCell
@@ -156,6 +158,7 @@ export default O.extend({
    * * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
    * * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
    * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * * `toggleSelectedFirst` - closure action {{#crossLink "Components.ModelsTable/actions.toggleSelectedFirst:method"}}ModelsTable.actions.toggleSelectedFirst{{/crossLink}}
    *
    * @type string
    * @property componentForSortCell

--- a/tests/dummy/app/components/select-all-rows-checkbox.js
+++ b/tests/dummy/app/components/select-all-rows-checkbox.js
@@ -7,6 +7,10 @@ export default Component.extend({
   actions: {
     toggleAllSelection() {
       get(this, 'toggleAllSelection')();
+    },
+
+    toggleSelectedFirst() {
+      get(this, 'toggleSelectedFirst')();
     }
   }
 });

--- a/tests/dummy/app/templates/components/select-all-rows-checkbox.hbs
+++ b/tests/dummy/app/templates/components/select-all-rows-checkbox.hbs
@@ -1,2 +1,4 @@
 <span {{action "toggleAllSelection"}} class="{{if (is-equal selectedItems.length data.length) themeInstance.select-all-rows themeInstance.deselect-all-rows}} toggle-all"></span>
+
+<span {{action "toggleSelectedFirst"}} class="{{if selectedFirst themeInstance.selected-first themeInstance.selected-not-first}} toggle-selected-first"></span>
 {{yield}}

--- a/tests/dummy/app/templates/examples/select-rows-with-checkboxes.hbs
+++ b/tests/dummy/app/templates/examples/select-rows-with-checkboxes.hbs
@@ -27,6 +27,10 @@ export default Component.extend({
   actions: {
     toggleAllSelection() {
       get(this, 'toggleAllSelection')();
+    },
+
+    toggleSelectedFirst() {
+      get(this, 'toggleSelectedFirst')();
     }
   }
 });

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -2100,6 +2100,84 @@ test('selectable rows (multipleSelect = true)', function (assert) {
   ModelsTableBs.toggleAllSelection();
   assert.equal(rows.filter(r => r.selected).length, 0, 'all rows are not selected');
 
+});test('selectable rows (multipleSelect = true)', function (assert) {
+
+  const checkboxColumn = {
+    component: 'select-row-checkbox',
+    useFilter: false,
+    mayBeHidden: false,
+    componentForSortCell: 'select-all-rows-checkbox'
+  };
+
+  const columns = generateColumns(['id']);
+  columns.unshift(checkboxColumn);
+
+  this.setProperties({
+    data: generateContent(30, 1),
+    columns
+  });
+  this.render(hbs`{{models-table data=data columns=columns multipleSelect=true}}`);
+
+  assert.equal(rows.filterBy('selected').length, 0, 'No selected rows by default');
+
+  rows.objectAt(0).click();
+  assert.ok(rows.objectAt(0).selected, 'First row is selected');
+
+  rows.objectAt(1).click();
+  assert.ok(rows.objectAt(0).selected, 'First row is still selected');
+  assert.ok(rows.objectAt(1).selected, 'Second row is selected');
+
+  rows.objectAt(0).click();
+  assert.notOk(rows.objectAt(0).selected, 'First row is not selected');
+  assert.ok(rows.objectAt(1).selected, 'Second row is selected');
+
+  rows.objectAt(1).click();
+  assert.notOk(rows.objectAt(0).selected, 'First row still is not selected');
+  assert.notOk(rows.objectAt(1).selected, 'Second row is not selected');
+
+  ModelsTableBs.toggleAllSelection();
+  assert.equal(rows.filter(r => r.selected).length, 10, 'all rows are selected');
+
+  ModelsTableBs.toggleAllSelection();
+  assert.equal(rows.filter(r => r.selected).length, 0, 'all rows are not selected');
+
+});
+
+test('selectable rows (multipleSelect = true, toggle selectedFirst)', function (assert) {
+
+  const checkboxColumn = {
+    component: 'select-row-checkbox',
+    useFilter: false,
+    mayBeHidden: false,
+    componentForSortCell: 'select-all-rows-checkbox'
+  };
+
+  const columns = generateColumns(['id']);
+  columns.unshift(checkboxColumn);
+
+  this.setProperties({
+    data: generateContent(30, 1),
+    columns
+  });
+  this.render(hbs`{{models-table data=data columns=columns multipleSelect=true}}`);
+
+  assert.equal(rows.filterBy('selected').length, 0, 'No selected rows by default');
+
+  rows.objectAt(2).click();
+  rows.objectAt(4).click();
+
+  ModelsTableBs.toggleSelectedFirst();
+  assert.equal(rows.filter(r => r.selected).length, 2, 'two rows are selected');
+  assert.ok(rows.objectAt(0).selected, 'The first selected item goes first');
+  assert.ok(rows.objectAt(1).selected, 'The second selected item goes second');
+
+  ModelsTableBs.toggleSelectedFirst();
+  assert.equal(rows.filter(r => r.selected).length, 2, 'two rows are still selected');
+  assert.ok(!rows.objectAt(0).selected, 'The original first row is back at its position');
+  assert.ok(!rows.objectAt(1).selected, 'The original second row is back at its position');
+  assert.ok(rows.objectAt(2).selected, 'The first selected item is back ast its position');
+  assert.ok(rows.objectAt(4).selected, 'The second selected item is back ast its position');
+
 });
 
 test('selectable rows (multipleSelect = false)', function (assert) {

--- a/tests/pages/models-table-bs.js
+++ b/tests/pages/models-table-bs.js
@@ -39,6 +39,7 @@ export default create({
   expandAllRows: clickable('thead .expand-all-rows'),
   collapseAllRows: clickable('thead .collapse-all-rows'),
   toggleAllSelection: clickable('thead .toggle-all'),
+  toggleSelectedFirst: clickable('thead .toggle-selected-first'),
   expandRowButtons: count('a.expand-row'),
   collapseRowButtons: count('a.collapse-row'),
   filters: collection('table thead tr:eq(1) th', {


### PR DESCRIPTION
I'm not sure if it's the right direction, since it is intrusive (it mutate the state of the underlying client item).
An other solution (more difficult to implement) could be to wrap the item in a Row object (maybe an ObjectProxy?), and only delegate to the underlying object when necessary. But it implies a large refactoring, I'm not sure to be capable of.
At least, I need some help to give me the direction