### PR TITLE
Allow any model field to be set as parameter for routeName

### DIFF
--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -58,7 +58,7 @@
       {{else}}
         {{#if column.routeName}}
           <td class={{column.className}}>
-            {{#link-to column.routeName record.id}}
+            {{#link-to column.routeName (get record column.routeProperty)}}
               {{#if column.propertyName}}
                 {{get record column.propertyName}}
               {{else}}

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -382,7 +382,7 @@ export default O.extend({
    * @type string
    * @default ''
    */
-  routeProperty: '',
+  routeProperty: 'id',
   /**
    * Object containing the definition of the column passed into the component
    *

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -375,7 +375,14 @@ export default O.extend({
    * @default ''
    */
   routeName: '',
-
+  /**
+   * If this property is defined, link to the route will be rendered in the cell. {{#crossLink "Utils.ModelsTableColumn/routeProperty:property"}}routeProperty{{/crossLink}} is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
+   *
+   * @property routeProperty
+   * @type string
+   * @default ''
+   */
+  routeProperty: '',
   /**
    * Object containing the definition of the column passed into the component
    *


### PR DESCRIPTION
Allow any model field to be set as a parameter for routeName

Currently, when a table is defined and a 'routeName' is added, the table will display the propertyName but will link to the 'id' field of the record.

In order to allow for another model property to be set as the parameter for the route, a new routeProperty has been created which defaults to 'id' (enables backward compatibility).

Where a 'routeName' is specified allow another model property to  be used instead of the 'id'

The routeProperty is the parameter to be passed to the route on transition.

E.g
    {
      'propertyName':'tktNo',
      'routeName':'accounts.tickets.ticket',
      'routeProperty':'tktNo', // if not set defaults to id
      'title':'Ticket No',
    },

f0a06ac
Darren Drumm
Darren Drumm
Default New routeProperty to 'id' 