### PR TITLE
[BREAKING] Make consistent properties for themes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@
 # compiled output
 /dist/
 /tmp/
+/docs/
 
 # dependencies
 /bower_components/

--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -103,9 +103,6 @@ export default
    * True if data is currently being loaded from the server.
    * Can be used in the template to e.g. display a loading spinner.
    *
-   * @type boolean
-   * @property isLoading
-   * @default false
    * @private
    */
   isLoading = false;
@@ -114,9 +111,6 @@ export default
    * True if last data query promise has been rejected.
    * Can be used in the template to e.g. indicate stale data or to e.g. show error state.
    *
-   * @type boolean
-   * @property isError
-   * @default false
    * @private
    */
   isError = false;
@@ -125,15 +119,13 @@ export default
    * The property on meta to load the pages count from.
    *
    * @type string
-   * @property metaPagesCountProperty
    * @default 'pagesCount'
    */
   metaPagesCountProperty = 'pagesCount';
   /**
    * The property on meta to load the total item count from.
    *
-   * @type {string}
-   * @property metaItemsCountProperty
+   * @type string
    * @default 'itemsCount'
    */
   metaItemsCountProperty = 'itemsCount';
@@ -143,7 +135,6 @@ export default
    * This can be tweaked to avoid making too many server requests.
    *
    * @type number
-   * @property debounceDataLoadTime
    * @default 500
    */
   debounceDataLoadTime = 500;
@@ -151,9 +142,6 @@ export default
   /**
    * Determines if multi-columns sorting should be used
    *
-   * @type boolean
-   * @property multipleColumnsSorting
-   * @default false
    */
   multipleColumnsSorting = false;
 
@@ -161,7 +149,6 @@ export default
    * The query parameters to use for server side filtering / querying.
    *
    * @type object
-   * @property filterQueryParameters
    */
   filterQueryParameters = {
     globalFilter: 'search',
@@ -172,7 +159,6 @@ export default
   };
 
   /**
-   * @property observedProperties
    * @type string[]
    * @private
    */
@@ -183,7 +169,6 @@ export default
    * This is set during didReceiveAttr and whenever the page/filters change.
    *
    * @override
-   * @property filteredContent
    * @default []
    * @private
    * @type object[]
@@ -194,7 +179,6 @@ export default
    * For server side filtering, visibleContent is same as the filtered content
    *
    * @override
-   * @property visibleContent
    * @private
    * @type object[]
    */
@@ -204,7 +188,6 @@ export default
    * For server side filtering, arrangedContent is same as the filtered content
    *
    * @override
-   * @property arrangedContent
    * @private
    * @type object[]
    */
@@ -216,7 +199,6 @@ export default
    *
    * @override
    * @type number
-   * @property arrangedContentLength
    * @private
    */
   @computed('filteredContent.meta')
@@ -230,7 +212,6 @@ export default
    * Set metaPagesCountProperty to change from which meta property this is loaded.
    *
    * @type number
-   * @property pagesCount
    * @override
    * @private
    */
@@ -244,7 +225,6 @@ export default
    * The index of the last item that is currently being shown.
    *
    * @type number
-   * @property lastIndex
    * @override
    * @private
    */

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -20,10 +20,54 @@ import layout from '../templates/components/models-table';
 import ModelsTableColumn, {propertyNameToTitle} from '../utils/column';
 
 /**
- * @typedef {object} groupedHeader
- * @property {string} title header for grouped columns
- * @property {number} colspan HTML colspan attr
- * @property {number} rowspan HTML rowspan attr
+ * @class GroupedHeader
+ */
+/**
+ * Header for grouped columns
+ * @property title
+ * @type string
+ * @for GroupedHeader
+ */
+/**
+ * HTML colspan attr
+ * @property colspan
+ * @type number
+ * @for GroupedHeader
+ */
+/**
+ * HTML rowspan attr
+ * @property rowspan
+ * @type number
+ * @for GroupedHeader
+ */
+
+/**
+ * @typedef {object} SelectOption
+ * @property {string|number|boolean} value
+ * @property label {string|number|boolean} label
+ */
+
+/**
+ * @typedef {object} ColumnSet
+ * @property {string} label
+ * @property {string[]|Function} showColumns
+ * @property {boolean} hideOtherColumns
+ * @property {boolean} toggleSet
+ */
+
+/**
+ * @typedef {object} ColumnDropdownOptions
+ * @property {boolean} showAll
+ * @property {boolean} hideAll
+ * @property {boolean} restoreDefaults
+ * @property {ColumnSet[]} columnSets
+ */
+
+/**
+ * @typedef {object} SortMap
+ * @property {string} asc
+ * @property {string} desc
+ * @property {string} none
  */
 
 const {
@@ -37,7 +81,7 @@ const NOT_SORTED = -1;
 
 /**
  * @ignore
- * @param {ModelsTableColumn} column
+ * @param {Utils.ModelsTableColumn} column
  * @returns {boolean}
  */
 function isSortedByDefault(column) {
@@ -66,10 +110,10 @@ function optionStrToObj(option) {
 }
 
 /**
- * Updates <code>filterOptions</code> for column which use <code>filterWithSelect</code>
- * and don't have <code>predefinedFilterOptions</code>
- * <code>filterOptions</code> are calculated like <code>data.mapBy(column.propertyName).uniq()</code>,
- * where data is component's <code>data</code>
+ * Updates `filterOptions` for column which use `filterWithSelect`
+ * and don't have `predefinedFilterOptions`
+ * `filterOptions` are calculated like `data.mapBy(column.propertyName).uniq()`,
+ * where data is component's `data`
  *
  * @param {string} propertyName
  * @returns {object[]}
@@ -161,7 +205,7 @@ function objToArray(map) {
  * ModelsTable yields references to the following contextual components:
  *
  * * [models-table/global-filter](Components.ModelsTableGlobalFilter.html) - global filter used for table data
- * * [models-table/columns-dropdown](Components.ModelsTableColumnsDropdown.html) - dropdown with list of options to toggle columns and column-sets visibility
+ * * [models-table/columns-dropdown](Components.Utils.ModelsTableColumnsDropdown.html) - dropdown with list of options to toggle columns and column-sets visibility
  * * [models-table/data-group-by-select](Components.ModelsTableDataGroupBySelect.html) - dropdown to select property for table-rows grouping
  * * [models-table/table](Components.ModelsTableTable.html) - table with a data
  * * [models-table/footer](Components.ModelsTableFooter.html) - summary and pagination
@@ -170,6 +214,7 @@ function objToArray(map) {
  *
  * ModelsTable has a lot of options you may configure, but there are two required properties called `data` and `columns`. First one contains data (e.g. list of records from the store). Second one is a list of table's columns (check [models-table-column](Utils.ModelsTableColumn.html) for available options).
  *
+ * @class ModelsTable
  * @namespace Components
  * @extends Ember.Component
  */
@@ -179,16 +224,27 @@ export default
 class ModelsTableComponent extends Component {
   /**
    * Number of records shown on one table-page
+   *
+   * @property pageSize
+   * @type number
+   * @default 10
    */
   pageSize = 10;
 
   /**
    * Currently shown page number. It may be set initially
+   *
+   * @property currentPageNumber
+   * @type number
+   * @default 1
    */
   currentPageNumber = 1;
 
   /**
    * Order of sorting for each columns. Unsorted column firstly become sorted ASC, then DESC, then sorting is dropped again
+   *
+   * @property sortMap
+   * @type SortMap
    */
   sortMap = {
     none: 'asc',
@@ -200,59 +256,98 @@ class ModelsTableComponent extends Component {
    * List of properties to sort table rows
    *
    * Each value is like 'propertyName:sortDirection'
+   *
+   * @property sortProperties
    * @protected
    */
   sortProperties = A([]);
 
   /**
    * Hash of custom functions to sort table rows
-   * @private
+   *
+   * @property sortFunctions
+   * @type {object}
+   * @protected
    */
   sortFunctions = Object.create(null);
 
   /**
-   * @private
+   * @property forceToFirstPageProps
+   * @type {string[]}
+   * @protected
+   * @default ['processedColumns.@each.filterString', 'filterString', 'pageSize']
    */
   forceToFirstPageProps = A(['processedColumns.@each.filterString', 'filterString', 'pageSize']);
 
   /**
    * Determines if multi-columns sorting should be used
+   *
+   * @property multipleColumnsSorting
+   * @type boolean
+   * @default true
    */
   multipleColumnsSorting = true;
 
   /**
    * Determines if component footer should be shown on the page
+   *
+   * @property showComponentFooter
+   * @type boolean
+   * @default true
    */
   showComponentFooter = true;
 
   /**
    * Determines if dropdown for current page number should be shown near the pagination block
+   *
+   * @property showCurrentPageNumberSelect
+   * @type boolean
+   * @default true
    */
   showCurrentPageNumberSelect = true;
 
   /**
    * Determines if numeric pagination should be used
+   *
+   * @property useNumericPagination
+   * @type boolean
+   * @default false
    */
   useNumericPagination = false;
 
   /**
    * Determines if columns-dropdown should be shown
    *
+   * @property showColumnsDropdown
+   * @type boolean
+   * @default true
    */
   showColumnsDropdown = true;
 
   /**
    * Determines if filtering by columns should be available to the user
+   *
+   * @property useFilteringByColumns
+   * @type boolean
+   * @default true
    */
   useFilteringByColumns = true;
 
   /**
    * Global filter value
+   *
+   * @property filterString
+   * @type string
+   * @default ''
    */
   filterString = '';
 
   /**
    * Determines if filtering (global and by column) should ignore case
+   *
+   * @property filteringIgnoreCase
+   * @type boolean
+   * @default false
    */
   filteringIgnoreCase = false;
 
@@ -260,16 +355,28 @@ class ModelsTableComponent extends Component {
    * Determines if filtering should be done by hidden columns
    *
    * **Notice:** after changing this value filtering results will be updated only after filter options are changed
+   *
+   * @property doFilteringByHiddenColumns
+   * @type boolean
+   * @default true
    */
   doFilteringByHiddenColumns = true;
 
   /**
    * Determines if 'Global filter'-field should be shown
+   *
+   * @property showGlobalFilter
+   * @type boolean
+   * @default true
    */
   showGlobalFilter = true;
 
   /**
    * Determines if focus should be on the 'Global filter'-field on component render
+   *
+   * @property focusGlobalFilter
+   * @type boolean
+   * @default false
    */
   focusGlobalFilter = false;
 
@@ -278,29 +385,40 @@ class ModelsTableComponent extends Component {
    *
    * * Auto generated titles for columns
    *
+   * @property checkTextTranslations
+   * @type boolean
+   * @default false
    */
   checkTextTranslations = false;
 
   /**
-   * Determines if <code>processedColumns</code> will be updated if <code>columns</code> are changed (<code>propertyName</code> and <code>template</code> are observed)
+   * Determines if `processedColumns` will be updated if `columns` are changed (`propertyName` and `template` are observed)
    *
-   * <b>IMPORTANT</b> All filter, sort and visibility options will be dropped to the default values while updating
+   * **IMPORTANT** All filter, sort and visibility options will be dropped to the default values while updating
+   *
+   * @property columnsAreUpdateable
+   * @type boolean
+   * @default false
    */
   columnsAreUpdateable = false;
 
   /**
    * Determines if rows should be grouped for some property
    *
-   * Grouped value may be shown in the separated row on the top of the group or in the first column (in the cell with rowspan) in the each group (see {{#crossLink 'Components.ModelsTable/displayGroupedValueAs:property'}}displayGroupedValueAs{{/crossLink}})
+   * Grouped value may be shown in the separated row on the top of the group or in the first column (in the cell with rowspan) in the each group (see [displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs))
    *
    * Generally you should not show column with property which is used for grouping (but it's up to you)
+   *
+   * @property useDataGrouping
+   * @type boolean
+   * @default false
    */
   useDataGrouping = false;
 
   /**
    * Property name used now for grouping rows
    *
-   * **IMPORTANT** It should be set initially if {{#crossLink 'Components.ModelsTable/useDataGrouping:property'}}useDataGrouping{{/crossLink}} is set to `true`
+   * **IMPORTANT** It should be set initially if [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) is set to `true`
    *
    */
   currentGroupingPropertyName = null;
@@ -308,7 +426,10 @@ class ModelsTableComponent extends Component {
   /**
    * Sort direction for grouped property values
    *
-   * @private
+   * @property sortByGroupedFieldDirection
+   * @protected
+   * @type string
+   * @default 'asc'
    */
   sortByGroupedFieldDirection = 'asc';
 
@@ -316,6 +437,10 @@ class ModelsTableComponent extends Component {
    * Determines how grouped value will be displayed - as a row or column
    *
    * Allowed values are `row` and `column`
+   *
+   * @property displayGroupedValueAs
+   * @type string
+   * @default 'row'
    */
   displayGroupedValueAs = 'row';
 
@@ -323,12 +448,20 @@ class ModelsTableComponent extends Component {
    * Used in numeric pagination. If pages count is less than `collapseNumPaginationForPagesCount`, all pages will be shown.
    * E.g. for `collapseNumPaginationForPagesCount = 4` and `pagesCount = 4` pagination will be `1 2 3 4`, however for
    * `collapseNumPaginationForPagesCount = 1` and `pagesCount = 4` pagination will be `1 2 ... 4`
+   *
+   * @property collapseNumPaginationForPagesCount
+   * @type number
+   * @default 1
    */
   collapseNumPaginationForPagesCount = 1;
 
   /**
-   * <code>columns</code> fields which are observed to update shown table-columns
-   * It is used only if <code>columnsAreUpdateable</code> is <code>true</code>
+   * `columns` fields which are observed to update shown table-columns
+   * It is used only if `columnsAreUpdateable` is `true`
+   *
+   * @property columnFieldsToCheckUpdate
+   * @type string[]
+   * @default ['propertyName', 'component']
    */
   columnFieldsToCheckUpdate = A(['propertyName', 'component']);
 
@@ -339,12 +472,17 @@ class ModelsTableComponent extends Component {
    * You may create your own theme-class and set `themeInstance` to it's instance. Check Theme properties you may define in your own theme.
    *
    * @type Themes.Bootstrap3Theme
+   * @property ThemeInstance
    */
 
   /**
    * All table records
    *
    * It's a first of the two attributes you must set to the component
+   *
+   * @property data
+   * @type object[]
+   * @default []
    */
   data = A([]);
 
@@ -352,6 +490,10 @@ class ModelsTableComponent extends Component {
    * Table columns. Check [ModelsTableColumn](Utils.ModelsTableColumn.html) for available properties
    *
    * It's a second of the two attributes you must set to the component
+   *
+   * @property columns
+   * @type Utils.ModelsTableColumn[]
+   * @default []
    */
   columns = A([]);
 
@@ -359,6 +501,10 @@ class ModelsTableComponent extends Component {
    * Hash of components to be used for columns.
    *
    * See [ModelsTableColumn](Utils.ModelsTableColumn.html), property component
+   *
+   * @property columnComponents
+   * @type object
+   * @default {}
    */
   columnComponents = {};
 
@@ -367,16 +513,23 @@ class ModelsTableComponent extends Component {
    * Each object should have:
    *  * `label` (string) - The label for the set. This will be displayed in the columns dropdown.
    *  * `showColumns` (array|Function) - This should either be an array of `propertyNames` to show, or a function. If it is a function, the function will be called with the `processedColumns` as attribute.
-   *  * `hideOtherColumns` (boolean) -  If this is true (default), all columns not specified in <code>showColumns</code> will be hidden. If this is set to false, other columns will be left at whatever visibility they were before.
+   *  * `hideOtherColumns` (boolean) -  If this is true (default), all columns not specified in `showColumns` will be hidden. If this is set to false, other columns will be left at whatever visibility they were before.
    *  * `toggleSet` (boolean) - If this is true (default is false), the set columns will be shown if one of them is currently hidden,
    else they will all be hidden. Settings this will result in a default of `hideOtherColumns=false`
+   *
+   * @property columnSets
+   * @type ColumnSet[]
+   * @default []
    */
   columnSets = A([]);
 
   /**
-   * List of columns shown in the table. It's created from the {{#crossLink 'Components.ModelsTable/columns:property'}}columns{{/crossLink}} provided to the component
+   * List of columns shown in the table. It's created from the [columns](Components.ModelsTable.html#property_columns) provided to the component
    *
-   * @private
+   * @protected
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
+   * @default []
    */
   processedColumns = A([]);
 
@@ -389,12 +542,18 @@ class ModelsTableComponent extends Component {
    * * `colspan` (number) - HTML colspan attr
    * * `rowspan` (number) - HTML rowspan attr
    *
-   * @type groupedHeader[][]
+   * @property groupedHeaders
+   * @type GroupedHeader[][]
+   * @default []
    */
   groupedHeaders = A([]);
 
   /**
    * Determines if page size should be shown
+   *
+   * @property showPageSize
+   * @type boolean
+   * @default true
    */
   showPageSize = true;
 
@@ -402,6 +561,10 @@ class ModelsTableComponent extends Component {
    * Expanded row items.
    *
    * It's set to the initial value when current page or page size is changed
+   *
+   * @property  expandedItems
+   * @type object[]
+   * @default []
    */
   @computed()
   get expandedItems() {
@@ -414,11 +577,19 @@ class ModelsTableComponent extends Component {
   /**
    * true - allow to expand more than 1 row,
    * false - only 1 row may be expanded in the same time
+   *
+   * @property multipleExpand
+   * @type boolean
+   * @default false
    */
   multipleExpand = false;
 
   /**
    * List of grouped property values where the groups are collapsed
+   *
+   * @property collapsedGroupValues
+   * @type array[]
+   * @default []
    */
   @computed()
   get collapsedGroupValues() {
@@ -431,12 +602,20 @@ class ModelsTableComponent extends Component {
   /**
    * Allow or disallow to select rows on click.
    * If `false` - no row can be selected
+   *
+   * @property selectRowOnClick
+   * @type boolean
+   * @default true
    */
   selectRowOnClick = true;
 
   /**
    * Allow or disallow to select multiple rows.
    * If `false` - only one row may be selected in the same time
+   *
+   * @property multipleSelect
+   * @type boolean
+   * @default false
    */
   multipleSelect = false;
 
@@ -445,12 +624,12 @@ class ModelsTableComponent extends Component {
    *
    * It will receive several options:
    * * `record` - current row value
-   * * `processedColumns` - current column (one of the {{#crossLink 'Components.ModelsTable/processedColumns:property'}}processedColumns{{/crossLink}})
+   * * `processedColumns` - current column (one of the [processedColumns](Components.ModelsTable.html#property_processedColumns))
    * * `index` - current row index
-   * * `selectedItems` - bound from {{#crossLink 'Components.ModelsTable/selectedItems:property'}}selectedItems{{/crossLink}}
-   * * `visibleProcessedColumns` - bound from {{#crossLink 'Components.ModelsTable/visibleProcessedColumns:property'}}visibleProcessedColumns{{/crossLink}}
-   * * `clickOnRow` - closure action {{#crossLink 'Components.ModelsTable/actions.clickOnRow:method'}}ModelsTable.actions.clickOnRow{{/crossLink}}
-   * * `themeInstance` - bound from {{#crossLink 'Components.ModelsTable/themeInstance:property'}}themeInstance{{/crossLink}}
+   * * `selectedItems` - bound from [selectedItems](Components.ModelsTable.html#property_selectedItems)
+   * * `visibleProcessedColumns` - bound from [visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
+   * * `clickOnRow` - closure action [clickOnRow](Components.ModelsTable.html#event_clickOnRow)
+   * * `themeInstance` - bound from [themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
    * Usage:
    *
@@ -461,24 +640,28 @@ class ModelsTableComponent extends Component {
    *   @expandedRowComponent={{component "expanded-row"}}
    * />
    * ```
+   *
+   * @property expandedRowComponent
+   * @type object
+   * @default null
    */
   expandedRowComponent = null;
 
   /**
    * Component used in the row with a grouped value
    *
-   * This component won't be used if {{#crossLink 'Component.ModelsTable/useDataGrouping:property'}}useDataGrouping{{/crossLink}} is not `true`
+   * This component won't be used if [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) is not `true`
    *
    * Component will receive several options:
    *
    * * `groupedValue` - grouped property value
-   * * `currentGroupingPropertyName` - bound from {{#crossLink 'Components.ModelsTable/currentGroupingPropertyName:property'}}currentGroupingPropertyName{{/crossLink}}
-   * * `displayGroupedValueAs` - bound from {{#crossLink 'Components.ModelsTable/displayGroupedValueAs:property'}}ModelsTable.displayGroupedValueAs{{/crossLink}}
-   * * `toggleGroupedRows` - closure action {{#crossLink 'Components.ModelsTable/actions.toggleGroupedRows:method'}}ModelsTable.actions.toggleGroupedRows{{/crossLink}}
-   * * `toggleGroupedRowsExpands` - closure action {{#crossLink 'Components.ModelsTable/actions.toggleGroupedRowsExpands:method'}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
-   * * `toggleGroupedRowsSelection` - closure action {{#crossLink 'Components.ModelsTable/actions.toggleGroupedRowsSelection:method'}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
-   * * `visibleProcessedColumns` - bound from {{#crossLink 'Components.ModelsTable/visibleProcessedColumns:property'}}ModelsTable.visibleProcessedColumns{{/crossLink}}
-   * * `themeInstance` - bound from {{#crossLink 'Components.ModelsTable/themeInstance:property'}}ModelsTable.themeInstance{{/crossLink}}
+   * * `currentGroupingPropertyName` - bound from [currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
+   * * `displayGroupedValueAs` - bound from [displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
+   * * `toggleGroupedRows` - closure action [toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
+   * * `toggleGroupedRowsExpands` - closure action [toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
+   * * `toggleGroupedRowsSelection` - closure action [toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
+   * * `visibleProcessedColumns` - bound from [visibleProcessedColumns](Components.ModelsTable.html#event_visibleProcessedColumns)
+   * * `themeInstance` - bound from [themeInstance](Components.ModelsTable.html#property_themeInstance)
    * * `groupedItems` - list of all rows group items
    * * `visibleGroupedItems` - list of rows group items shown on the current table page
    * * `selectedGroupedItems` - list of selected rows group items
@@ -493,16 +676,20 @@ class ModelsTableComponent extends Component {
    *   @groupingRowComponent={{component "grouping-row"}}
    * />
    * ```
+   *
+   * @property groupingRowComponent
+   * @type object
+   * @default null
    */
   groupingRowComponent = null;
 
   /**
-   * This component won't be used if {{#crossLink 'Component.ModelsTable/useDataGrouping:property'}}useDataGrouping{{/crossLink}} is not `true`
+   * This component won't be used if [useDataGrouping](Compnents.ModelsTable.html#property_useDataGrouping) is not `true`
    *
    * Component will receive several options:
    *
-   * * `visibleProcessedColumns` - bound from {{#crossLink 'Components.ModelsTable/visibleProcessedColumns:property'}}ModelsTable.visibleProcessedColumns{{/crossLink}}
-   * * `themeInstance` - bound from {{#crossLink 'Components.ModelsTable/themeInstance:property'}}ModelsTable.themeInstance{{/crossLink}}
+   * * `visibleProcessedColumns` - bound from [visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
+   * * `themeInstance` - bound from [themeInstance](Components.ModelsTable.html#property_themeInstance)
    * * `groupedItems` - list of all rows group items
    * * `visibleGroupedItems` - list of rows group items shown on the current table page
    * * `selectedGroupedItems` - list of selected rows group items
@@ -517,14 +704,17 @@ class ModelsTableComponent extends Component {
    *   @groupSummaryRowComponent={{component "group-summary-row"}}
    * />
    * ```
+   *
+   * @property groupSummaryRowComponent
+   * @type object
+   * @default null
    */
   groupSummaryRowComponent = null;
 
   /**
    * Component for header cell for column with grouping value
    *
-   * This component won't be used if {{#crossLink 'Component.ModelsTable/useDataGrouping:property'}}useDataGrouping{{/crossLink}} is not `true` and
-   * {{#crossLink 'Component.ModelsTable/displayGroupedValueAs:property'}}displayGroupedValueAs{{/crossLink}} is not `columns`
+   * This component won't be used if [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) is not `true` and [displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs) is not `columns`
    *
    * Usage:
    *
@@ -539,6 +729,10 @@ class ModelsTableComponent extends Component {
    * Component will receive such options:
    *
    * * `currentGroupingPropertyName` - property name used to group rows in the current moment
+   *
+   * @property groupHeaderCellComponent
+   * @type object
+   * @default null
    */
   groupHeaderCellComponent = null;
 
@@ -573,7 +767,9 @@ class ModelsTableComponent extends Component {
   /**
    * Action sent on init to give access to the Public API
    *
-   * @type closureFunction
+   * @property registerAPI
+   * @type Function
+   * @default null
    */
   registerAPI = null;
 
@@ -650,7 +846,11 @@ class ModelsTableComponent extends Component {
   /**
    * List of currently selected row items
    *
-   * Row may be selected by clicking on it, if {{#crossLink 'Components.ModelsTable/selectRowOnClick:property'}}selectRowOnClick{{/crossLink}} is set to `true`
+   * Row may be selected by clicking on it, if [selectRowOnClick](Components.ModelsTable.html#event_selectRowOnClick) is set to `true`
+   *
+   * @property selectedItems
+   * @type object[]
+   * @default []
    */
   @computed()
   get selectedItems() {
@@ -663,15 +863,20 @@ class ModelsTableComponent extends Component {
   /**
    * List of the currently visible columns
    *
-   * @private
+   * @protected
+   * @property visibleProcessedColumns
+   * @type boolean
+   * @default false
    */
   @filterBy('processedColumns', 'isVisible', true) visibleProcessedColumns;
 
   /**
-   * True if all processedColumns are hidden by <code>isHidden</code>
+   * True if all processedColumns are hidden by `isHidden`
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property allColumnsAreHidden
+   * @type boolean
+   * @default false
    */
   @computed('processedColumns.@each.isHidden')
   get allColumnsAreHidden() {
@@ -684,16 +889,19 @@ class ModelsTableComponent extends Component {
    * It may be a list of strings of list of objects. In first case label and value in the select-box will be the same.
    * In the second case you must set `label` and `value` properties for each list item
    *
-   * **IMPORTANT** It must contain {{#crossLink 'Components.ModelsTable/currentGroupingPropertyName:property'}}currentGroupingPropertyName{{/crossLink}}-value
+   * **IMPORTANT** It must contain [currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)-value
    *
+   * @property dataGroupProperties
    * @type string[]|object[]
    * @default []
    */
   dataGroupProperties = A([]);
 
   /**
-   * @private
-   * @readonly
+   * @protected
+   * @property dataGroupOptions
+   * @type SelectOption[]
+   * @default []
    */
   @computed('dataGroupProperties.[]')
   get dataGroupOptions() {
@@ -708,16 +916,20 @@ class ModelsTableComponent extends Component {
   /**
    * `true` if some value is set to the global filter
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property globalFilterUsed
+   * @type boolean
+   * @default false
    */
   @notEmpty('filterString') globalFilterUsed;
 
   /**
    * `true` if global filter or filter by any column is used
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property anyFilterUsed
+   * @type boolean
+   * @default false
    */
   @computed('globalFilterUsed', 'processedColumns.@each.filterUsed')
   get anyFilterUsed() {
@@ -727,8 +939,10 @@ class ModelsTableComponent extends Component {
   /**
    * `true` if all processedColumns don't use filtering and sorting
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property noHeaderFilteringAndSorting
+   * @type boolean
+   * @default false
    */
   @computed('processedColumns.@each.{useSorting,useFilter}')
   get noHeaderFilteringAndSorting() {
@@ -738,8 +952,10 @@ class ModelsTableComponent extends Component {
   /**
    * Number of pages
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property pagesCount
+   * @type number
+   * @default 0
    */
   @computed('arrangedContent.[]', 'pageSize')
   get pagesCount() {
@@ -748,12 +964,14 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * {{#crossLink 'Components.ModelsTable/data:property'}}data{{/crossLink}} filtered with a global filter and columns filters
+   * [data](Components.ModelsTable.html#property_data) filtered with a global filter and columns filters
    *
-   * Filtering by columns is ignored if {{#crossLink 'Components.ModelsTable/useFilteringByColumns:property'}}useFilteringByColumns{{/crossLink}} is set to `false`
+   * Filtering by columns is ignored if [useFilteringByColumns](Components.ModelsTable.html#property_useFilteringByColumns) is set to `false`
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property filteredContent
+   * @type object[]
+   * @default []
    */
   @computed('filterString', 'data.[]', 'useFilteringByColumns', 'processedColumns.@each.filterString')
   get filteredContent() {
@@ -814,10 +1032,12 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * {{#crossLink 'Components.ModelsTable/filteredContent:property'}}filteredContent{{/crossLink}} sorted by needed properties
+   * [filteredContent](Components.ModelsTable.html#property_filteredContent) sorted by needed properties
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property arrangedContent
+   * @type object[]
+   * @default []
    */
   @computed('filteredContent.[]', 'sortProperties.[]', 'sortFunctions.[]')
   get arrangedContent() {
@@ -842,24 +1062,33 @@ class ModelsTableComponent extends Component {
       return 0;
     }) : _filteredContent;
   }
-
   set arrangedContent(v) {
     return v;
   }
 
+  /**
+   * @method filteredContentObserver
+   * @protected
+   */
   filteredContentObserver() {
     run.once(this, this.filteredContentObserverOnce);
   }
 
+  /**
+   * @method filteredContentObserverOnce
+   * @protected
+   */
   filteredContentObserverOnce() {
     this.updateState({recordsCount: this.get('filteredContent.length')});
   }
 
   /**
-   * {{#crossLink 'Components.ModelsTable/filteredContent:property'}}filteredContent{{/crossLink}} grouped by {{#crossLink 'Components.ModelsTable/currentGroupingPropertyName:property'}}currentGroupingPropertyName{{/crossLink}} sorted by needed properties
+   * [filteredContent](Components.ModelsTable.html#property_filteredContent) grouped by [currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName) sorted by needed properties
    *
-   * @private
-   * @readonly
+   * @protected
+   * @property groupedArrangedContent
+   * @type object[]
+   * @default []
    */
   @computed('filteredContent.[]', 'sortProperties.[]', 'sortFunctions.[]', 'useDataGrouping', 'currentGroupingPropertyName', 'sortByGroupedFieldDirection')
   get groupedArrangedContent() {
@@ -895,10 +1124,12 @@ class ModelsTableComponent extends Component {
   /**
    * Content of the current table page
    *
-   * {{#crossLink 'Components.ModelsTable/arrangedContent:property'}}arrangedContent{{/crossLink}} sliced for currently shown page
+   * [arrangedContent](Componens.ModelsTable.html#property_arrangedContent) sliced for currently shown page
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property visibleContent
+   * @type object[]
+   * @default []
    */
   @computed('arrangedContent.[]', 'pageSize', 'currentPageNumber')
   get visibleContent() {
@@ -913,10 +1144,12 @@ class ModelsTableComponent extends Component {
   /**
    * Content of the current table page when rows grouping is used
    *
-   * {{#crossLink 'Components.ModelsTable/groupedVisibleContent:property'}}groupedVisibleContent{{/crossLink}} sliced for currently shown page
+   * [groupedVisibleContent](Components.ModelsTable.html#property_groupedVisibleContent) sliced for currently shown page
    *
-   * @private
-   * @readonly
+   * @protected
+   * @property groupedVisibleContent
+   * @type object[]
+   * @default []
    */
   @computed('groupedArrangedContent', 'pageSize', 'currentPageNumber', 'useDataGrouping', 'currentGroupingPropertyName')
   get groupedVisibleContent() {
@@ -933,8 +1166,10 @@ class ModelsTableComponent extends Component {
   /**
    * List of grouped property values in order to show groups in the table
    *
-   * @private
-   * @readonly
+   * @protected
+   * @property groupedVisibleContentValuesOrder
+   * @type array
+   * @default []
    */
   @computed('groupedVisibleContent.[]', 'currentGroupingPropertyName')
   get groupedVisibleContentValuesOrder() {
@@ -953,19 +1188,22 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Alias to <code>arrangedContent.length</code>
+   * Alias to `arrangedContent.length`
    *
+   * @protected
+   * @property arrangedContentLength
    * @type number
-   * @readonly
-   * @private
+   * @default 0
    */
   @alias('arrangedContent.length') arrangedContentLength;
 
   /**
    * Index of the first currently shown record
    *
-   * @private
-   * @readonly
+   * @protected
+   * @property firstIndex
+   * @type number
+   * @default 0
    */
   @computed('arrangedContentLength', 'pageSize', 'currentPageNumber')
   get firstIndex() {
@@ -975,8 +1213,10 @@ class ModelsTableComponent extends Component {
   /**
    * Index of the last currently shown record
    *
-   * @readonly
-   * @private
+   * @protected
+   * @property lastIndex
+   * @type number
+   * @default 10
    */
   @computed('isLastPage', 'arrangedContentLength', 'currentPageNumber', 'pageSize')
   get lastIndex() {
@@ -984,25 +1224,33 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * List of possible <code>pageSize</code> values. Used to change size of <code>visibleContent</code>
+   * List of possible [pageSize](Components.ModelsTable.html#property_pageSize) values. Used to change size of `visibleContent`
+   *
+   * @property pageSizeValues
+   * @type number[]
+   * @default [10, 25, 50]
    */
   pageSizeValues = A([10, 25, 50]);
 
   /**
    * List of options for pageSize-selectBox
-   * It's mapped from <code>pageSizeValues</code>
+   * It's mapped from [pageSizeValues](Componens.ModelsTable.html#property_pageSizeValues)
    * This value should not be set manually!
    *
-   * @type {[{value: string|number, label: string|number}]}
-   * @private
+   * @protected
+   * @property pageSizeOptions
+   * @type SelectOption[]
+   * @default []
    */
   pageSizeOptions = A([]);
 
   /**
    * List of options for pageNumber-selectBox
    *
-   * @type {[{value: string|number, label: string|number}]}
-   * @private
+   * @protected
+   * @property currentPageNumberOptions
+   * @type SelectOption[]
+   * @default []
    */
   @computed('pagesCount')
   get currentPageNumberOptions() {
@@ -1013,9 +1261,9 @@ class ModelsTableComponent extends Component {
    * These are options for the columns dropdown.
    * By default, the 'Show All', 'Hide All' and 'Restore Defaults' buttons are displayed.
    *
-   * @type {{showAll: boolean, hideAll: boolean, restoreDefaults: boolean, columnSets: object[]}}
-   * @readonly
-   * @private
+   * @protected
+   * @property columnDropdownOptions
+   * @type ColumnDropdownOptions
    */
   @computed('columnSets.{label,showColumns,hideOtherColumns}')
   get columnDropdownOptions() {
@@ -1032,9 +1280,18 @@ class ModelsTableComponent extends Component {
    *
    *  * `refilter()` - Invalidates the filteredContent property, causing the table to be re-filtered.
    *  * `recordsCount` - Size of the current arranged content
+   *
+   *  @property publicAPI
+   *  @default null
    */
   publicAPI = null;
 
+  /**
+   * @method updateState
+   * @param {object} changes
+   * @returns {object}
+   * @protected
+   */
   updateState(changes) {
     let newState = set(this, 'publicAPI', assign({}, this.publicAPI, changes));
     let registerAPI = this.registerAPI;
@@ -1047,14 +1304,16 @@ class ModelsTableComponent extends Component {
   /**
    * Show first page if for some reasons there is no content for current page, but table data exists
    *
-   * @private
+   * @method visibleContentObserver
+   * @protected
    */
   visibleContentObserver() {
     run.once(this, this.visibleContentObserverOnce);
   }
 
   /**
-   * @private
+   * @method visibleContentObserverOnce
+   * @protected
    */
   visibleContentObserverOnce() {
     const visibleContentLength = get(this, 'visibleContent.length');
@@ -1082,7 +1341,8 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @private
+   * @method _checkColumnTitles
+   * @protected
    */
   _checkColumnTitles() {
     this.columns.forEach((c, index) => {
@@ -1094,6 +1354,9 @@ class ModelsTableComponent extends Component {
    * Component init
    *
    * Set visibility and filtering attributes for each column
+   *
+   * @method setup
+   * @protected
    */
   setup() {
     this._setupSelectedRows();
@@ -1115,12 +1378,19 @@ class ModelsTableComponent extends Component {
     });
   }
 
+  /**
+   * @method refilter
+   * @protected
+   */
   refilter() {
     this.notifyPropertyChange('filteredContent');
   }
 
   /**
    * Recalculate processedColumns when the columns attr changes
+   *
+   * @method updateColumns
+   * @protected
    */
   updateColumns() {
     if (this.columnsAreUpdateable) {
@@ -1130,6 +1400,9 @@ class ModelsTableComponent extends Component {
 
   /**
    * Focus on 'Global filter' on component render
+   *
+   * @method focus
+   * @protected
    */
   focus() {
     if (this.showGlobalFilter && this.focusGlobalFilter) {
@@ -1141,7 +1414,9 @@ class ModelsTableComponent extends Component {
    * Preselect table rows if `selectedItems` is provided
    *
    * `multipleSelected` may be set `true` if `selectedItems` has more than 1 item
-   * @private
+   *
+   * @method _setupSelectedRows
+   * @protected
    */
   _setupSelectedRows() {
     if (isArray(this.selectedItems) && this.selectedItems.length > 1 && !this.multipleSelected) {
@@ -1151,9 +1426,10 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Wrapper for <code>_setupColumns</code> to call it only once when observer is fired
+   * Wrapper for [_setupColumns](Components.ModelsTable.html#method__setupColumns) to call it only once when observer is fired
    *
-   * @private
+   * @method _setupColumnsOnce
+   * @protected
    */
   _setupColumnsOnce() {
     run.once(this, this._setupColumns);
@@ -1162,8 +1438,9 @@ class ModelsTableComponent extends Component {
   /**
    * Generate hash for column-`extend`
    *
-   * @param {object} options
-   * @private
+   * @method _createColumnInstance
+   * @param {Utils.ModelsTableColumn} options
+   * @protected
    */
   _createColumnInstance(options) {
     const {propertyName, filteredBy, disableFiltering, filterWithSelect} = options;
@@ -1210,8 +1487,10 @@ class ModelsTableComponent extends Component {
   /**
    * Set values for some column-properties after its creation
    *
-   * @param {object} column
-   * @private
+   * @method _postProcessColumn
+   * @param {Utils.ModelsTableColumn} column
+   * @return Utils.ModelsTableColumn
+   * @protected
    */
   _postProcessColumn(column) {
     set(column, '__mt', this);
@@ -1237,7 +1516,9 @@ class ModelsTableComponent extends Component {
    * }
    * ```
    *
-   * @param {object} options
+   * @param {Utils.ModelsTableColumn} options
+   * @method _createColumn
+   * @return Utils.ModelsTableColumn
    */
   _createColumn(options) {
     const column = this._createColumnInstance(options);
@@ -1249,6 +1530,7 @@ class ModelsTableComponent extends Component {
    * Create new properties for `columns`
    *
    * @private
+   * @method _setupColumns
    */
   _setupColumns() {
     let self = this;
@@ -1316,7 +1598,8 @@ class ModelsTableComponent extends Component {
   /**
    * Create new properties for `columns` for components
    *
-   * @private
+   * @protected
+   * @method _setupColumnsComponent
    */
   _setupColumnsComponent(c, column) {
     if (isPresent(this.columnComponents)) {
@@ -1343,10 +1626,11 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Provide backward compatibility with <code>pageSizeValues</code> equal to an array with numbers and not objects
-   * <code>pageSizeValues</code> is live as is, <code>pageSizeOptions</code> is used in the templates
+   * Provide backward compatibility with `pageSizeValues` equal to an array with numbers and not objects
+   * `pageSizeValues` is live as is, `pageSizeOptions` is used in the templates
    *
-   * @private
+   * @protected
+   * @method _setupPageSizeOptions
    */
   _setupPageSizeOptions() {
     let pageSizeOptions = this.pageSizeValues.map(optionStrToObj);
@@ -1354,9 +1638,10 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Set <code>sortProperties</code> when single-column sorting is used
+   * Set `sortProperties` when single-column sorting is used
    *
    * @protected
+   * @method _singleColumnSorting
    */
   _singleColumnSorting(column, sortedBy, newSorting) {
     this.processedColumns.setEach('sorting', 'none');
@@ -1368,8 +1653,9 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Set <code>sortProperties</code> when multi-columns sorting is used
+   * Set `sortProperties` when multi-columns sorting is used
    *
+   * @method _multiColumnsSorting
    * @protected
    */
   _multiColumnsSorting(column, sortedBy, newSorting) {
@@ -1402,13 +1688,15 @@ class ModelsTableComponent extends Component {
    * Action is sent if `displayDataChangedAction` is a closure-action
    *
    * @protected
+   * @method userInteractionObserver
    */
   userInteractionObserver() {
     run.once(this, this.userInteractionObserverOnce);
   }
 
   /**
-   * @private
+   * @protected
+   * @method userInteractionObserverOnce
    */
   userInteractionObserverOnce() {
     let actionIsFunction = typeof this.displayDataChangedAction === 'function';
@@ -1438,7 +1726,8 @@ class ModelsTableComponent extends Component {
    * Send `columnsVisibilityChangedAction`-action when user changes which columns are visible.
    * Action is sent if `columnsVisibilityChangedAction` is a closure action
    *
-   * @private
+   * @protected
+   * @method _sendColumnsVisibilityChangedAction
    */
   _sendColumnsVisibilityChangedAction() {
     let actionIsFunction = typeof this.columnsVisibilityChangedAction === 'function';
@@ -1456,7 +1745,8 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for global filter and filter by each column
    *
-   * @private
+   * @protected
+   * @method forceToFirstPage
    */
   forceToFirstPage() {
     set(this, 'currentPageNumber', 1);
@@ -1466,7 +1756,8 @@ class ModelsTableComponent extends Component {
   /**
    * Collapse open rows when user change page size or moved to the another page
    *
-   * @private
+   * @protected
+   * @method collapseRowOnNavigate
    */
   @observes('currentPageNumber', 'pageSize')
   collapseRowOnNavigate() {
@@ -1476,6 +1767,9 @@ class ModelsTableComponent extends Component {
   /**
    * Rebuild the whole table.
    * This can be called to force a complete re-render of the table.
+   *
+   * @method rebuildTable
+   * @protected
    */
   rebuildTable() {
     set(this, 'currentPageNumber', 1);
@@ -1486,7 +1780,8 @@ class ModelsTableComponent extends Component {
   /**
    * Update colspans for table header cells
    *
-   * @private
+   * @protected
+   * @method updateHeaderCellsColspan
    */
   @observes('processedColumns.@each.{isVisible,colspanForSortCell,colspanForFilterCell}')
   updateHeaderCellsColspan() {
@@ -1494,7 +1789,8 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @private
+   * @protected
+   * @method updateHeaderCellsColspanOnce
    */
   updateHeaderCellsColspanOnce() {
     this.processedColumns.forEach((column, index, columns) => {
@@ -1510,7 +1806,8 @@ class ModelsTableComponent extends Component {
   /**
    * Clear all filters.
    *
-   * @private
+   * @protected
+   * @method _clearFilters
    */
   _clearFilters() {
     set(this, 'filterString', '');
@@ -1534,7 +1831,11 @@ class ModelsTableComponent extends Component {
   /**
    * Toggle visibility for provided column
    *
-   * It doesn't do nothing if column can't be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}}). May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
+   * It doesn't do nothing if column can't be hidden (see [mayBeHidden](Utils.ModelsTableColumn.html#property_mayBeHidden)). May trigger sending [columnsVisibilityChangedAction](Components.ModelsTable.html#event_columnsVisibilityChangedAction)
+   *
+   * @event toggleHidden
+   * @param {Utils.ModelsTableColumn} column
+   * @protected
    */
   @action
   toggleHidden(column) {
@@ -1547,7 +1848,10 @@ class ModelsTableComponent extends Component {
   /**
    * Show all columns
    *
-   * Set each column `isHidden` value to `false`. May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
+   * Set each column `isHidden` value to `false`. May trigger sending [columnsVisibilityChangedAction](Components.ModelsTable.html#event_columnsVisibilityChangedAction)
+   *
+   * @event showAllColumns
+   * @protected
    */
   @action
   showAllColumns() {
@@ -1556,9 +1860,12 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Hide all columns that may be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}})
+   * Hide all columns that may be hidden (see [mayBeHidden](Utils.ModelsTableColumn.html#property_mayBeHidden))
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
+   * May trigger sending [columnsVisibilityChangedAction](Components.ModelsTable.html#event_columnsVisibilityChangedAction)
+   *
+   * @event hideAllColumns
+   * @protected
    */
   @action
   hideAllColumns() {
@@ -1567,9 +1874,12 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Restore columns visibility values according to their default visibility settings (see {{#crossLink 'Utils.ModelsTableColumn/defaultVisible:property'}}defaultVisible{{/crossLink}})
+   * Restore columns visibility values according to their default visibility settings (see [defaultVisible](Utils.ModelsTableColumn.html#property_defaultVisible))
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
+   * May trigger sending [columnsVisibilityChangedAction](Components.MdoelsTableColumn.html#event_columnsVisibilityChangedAction)
+   *
+   * @event restoreDefaultVisibility
+   * @protected
    */
   @action
   restoreDefaultVisibility() {
@@ -1582,7 +1892,11 @@ class ModelsTableComponent extends Component {
   /**
    * Toggle visibility for every column in the selected columns set
    *
-   * It ignore columns that can't be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}}). May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
+   * It ignore columns that can't be hidden (see [mayBeHidden](Utils.ModelsTableColumn.html#property_mayBeHidden)). May trigger sending [columnsVisibilityChangedAction](Components.ModelsTable.html#property_columnsVisibilityChangedAction)
+   *
+   * @event toggleColumnSet
+   * @param {ColumnSet} columnSetToToggle
+   * @protected
    */
   @action
   toggleColumnSet({showColumns = [], hideOtherColumns, toggleSet = false} = {}) {
@@ -1641,7 +1955,11 @@ class ModelsTableComponent extends Component {
   /**
    * Pagination click-handler
    *
-   * It moves user to the selected page. Check [models-table/pagination-numeric](Components.ModelsTablePaginationNumeric.html) and [models-table/pagination-simple](Components.ModelsTablePaginationSimple.html) for usage examples. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * It moves user to the selected page. Check [models-table/pagination-numeric](Components.ModelsTablePaginationNumeric.html) and [models-table/pagination-simple](Components.ModelsTablePaginationSimple.html) for usage examples. May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event gotoCustomPage
+   * @param {number} pageNumber
+   * @protected
    */
   @action
   gotoCustomPage(pageNumber) {
@@ -1650,9 +1968,9 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * Sort selected column by {{#crossLink 'Utils.ModelsTableColumn/sortedBy:property'}}sortedBy{{/crossLink}} or {{#crossLink 'Utils.ModelsTableColumn/propertyName:property'}}propertyName{{/crossLink}}
+   * Sort selected column by [sortedBy](Utils.ModelsTableColumn.html#property_sortedBy) or [propertyName](Utils.ModelsTableColumn.html#property_propertyName)
    *
-   * It will drop sorting for other columns if {{#crossLink 'Components.ModelsTable/multipleColumnsSorting:property'}}multipleColumnsSorting{{/crossLink}} is set to `false`. It will add new sorting if {{#crossLink 'Components.ModelsTable/multipleColumnsSorting:property'}}multipleColumnsSorting{{/crossLink}} is set to `true`. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}. Table will be dropped to the first page if sorting is done
+   * It will drop sorting for other columns if [multipleColumnsSorting](Components.ModelsTable.html#property_multipleColumnsSorting) is set to `false`. It will add new sorting if [multipleColumnsSorting](Components.ModelsTable.html#property_multipleColumnsSorting) is set to `true`. May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction). Table will be dropped to the first page if sorting is done
    *
    * For multiColumns-sorting calling sort will change sort-order. E.g.:
    *
@@ -1660,6 +1978,10 @@ class ModelsTableComponent extends Component {
    * sortProperties = ['a:asc', 'b:asc', 'c:desc'];
    * sort({propertyName: 'b'}); // sortProperties now is ['a:asc', 'c:desc', 'b:desc']
    * ```
+   *
+   * @event sort
+   * @param {Utils.ModelsTableColumn} column
+   * @protected
    */
   @action
   sort(column) {
@@ -1688,7 +2010,12 @@ class ModelsTableComponent extends Component {
   /**
    * Expand selected row
    *
-   * It will cause expandedRowComponent to be used for it. It will collapse already expanded row if {{#crossLink 'Components.ModelsTable/multipleExpand:property'}}multipleExpand{{/crossLink}} is set to `false`. Expanding is assigned to the record itself and not their index. So, if page #1 has first row expanded and user is moved to any another page, first row on new page won't be expanded. But when user will be back to the first page, first row will be expanded. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * It will cause expandedRowComponent to be used for it. It will collapse already expanded row if [multipleExpand](Components.ModelsTable.html#property_multipleExpand) is set to `false`. Expanding is assigned to the record itself and not their index. So, if page #1 has first row expanded and user is moved to any another page, first row on new page won't be expanded. But when user will be back to the first page, first row will be expanded. May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event expandRow
+   * @param {number} index
+   * @param {object} dataItem
+   * @protected
    */
   @action
   expandRow(index, dataItem) {
@@ -1704,7 +2031,12 @@ class ModelsTableComponent extends Component {
   /**
    * Collapse selected row
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * May trigger sending [displayDataChangedAction](Componets.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event collapseRow
+   * @param {number} index
+   * @param {object} dataItem
+   * @protected
    */
   @action
   collapseRow(index, dataItem) {
@@ -1716,7 +2048,10 @@ class ModelsTableComponent extends Component {
   /**
    * Expand all rows in the current page
    *
-   * It works only if {{#crossLink 'Components.ModelsTable/multipleExpand:property'}}multipleExpand{{/crossLink}} is set to `true`. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * It works only if [multipleExpand](Components.ModelsTable.html#property_multipleExpand) is set to `true`. May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event expandAllRows
+   * @protected
    */
   @action
   expandAllRows() {
@@ -1735,7 +2070,10 @@ class ModelsTableComponent extends Component {
   /**
    * Collapse all rows in the current page
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event collapseAllRows
+   * @protected
    */
   @action
   collapseAllRows() {
@@ -1746,7 +2084,12 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for row-click
    *
-   * Toggle <code>selected</code>-state for row. Select only one or multiple rows depends on {{#crossLink 'Components.ModelsTable/multipleSelect:property'}}multipleSelect{{/crossLink}} value. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * Toggle `selected`-state for row. Select only one or multiple rows depends on [multipleSelect](Components.ModelsTable.html#property_multipleSelect) value. May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event clickOnRow
+   * @param {number} index
+   * @param {object} dataItem
+   * @protected
    */
   @action
   clickOnRow(index, dataItem) {
@@ -1769,7 +2112,11 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for double-click on row
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/rowDoubleClickAction:property'}}rowDoubleClickAction{{/crossLink}}
+   * May trigger sending [rowDoubleClickAction](Components.ModelsTable.html#event_rowDoubleClickAction)
+   *
+   * @event doubleClickOnRow
+   * @param {number} index
+   * @param {object} dataItem
    */
   @action
   doubleClickOnRow(index, dataItem) {
@@ -1783,7 +2130,12 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for row-hover
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/rowHoverAction:property'}}rowHoverAction{{/crossLink}}
+   * May trigger sending [rowHoverAction](Components.ModelsTable.html#event_rowHoverAction)
+   *
+   * @event hoverOnRow
+   * @param {number} index
+   * @param {object} dataItem
+   * @protected
    */
   @action
   hoverOnRow(index, dataItem) {
@@ -1797,7 +2149,12 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for row-hover
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/rowHoverAction:property'}}rowOutAction{{/crossLink}}
+   * May trigger sending [rowOutAction](Components.ModelsTable.html#event_rowOutAction)
+   *
+   * @event outRow
+   * @param {number} index
+   * @param {object} dataItem
+   * @protected
    */
   @action
   outRow(index, dataItem) {
@@ -1811,7 +2168,9 @@ class ModelsTableComponent extends Component {
   /**
    * Clear all column filters and global filter
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event clearFilters
    */
   @action
   clearFilters() {
@@ -1821,7 +2180,10 @@ class ModelsTableComponent extends Component {
   /**
    * Select/deselect all rows
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event toggleAllSelection
+   * @protected
    */
   @action
   toggleAllSelection() {
@@ -1839,6 +2201,10 @@ class ModelsTableComponent extends Component {
    * Expand or collapse all rows in the rows group
    *
    * **IMPORTANT** `multipleExpand` should be set to `true` otherwise this action won't do anything
+   *
+   * @event toggleGroupedRowsExpands
+   * @param {string|number|boolean} groupedValue
+   * @protected
    */
   @action
   toggleGroupedRowsExpands(groupedValue) {
@@ -1863,7 +2229,11 @@ class ModelsTableComponent extends Component {
    *
    * **IMPORTANT** `multipleSelect` should be set to `true` otherwise this action won't do anything
    *
-   * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
+   * May trigger sending [displayDataChangedAction](Components.ModelsTable.html#event_displayDataChangedAction)
+   *
+   * @event toggleGroupedRowsSelection
+   * @param {string|number|boolean} groupedValue
+   * @protected
    */
   @action
   toggleGroupedRowsSelection(groupedValue) {
@@ -1885,6 +2255,10 @@ class ModelsTableComponent extends Component {
 
   /**
    * Collapse or expand rows group
+   *
+   * @event toggleGroupedRows
+   * @param {string|number|boolean} groupedValue
+   * @protected
    */
   @action
   toggleGroupedRows(groupedValue) {

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -171,7 +171,6 @@ function objToArray(map) {
  * ModelsTable has a lot of options you may configure, but there are two required properties called `data` and `columns`. First one contains data (e.g. list of records from the store). Second one is a list of table's columns (check [models-table-column](Utils.ModelsTableColumn.html) for available options).
  *
  * @namespace Components
- * @class ModelsTable
  * @extends Ember.Component
  */
 export default
@@ -180,28 +179,16 @@ export default
 class ModelsTableComponent extends Component {
   /**
    * Number of records shown on one table-page
-   *
-   * @type number
-   * @property pageSize
-   * @default 10
    */
   pageSize = 10;
 
   /**
    * Currently shown page number. It may be set initially
-   *
-   * @type number
-   * @property currentPageNumber
-   * @default 1
    */
   currentPageNumber = 1;
 
   /**
    * Order of sorting for each columns. Unsorted column firstly become sorted ASC, then DESC, then sorting is dropped again
-   *
-   * @property sortMap
-   * @type object
-   * @default {{ none: 'asc', asc: 'desc', desc: 'none' }}
    */
   sortMap = {
     none: 'asc',
@@ -213,101 +200,59 @@ class ModelsTableComponent extends Component {
    * List of properties to sort table rows
    *
    * Each value is like 'propertyName:sortDirection'
-   *
-   * @type string[]
-   * @property sortProperties
-   * @default []
    * @protected
    */
   sortProperties = A([]);
 
   /**
    * Hash of custom functions to sort table rows
-   *
-   * @type Object
-   * @property sortFunctions
-   * @default {}
    * @private
    */
   sortFunctions = Object.create(null);
 
   /**
-   * @type string[]
-   * @default ['processedColumns.@each.filterString', 'filterString', 'pageSize']
    * @private
-   * @readonly
    */
   forceToFirstPageProps = A(['processedColumns.@each.filterString', 'filterString', 'pageSize']);
 
   /**
    * Determines if multi-columns sorting should be used
-   *
-   * @type boolean
-   * @property multipleColumnsSorting
-   * @default true
    */
   multipleColumnsSorting = true;
 
   /**
    * Determines if component footer should be shown on the page
-   *
-   * @type boolean
-   * @property showComponentFooter
-   * @default true
    */
   showComponentFooter = true;
 
   /**
    * Determines if dropdown for current page number should be shown near the pagination block
-   *
-   * @property showCurrentPageNumberSelect
-   * @type boolean
-   * @default true
    */
   showCurrentPageNumberSelect = true;
 
   /**
    * Determines if numeric pagination should be used
-   *
-   * @type boolean
-   * @property useNumericPagination
-   * @default false
    */
   useNumericPagination = false;
 
   /**
    * Determines if columns-dropdown should be shown
    *
-   * @type boolean
-   * @property showColumnsDropdown
-   * @default true
    */
   showColumnsDropdown = true;
 
   /**
    * Determines if filtering by columns should be available to the user
-   *
-   * @type boolean
-   * @property useFilteringByColumns
-   * @default true
    */
   useFilteringByColumns = true;
 
   /**
    * Global filter value
-   *
-   * @type string
-   * @property filterString
-   * @default ''
    */
   filterString = '';
 
   /**
    * Determines if filtering (global and by column) should ignore case
-   *
-   * @type boolean
-   * @property filteringIgnoreCase
-   * @default false
    */
   filteringIgnoreCase = false;
 
@@ -315,28 +260,16 @@ class ModelsTableComponent extends Component {
    * Determines if filtering should be done by hidden columns
    *
    * **Notice:** after changing this value filtering results will be updated only after filter options are changed
-   *
-   * @type boolean
-   * @property doFilteringByHiddenColumns
-   * @default true
    */
   doFilteringByHiddenColumns = true;
 
   /**
    * Determines if 'Global filter'-field should be shown
-   *
-   * @type boolean
-   * @property showGlobalFilter
-   * @default true
    */
   showGlobalFilter = true;
 
   /**
    * Determines if focus should be on the 'Global filter'-field on component render
-   *
-   * @type boolean
-   * @property focusGlobalFilter
-   * @default false
    */
   focusGlobalFilter = false;
 
@@ -345,20 +278,13 @@ class ModelsTableComponent extends Component {
    *
    * * Auto generated titles for columns
    *
-   * @property checkTextTranslations
-   * @type boolean
-   * @default false
    */
   checkTextTranslations = false;
 
   /**
-   * Determines if <code>processedColumns</code> will be updated if <code>columns</code> are changed (<code>propertyName</code> and
-   * <code>template</code> are observed)
-   * <b>IMPORTANT</b> All filter, sort and visibility options will be dropped to the default values while updating
+   * Determines if <code>processedColumns</code> will be updated if <code>columns</code> are changed (<code>propertyName</code> and <code>template</code> are observed)
    *
-   * @type boolean
-   * @property columnsAreUpdateable
-   * @default false
+   * <b>IMPORTANT</b> All filter, sort and visibility options will be dropped to the default values while updating
    */
   columnsAreUpdateable = false;
 
@@ -368,10 +294,6 @@ class ModelsTableComponent extends Component {
    * Grouped value may be shown in the separated row on the top of the group or in the first column (in the cell with rowspan) in the each group (see {{#crossLink 'Components.ModelsTable/displayGroupedValueAs:property'}}displayGroupedValueAs{{/crossLink}})
    *
    * Generally you should not show column with property which is used for grouping (but it's up to you)
-   *
-   * @property useDataGrouping
-   * @type boolean
-   * @default false
    */
   useDataGrouping = false;
 
@@ -380,18 +302,12 @@ class ModelsTableComponent extends Component {
    *
    * **IMPORTANT** It should be set initially if {{#crossLink 'Components.ModelsTable/useDataGrouping:property'}}useDataGrouping{{/crossLink}} is set to `true`
    *
-   * @property currentGroupingPropertyName
-   * @type string
-   * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
    * Sort direction for grouped property values
    *
-   * @property sortByGroupedFieldDirection
-   * @type string
-   * @default 'asc'
    * @private
    */
   sortByGroupedFieldDirection = 'asc';
@@ -400,10 +316,6 @@ class ModelsTableComponent extends Component {
    * Determines how grouped value will be displayed - as a row or column
    *
    * Allowed values are `row` and `column`
-   *
-   * @property displayGroupedValueAs
-   * @type string
-   * @default 'row'
    */
   displayGroupedValueAs = 'row';
 
@@ -411,20 +323,12 @@ class ModelsTableComponent extends Component {
    * Used in numeric pagination. If pages count is less than `collapseNumPaginationForPagesCount`, all pages will be shown.
    * E.g. for `collapseNumPaginationForPagesCount = 4` and `pagesCount = 4` pagination will be `1 2 3 4`, however for
    * `collapseNumPaginationForPagesCount = 1` and `pagesCount = 4` pagination will be `1 2 ... 4`
-   *
-   * @property collapseNumPaginationForPagesCount
-   * @type number
-   * @default 1
    */
   collapseNumPaginationForPagesCount = 1;
 
   /**
    * <code>columns</code> fields which are observed to update shown table-columns
    * It is used only if <code>columnsAreUpdateable</code> is <code>true</code>
-   *
-   * @type string[]
-   * @property columnFieldsToCheckUpdate
-   * @default ['propertyName', 'component']
    */
   columnFieldsToCheckUpdate = A(['propertyName', 'component']);
 
@@ -434,18 +338,13 @@ class ModelsTableComponent extends Component {
    *
    * You may create your own theme-class and set `themeInstance` to it's instance. Check Theme properties you may define in your own theme.
    *
-   * @type Themes.Bootstrap3
-   * @property themeInstance
+   * @type Themes.Bootstrap3Theme
    */
 
   /**
    * All table records
    *
    * It's a first of the two attributes you must set to the component
-   *
-   * @type object[]
-   * @property data
-   * @default []
    */
   data = A([]);
 
@@ -453,10 +352,6 @@ class ModelsTableComponent extends Component {
    * Table columns. Check [ModelsTableColumn](Utils.ModelsTableColumn.html) for available properties
    *
    * It's a second of the two attributes you must set to the component
-   *
-   * @type object[]
-   * @property columns
-   * @default []
    */
   columns = A([]);
 
@@ -464,10 +359,6 @@ class ModelsTableComponent extends Component {
    * Hash of components to be used for columns.
    *
    * See [ModelsTableColumn](Utils.ModelsTableColumn.html), property component
-   *
-   * @type Object
-   * @property columnComponents
-   * @default {}
    */
   columnComponents = {};
 
@@ -479,19 +370,12 @@ class ModelsTableComponent extends Component {
    *  * `hideOtherColumns` (boolean) -  If this is true (default), all columns not specified in <code>showColumns</code> will be hidden. If this is set to false, other columns will be left at whatever visibility they were before.
    *  * `toggleSet` (boolean) - If this is true (default is false), the set columns will be shown if one of them is currently hidden,
    else they will all be hidden. Settings this will result in a default of `hideOtherColumns=false`
-   *
-   * @type Object[]
-   * @property columnSets
-   * @default []
    */
   columnSets = A([]);
 
   /**
    * List of columns shown in the table. It's created from the {{#crossLink 'Components.ModelsTable/columns:property'}}columns{{/crossLink}} provided to the component
    *
-   * @type Object[]
-   * @property processedColumns
-   * @default []
    * @private
    */
   processedColumns = A([]);
@@ -505,18 +389,12 @@ class ModelsTableComponent extends Component {
    * * `colspan` (number) - HTML colspan attr
    * * `rowspan` (number) - HTML rowspan attr
    *
-   * @property groupedHeaders
    * @type groupedHeader[][]
-   * @default []
    */
   groupedHeaders = A([]);
 
   /**
    * Determines if page size should be shown
-   *
-   * @type boolean
-   * @property showPageSize
-   * @default true
    */
   showPageSize = true;
 
@@ -524,10 +402,6 @@ class ModelsTableComponent extends Component {
    * Expanded row items.
    *
    * It's set to the initial value when current page or page size is changed
-   *
-   * @type object[]
-   * @property expandedItems
-   * @default null
    */
   @computed()
   get expandedItems() {
@@ -540,19 +414,11 @@ class ModelsTableComponent extends Component {
   /**
    * true - allow to expand more than 1 row,
    * false - only 1 row may be expanded in the same time
-   *
-   * @type boolean
-   * @property multipleExpand
-   * @default false
    */
   multipleExpand = false;
 
   /**
    * List of grouped property values where the groups are collapsed
-   *
-   * @type array
-   * @property collapsedGroupValues
-   * @default []
    */
   @computed()
   get collapsedGroupValues() {
@@ -565,20 +431,12 @@ class ModelsTableComponent extends Component {
   /**
    * Allow or disallow to select rows on click.
    * If `false` - no row can be selected
-   *
-   * @type boolean
-   * @property selectRowOnClick
-   * @default true
    */
   selectRowOnClick = true;
 
   /**
    * Allow or disallow to select multiple rows.
    * If `false` - only one row may be selected in the same time
-   *
-   * @type boolean
-   * @property multipleSelect
-   * @default false
    */
   multipleSelect = false;
 
@@ -597,12 +455,12 @@ class ModelsTableComponent extends Component {
    * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @expandedRowComponent={{component "expanded-row"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @expandedRowComponent={{component "expanded-row"}}
+   * />
    * ```
-   *
-   * @type object
-   * @property expandedRowComponent
-   * @default null
    */
   expandedRowComponent = null;
 
@@ -629,12 +487,12 @@ class ModelsTableComponent extends Component {
    * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @groupingRowComponent={{component "grouping-row"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @groupingRowComponent={{component "grouping-row"}}
+   * />
    * ```
-   *
-   * @type object
-   * @property groupingRowComponent
-   * @default null
    */
   groupingRowComponent = null;
 
@@ -653,12 +511,12 @@ class ModelsTableComponent extends Component {
    * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @groupSummaryRowComponent={{component "group-summary-row"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @groupSummaryRowComponent={{component "group-summary-row"}}
+   * />
    * ```
-   *
-   * @type object
-   * @property groupSummaryRowComponent
-   * @default null
    */
   groupSummaryRowComponent = null;
 
@@ -671,16 +529,16 @@ class ModelsTableComponent extends Component {
    * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @groupHeaderCellComponent={{component "group-header-cell"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @groupHeaderCellComponent={{component "group-header-cell"}}
+   * />
    * ```
    *
    * Component will receive such options:
    *
    * * `currentGroupingPropertyName` - property name used to group rows in the current moment
-   *
-   * @property groupHeaderCellComponent
-   * @type object
-   * @default null
    */
   groupHeaderCellComponent = null;
 
@@ -701,7 +559,11 @@ class ModelsTableComponent extends Component {
    * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @displayDataChangedAction={{action "someAction"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @displayDataChangedAction={{action "someAction"}}
+   * />
    * ```
    *
    * @event displayDataChangedAction
@@ -711,8 +573,6 @@ class ModelsTableComponent extends Component {
   /**
    * Action sent on init to give access to the Public API
    *
-   * @default null
-   * @property registerAPI
    * @type closureFunction
    */
   registerAPI = null;
@@ -725,7 +585,11 @@ class ModelsTableComponent extends Component {
    * * Usage:
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @columnsVisibilityChangedAction={{action "someAction"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @columnsVisibilityChangedAction={{action "someAction"}}
+   * />
    * ```
    *
    * @event columnsVisibilityChangedAction
@@ -738,7 +602,11 @@ class ModelsTableComponent extends Component {
    * Usage
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @rowDoubleClickAction={{action "someAction"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @rowDoubleClickAction={{action "someAction"}}
+   * />
    * ```
    *
    * @event rowDoubleClickAction
@@ -751,7 +619,11 @@ class ModelsTableComponent extends Component {
    * Usage
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @rowHoverAction={{action "someAction"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @rowHoverAction={{action "someAction"}}
+   * />
    * ```
    *
    * @event rowHoverAction
@@ -764,7 +636,11 @@ class ModelsTableComponent extends Component {
    * Usage
    *
    * ```hbs
-   * <ModelsTable @data={{model}} @columns={{columns}} @rowOutAction={{action "someAction"}} />
+   * <ModelsTable
+   *   @data={{model}}
+   *   @columns={{columns}}
+   *   @rowOutAction={{action "someAction"}}
+   * />
    * ```
    *
    * @event rowOutAction
@@ -775,10 +651,6 @@ class ModelsTableComponent extends Component {
    * List of currently selected row items
    *
    * Row may be selected by clicking on it, if {{#crossLink 'Components.ModelsTable/selectRowOnClick:property'}}selectRowOnClick{{/crossLink}} is set to `true`
-   *
-   * @default null
-   * @property selectedItems
-   * @type object[]
    */
   @computed()
   get selectedItems() {
@@ -791,9 +663,6 @@ class ModelsTableComponent extends Component {
   /**
    * List of the currently visible columns
    *
-   * @type Object[]
-   * @property visibleProcessedColumns
-   * @default []
    * @private
    */
   @filterBy('processedColumns', 'isVisible', true) visibleProcessedColumns;
@@ -801,8 +670,6 @@ class ModelsTableComponent extends Component {
   /**
    * True if all processedColumns are hidden by <code>isHidden</code>
    *
-   * @type boolean
-   * @property allColumnsAreHidden
    * @readonly
    * @private
    */
@@ -819,15 +686,12 @@ class ModelsTableComponent extends Component {
    *
    * **IMPORTANT** It must contain {{#crossLink 'Components.ModelsTable/currentGroupingPropertyName:property'}}currentGroupingPropertyName{{/crossLink}}-value
    *
-   * @property dataGroupProperties
    * @type string[]|object[]
    * @default []
    */
   dataGroupProperties = A([]);
 
   /**
-   * @property dataGroupOptions
-   * @type object[]
    * @private
    * @readonly
    */
@@ -844,8 +708,6 @@ class ModelsTableComponent extends Component {
   /**
    * `true` if some value is set to the global filter
    *
-   * @type boolean
-   * @property globalFilterUsed
    * @readonly
    * @private
    */
@@ -854,8 +716,6 @@ class ModelsTableComponent extends Component {
   /**
    * `true` if global filter or filter by any column is used
    *
-   * @type boolean
-   * @property anyFilterUsed
    * @readonly
    * @private
    */
@@ -867,8 +727,6 @@ class ModelsTableComponent extends Component {
   /**
    * `true` if all processedColumns don't use filtering and sorting
    *
-   * @type boolean
-   * @property noHeaderFilteringAndSorting
    * @readonly
    * @private
    */
@@ -880,8 +738,6 @@ class ModelsTableComponent extends Component {
   /**
    * Number of pages
    *
-   * @type number
-   * @property pagesCount
    * @readonly
    * @private
    */
@@ -896,8 +752,6 @@ class ModelsTableComponent extends Component {
    *
    * Filtering by columns is ignored if {{#crossLink 'Components.ModelsTable/useFilteringByColumns:property'}}useFilteringByColumns{{/crossLink}} is set to `false`
    *
-   * @type Object[]
-   * @property filteredContent
    * @readonly
    * @private
    */
@@ -962,8 +816,6 @@ class ModelsTableComponent extends Component {
   /**
    * {{#crossLink 'Components.ModelsTable/filteredContent:property'}}filteredContent{{/crossLink}} sorted by needed properties
    *
-   * @type Object[]
-   * @property arrangedContent
    * @readonly
    * @private
    */
@@ -1006,8 +858,6 @@ class ModelsTableComponent extends Component {
   /**
    * {{#crossLink 'Components.ModelsTable/filteredContent:property'}}filteredContent{{/crossLink}} grouped by {{#crossLink 'Components.ModelsTable/currentGroupingPropertyName:property'}}currentGroupingPropertyName{{/crossLink}} sorted by needed properties
    *
-   * @property groupedArrangedContent
-   * @type object[]
    * @private
    * @readonly
    */
@@ -1047,8 +897,6 @@ class ModelsTableComponent extends Component {
    *
    * {{#crossLink 'Components.ModelsTable/arrangedContent:property'}}arrangedContent{{/crossLink}} sliced for currently shown page
    *
-   * @type Object[]
-   * @property visibleContent
    * @readonly
    * @private
    */
@@ -1067,9 +915,6 @@ class ModelsTableComponent extends Component {
    *
    * {{#crossLink 'Components.ModelsTable/groupedVisibleContent:property'}}groupedVisibleContent{{/crossLink}} sliced for currently shown page
    *
-   * @property groupedVisibleContent
-   * @default {}
-   * @type object
    * @private
    * @readonly
    */
@@ -1088,8 +933,6 @@ class ModelsTableComponent extends Component {
   /**
    * List of grouped property values in order to show groups in the table
    *
-   * @type array
-   * @property groupedVisibleContentValuesOrder
    * @private
    * @readonly
    */
@@ -1101,8 +944,6 @@ class ModelsTableComponent extends Component {
   /**
    * Is user on the last page
    *
-   * @type boolean
-   * @property isLastPage
    * @readonly
    * @private
    */
@@ -1115,7 +956,6 @@ class ModelsTableComponent extends Component {
    * Alias to <code>arrangedContent.length</code>
    *
    * @type number
-   * @property arrangedContentLength
    * @readonly
    * @private
    */
@@ -1124,8 +964,6 @@ class ModelsTableComponent extends Component {
   /**
    * Index of the first currently shown record
    *
-   * @type number
-   * @property firstIndex
    * @private
    * @readonly
    */
@@ -1137,8 +975,6 @@ class ModelsTableComponent extends Component {
   /**
    * Index of the last currently shown record
    *
-   * @type number
-   * @property lastIndex
    * @readonly
    * @private
    */
@@ -1149,10 +985,6 @@ class ModelsTableComponent extends Component {
 
   /**
    * List of possible <code>pageSize</code> values. Used to change size of <code>visibleContent</code>
-   *
-   * @type number[]
-   * @default [10, 25, 50]
-   * @property pageSizeValues
    */
   pageSizeValues = A([10, 25, 50]);
 
@@ -1161,9 +993,7 @@ class ModelsTableComponent extends Component {
    * It's mapped from <code>pageSizeValues</code>
    * This value should not be set manually!
    *
-   * @type [{value: string|number, label: string|number}]
-   * @property pageSizeOptions
-   * @default []
+   * @type {[{value: string|number, label: string|number}]}
    * @private
    */
   pageSizeOptions = A([]);
@@ -1171,9 +1001,7 @@ class ModelsTableComponent extends Component {
   /**
    * List of options for pageNumber-selectBox
    *
-   * @property currentPageNumberOptions
-   * @type [{value: string|number, label: string|number}]
-   * @default []
+   * @type {[{value: string|number, label: string|number}]}
    * @private
    */
   @computed('pagesCount')
@@ -1185,8 +1013,7 @@ class ModelsTableComponent extends Component {
    * These are options for the columns dropdown.
    * By default, the 'Show All', 'Hide All' and 'Restore Defaults' buttons are displayed.
    *
-   * @type { showAll: boolean, hideAll: boolean, restoreDefaults: boolean, columnSets: object[] }
-   * @property columnDropdownOptions
+   * @type {{showAll: boolean, hideAll: boolean, restoreDefaults: boolean, columnSets: object[]}}
    * @readonly
    * @private
    */
@@ -1203,14 +1030,8 @@ class ModelsTableComponent extends Component {
   /**
    * Public API that allows for programmatic interaction with the component
    *
-   * {
-   *  refilter() - Invalidates the filteredContent property, causing the table to be re-filtered.
-   *  recordsCount - Size of the current arranged content
-   * }
-   *
-   * @type object
-   * @property publicAPI
-   *
+   *  * `refilter()` - Invalidates the filteredContent property, causing the table to be re-filtered.
+   *  * `recordsCount` - Size of the current arranged content
    */
   publicAPI = null;
 
@@ -1226,8 +1047,6 @@ class ModelsTableComponent extends Component {
   /**
    * Show first page if for some reasons there is no content for current page, but table data exists
    *
-   * @method visibleContentObserver
-   * @returns {undefined}
    * @private
    */
   visibleContentObserver() {
@@ -1235,8 +1054,6 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @method visibleContentObserverOnce
-   * @returns {undefined}
    * @private
    */
   visibleContentObserverOnce() {
@@ -1265,9 +1082,7 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @method checkColumnTitles
    * @private
-   * @returns {undefined}
    */
   _checkColumnTitles() {
     this.columns.forEach((c, index) => {
@@ -1279,9 +1094,6 @@ class ModelsTableComponent extends Component {
    * Component init
    *
    * Set visibility and filtering attributes for each column
-   *
-   * @method setup
-   * @returns {undefined}
    */
   setup() {
     this._setupSelectedRows();
@@ -1309,9 +1121,6 @@ class ModelsTableComponent extends Component {
 
   /**
    * Recalculate processedColumns when the columns attr changes
-   *
-   * @method updateColumns
-   * @returns {undefined}
    */
   updateColumns() {
     if (this.columnsAreUpdateable) {
@@ -1321,9 +1130,6 @@ class ModelsTableComponent extends Component {
 
   /**
    * Focus on 'Global filter' on component render
-   *
-   * @method focus
-   * @returns {undefined}
    */
   focus() {
     if (this.showGlobalFilter && this.focusGlobalFilter) {
@@ -1335,10 +1141,7 @@ class ModelsTableComponent extends Component {
    * Preselect table rows if `selectedItems` is provided
    *
    * `multipleSelected` may be set `true` if `selectedItems` has more than 1 item
-   *
-   * @private _setupSelectedRows
-   * @returns {undefined}
-   * @method
+   * @private
    */
   _setupSelectedRows() {
     if (isArray(this.selectedItems) && this.selectedItems.length > 1 && !this.multipleSelected) {
@@ -1350,8 +1153,6 @@ class ModelsTableComponent extends Component {
   /**
    * Wrapper for <code>_setupColumns</code> to call it only once when observer is fired
    *
-   * @method _setupColumnsOnce
-   * @returns {undefined}
    * @private
    */
   _setupColumnsOnce() {
@@ -1361,9 +1162,7 @@ class ModelsTableComponent extends Component {
   /**
    * Generate hash for column-`extend`
    *
-   * @method _createColumnInstance
    * @param {object} options
-   * @returns {object}
    * @private
    */
   _createColumnInstance(options) {
@@ -1411,9 +1210,7 @@ class ModelsTableComponent extends Component {
   /**
    * Set values for some column-properties after its creation
    *
-   * @method _postProcessColumn
    * @param {object} column
-   * @returns {object}
    * @private
    */
   _postProcessColumn(column) {
@@ -1440,9 +1237,7 @@ class ModelsTableComponent extends Component {
    * }
    * ```
    *
-   * @method _createColumn
    * @param {object} options
-   * @returns {Object}
    */
   _createColumn(options) {
     const column = this._createColumnInstance(options);
@@ -1453,8 +1248,6 @@ class ModelsTableComponent extends Component {
   /**
    * Create new properties for `columns`
    *
-   * @method _setupColumns
-   * @returns {undefined}
    * @private
    */
   _setupColumns() {
@@ -1523,10 +1316,6 @@ class ModelsTableComponent extends Component {
   /**
    * Create new properties for `columns` for components
    *
-   * @method _setupColumnsComponent
-   * @param {ModelsTableColumn} c
-   * @param {object} column raw column
-   * @returns {undefined}
    * @private
    */
   _setupColumnsComponent(c, column) {
@@ -1557,8 +1346,6 @@ class ModelsTableComponent extends Component {
    * Provide backward compatibility with <code>pageSizeValues</code> equal to an array with numbers and not objects
    * <code>pageSizeValues</code> is live as is, <code>pageSizeOptions</code> is used in the templates
    *
-   * @method _setupPageSizeOptions
-   * @returns {undefined}
    * @private
    */
   _setupPageSizeOptions() {
@@ -1569,11 +1356,6 @@ class ModelsTableComponent extends Component {
   /**
    * Set <code>sortProperties</code> when single-column sorting is used
    *
-   * @param {ModelsTableColumn} column
-   * @param {string} sortedBy
-   * @param {string} newSorting 'asc|desc|none'
-   * @method _singleColumnSorting
-   * @returns {undefined}
    * @protected
    */
   _singleColumnSorting(column, sortedBy, newSorting) {
@@ -1588,11 +1370,6 @@ class ModelsTableComponent extends Component {
   /**
    * Set <code>sortProperties</code> when multi-columns sorting is used
    *
-   * @param {ModelsTableColumn} column
-   * @param {string} sortedBy
-   * @param {string} newSorting 'asc|desc|none'
-   * @method _multiColumnsSorting
-   * @returns {undefined}
    * @protected
    */
   _multiColumnsSorting(column, sortedBy, newSorting) {
@@ -1624,8 +1401,6 @@ class ModelsTableComponent extends Component {
    * Send `displayDataChangedAction`-action when user does sort of filter.
    * Action is sent if `displayDataChangedAction` is a closure-action
    *
-   * @method userInteractionObserver
-   * @returns {undefined}
    * @protected
    */
   userInteractionObserver() {
@@ -1633,8 +1408,6 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @method userInteractionObserverOnce
-   * @returns {undefined}
    * @private
    */
   userInteractionObserverOnce() {
@@ -1665,8 +1438,6 @@ class ModelsTableComponent extends Component {
    * Send `columnsVisibilityChangedAction`-action when user changes which columns are visible.
    * Action is sent if `columnsVisibilityChangedAction` is a closure action
    *
-   * @returns {undefined}
-   * @method _sendColumnsVisibilityChangedAction
    * @private
    */
   _sendColumnsVisibilityChangedAction() {
@@ -1685,8 +1456,6 @@ class ModelsTableComponent extends Component {
   /**
    * Handler for global filter and filter by each column
    *
-   * @method forceToFirstPage
-   * @returns {undefined}
    * @private
    */
   forceToFirstPage() {
@@ -1697,8 +1466,6 @@ class ModelsTableComponent extends Component {
   /**
    * Collapse open rows when user change page size or moved to the another page
    *
-   * @method collapseRowOnNavigate
-   * @returns {undefined}
    * @private
    */
   @observes('currentPageNumber', 'pageSize')
@@ -1709,9 +1476,6 @@ class ModelsTableComponent extends Component {
   /**
    * Rebuild the whole table.
    * This can be called to force a complete re-render of the table.
-   *
-   * @method rebuildTable
-   * @returns {undefined}
    */
   rebuildTable() {
     set(this, 'currentPageNumber', 1);
@@ -1722,8 +1486,6 @@ class ModelsTableComponent extends Component {
   /**
    * Update colspans for table header cells
    *
-   * @method updateHeaderCellsColspan
-   * @returns {undefined}
    * @private
    */
   @observes('processedColumns.@each.{isVisible,colspanForSortCell,colspanForFilterCell}')
@@ -1732,8 +1494,6 @@ class ModelsTableComponent extends Component {
   }
 
   /**
-   * @method updateHeaderCellsColspanOnce
-   * @returns {undefined}
    * @private
    */
   updateHeaderCellsColspanOnce() {
@@ -1750,8 +1510,6 @@ class ModelsTableComponent extends Component {
   /**
    * Clear all filters.
    *
-   * @method _clearFilters
-   * @returns {undefined}
    * @private
    */
   _clearFilters() {
@@ -1777,10 +1535,6 @@ class ModelsTableComponent extends Component {
    * Toggle visibility for provided column
    *
    * It doesn't do nothing if column can't be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}}). May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
-   *
-   * @method actions.toggleHidden
-   * @param {ModelsTableColumn} column
-   * @returns {undefined}
    */
   @action
   toggleHidden(column) {
@@ -1794,9 +1548,6 @@ class ModelsTableComponent extends Component {
    * Show all columns
    *
    * Set each column `isHidden` value to `false`. May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
-   *
-   * @method actions.showAllColumns
-   * @returns {undefined}
    */
   @action
   showAllColumns() {
@@ -1808,9 +1559,6 @@ class ModelsTableComponent extends Component {
    * Hide all columns that may be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}})
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
-   *
-   * @method actions.hideAllColumns
-   * @returns {undefined}
    */
   @action
   hideAllColumns() {
@@ -1822,9 +1570,6 @@ class ModelsTableComponent extends Component {
    * Restore columns visibility values according to their default visibility settings (see {{#crossLink 'Utils.ModelsTableColumn/defaultVisible:property'}}defaultVisible{{/crossLink}})
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
-   *
-   * @method actions.restoreDefaultVisibility
-   * @returns {undefined}
    */
   @action
   restoreDefaultVisibility() {
@@ -1838,9 +1583,6 @@ class ModelsTableComponent extends Component {
    * Toggle visibility for every column in the selected columns set
    *
    * It ignore columns that can't be hidden (see {{#crossLink 'Utils.ModelsTableColumn/mayBeHidden:property'}}mayBeHidden{{/crossLink}}). May trigger sending {{#crossLink 'Components.ModelsTable/columnsVisibilityChangedAction:property'}}columnsVisibilityChangedAction{{/crossLink}}
-   *
-   * @method actions.toggleColumnSet
-   * @returns {undefined}
    */
   @action
   toggleColumnSet({showColumns = [], hideOtherColumns, toggleSet = false} = {}) {
@@ -1900,10 +1642,6 @@ class ModelsTableComponent extends Component {
    * Pagination click-handler
    *
    * It moves user to the selected page. Check [models-table/pagination-numeric](Components.ModelsTablePaginationNumeric.html) and [models-table/pagination-simple](Components.ModelsTablePaginationSimple.html) for usage examples. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @param {number} pageNumber
-   * @method actions.gotoCustomPage
-   * @returns {undefined}
    */
   @action
   gotoCustomPage(pageNumber) {
@@ -1922,10 +1660,6 @@ class ModelsTableComponent extends Component {
    * sortProperties = ['a:asc', 'b:asc', 'c:desc'];
    * sort({propertyName: 'b'}); // sortProperties now is ['a:asc', 'c:desc', 'b:desc']
    * ```
-   *
-   * @method actions.sort
-   * @param {ModelsTableColumn} column
-   * @returns {undefined}
    */
   @action
   sort(column) {
@@ -1955,11 +1689,6 @@ class ModelsTableComponent extends Component {
    * Expand selected row
    *
    * It will cause expandedRowComponent to be used for it. It will collapse already expanded row if {{#crossLink 'Components.ModelsTable/multipleExpand:property'}}multipleExpand{{/crossLink}} is set to `false`. Expanding is assigned to the record itself and not their index. So, if page #1 has first row expanded and user is moved to any another page, first row on new page won't be expanded. But when user will be back to the first page, first row will be expanded. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.expandRow
    */
   @action
   expandRow(index, dataItem) {
@@ -1976,11 +1705,6 @@ class ModelsTableComponent extends Component {
    * Collapse selected row
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.collapseRow
    */
   @action
   collapseRow(index, dataItem) {
@@ -1993,9 +1717,6 @@ class ModelsTableComponent extends Component {
    * Expand all rows in the current page
    *
    * It works only if {{#crossLink 'Components.ModelsTable/multipleExpand:property'}}multipleExpand{{/crossLink}} is set to `true`. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @method actions.expandAllRows
-   * @returns {undefined}
    */
   @action
   expandAllRows() {
@@ -2015,9 +1736,6 @@ class ModelsTableComponent extends Component {
    * Collapse all rows in the current page
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @method actions.collapseAllRows
-   * @returns {undefined}
    */
   @action
   collapseAllRows() {
@@ -2029,11 +1747,6 @@ class ModelsTableComponent extends Component {
    * Handler for row-click
    *
    * Toggle <code>selected</code>-state for row. Select only one or multiple rows depends on {{#crossLink 'Components.ModelsTable/multipleSelect:property'}}multipleSelect{{/crossLink}} value. May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.clickOnRow
    */
   @action
   clickOnRow(index, dataItem) {
@@ -2057,11 +1770,6 @@ class ModelsTableComponent extends Component {
    * Handler for double-click on row
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/rowDoubleClickAction:property'}}rowDoubleClickAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.doubleClickOnRow
    */
   @action
   doubleClickOnRow(index, dataItem) {
@@ -2076,11 +1784,6 @@ class ModelsTableComponent extends Component {
    * Handler for row-hover
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/rowHoverAction:property'}}rowHoverAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.hoverOnRow
    */
   @action
   hoverOnRow(index, dataItem) {
@@ -2095,11 +1798,6 @@ class ModelsTableComponent extends Component {
    * Handler for row-hover
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/rowHoverAction:property'}}rowOutAction{{/crossLink}}
-   *
-   * @param {number} index
-   * @param {object} dataItem
-   * @returns {undefined}
-   * @method actions.outRow
    */
   @action
   outRow(index, dataItem) {
@@ -2114,9 +1812,6 @@ class ModelsTableComponent extends Component {
    * Clear all column filters and global filter
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @returns {undefined}
-   * @method actions.clearFilters
    */
   @action
   clearFilters() {
@@ -2127,9 +1822,6 @@ class ModelsTableComponent extends Component {
    * Select/deselect all rows
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @method actions.toggleAllSelection
-   * @returns {undefined}
    */
   @action
   toggleAllSelection() {
@@ -2147,10 +1839,6 @@ class ModelsTableComponent extends Component {
    * Expand or collapse all rows in the rows group
    *
    * **IMPORTANT** `multipleExpand` should be set to `true` otherwise this action won't do anything
-   *
-   * @method actions.toggleGroupedRowsExpands
-   * @param {*} groupedValue
-   * @returns {undefined}
    */
   @action
   toggleGroupedRowsExpands(groupedValue) {
@@ -2176,10 +1864,6 @@ class ModelsTableComponent extends Component {
    * **IMPORTANT** `multipleSelect` should be set to `true` otherwise this action won't do anything
    *
    * May trigger sending {{#crossLink 'Components.ModelsTable/displayDataChangedAction:property'}}displayDataChangedAction{{/crossLink}}
-   *
-   * @method actions.toggleGroupedRowsSelection
-   * @param {*} groupedValue
-   * @returns {undefined}
    */
   @action
   toggleGroupedRowsSelection(groupedValue) {
@@ -2201,10 +1885,6 @@ class ModelsTableComponent extends Component {
 
   /**
    * Collapse or expand rows group
-   *
-   * @method actions.toggleGroupedRows
-   * @param {*} groupedValue
-   * @returns {undefined}
    */
   @action
   toggleGroupedRows(groupedValue) {

--- a/addon/components/models-table/cell-column-summary.js
+++ b/addon/components/models-table/cell-column-summary.js
@@ -70,25 +70,29 @@ export default
 @templateLayout(layout)
 @tagName('td')
 class CellColumnSummaryComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @type object[]
    * @default null
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
-   * @type number[]
+   * @property expandedItems
+   * @type object[]
    * @default null
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @type object[]
    * @default null
    */
@@ -97,6 +101,7 @@ class CellColumnSummaryComponent extends Component {
   /**
    * `selectedItems.mapBy(column.propertyName)`
    *
+   * @property mappedSelectedItems
    * @default []
    * @type array
    */
@@ -105,6 +110,7 @@ class CellColumnSummaryComponent extends Component {
   /**
    * `expandedItems.mapBy(column.propertyName)`
    *
+   * @property mappedExpandedItems
    * @default []
    * @type array
    */
@@ -119,51 +125,61 @@ class CellColumnSummaryComponent extends Component {
   mappedData = [];
 
   /**
+   * @property minSelected
    * @type number
    */
   @minBy('mappedSelectedItems') minSelected;
 
   /**
+   * @property minData
    * @type number
    */
   @minBy('mappedData') minData;
 
   /**
+   * @property maxSelected
    * @type number
    */
-  @maxBy('mappedSelectedItems')maxSelected;
+  @maxBy('mappedSelectedItems') maxSelected;
 
   /**
+   * @property maxData
    * @type number
    */
   @maxBy('mappedData') maxData;
 
   /**
+   * @property sumSelected
    * @type number
    */
   @sumBy('mappedSelectedItems') sumSelected;
 
   /**
+   * @property sumData
    * @type number
    */
   @sumBy('mappedData') sumData;
 
   /**
+   * @property avgSelected
    * @type number
    */
   @avgBy('mappedSelectedItems', 'sumSelected') avgSelected;
 
   /**
+   * @property avgData
    * @type number
    */
   @avgBy('mappedData', 'sumData') avgData;
 
   /**
+   * @property medianSelected
    * @type number
    */
   @medianBy('mappedSelectedItems') medianSelected;
 
   /**
+   * @property medianData
    * @type number
    */
   @medianBy('mappedData') medianData;

--- a/addon/components/models-table/cell-column-summary.js
+++ b/addon/components/models-table/cell-column-summary.js
@@ -73,7 +73,6 @@ class CellColumnSummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @type object[]
    * @default null
    */
@@ -82,7 +81,6 @@ class CellColumnSummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @type number[]
    * @default null
    */
@@ -91,7 +89,6 @@ class CellColumnSummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @type object[]
    * @default null
    */
@@ -100,7 +97,6 @@ class CellColumnSummaryComponent extends Component {
   /**
    * `selectedItems.mapBy(column.propertyName)`
    *
-   * @property mappedSelectedItems
    * @default []
    * @type array
    */
@@ -109,7 +105,6 @@ class CellColumnSummaryComponent extends Component {
   /**
    * `expandedItems.mapBy(column.propertyName)`
    *
-   * @property mappedExpandedItems
    * @default []
    * @type array
    */
@@ -118,68 +113,57 @@ class CellColumnSummaryComponent extends Component {
   /**
    * `data.mapBy(column.propertyName)`
    *
-   * @property mappedData
    * @default []
    * @type array
    */
   mappedData = [];
 
   /**
-   * @property minSelected
    * @type number
    */
   @minBy('mappedSelectedItems') minSelected;
 
   /**
-   * @property minData
    * @type number
    */
   @minBy('mappedData') minData;
 
   /**
-   * @property maxSelected
    * @type number
    */
   @maxBy('mappedSelectedItems')maxSelected;
 
   /**
-   * @property maxData
    * @type number
    */
   @maxBy('mappedData') maxData;
 
   /**
-   * @property sumSelected
    * @type number
    */
   @sumBy('mappedSelectedItems') sumSelected;
 
   /**
-   * @property sumData
    * @type number
    */
   @sumBy('mappedData') sumData;
 
   /**
-   * @property avgSelected
    * @type number
    */
   @avgBy('mappedSelectedItems', 'sumSelected') avgSelected;
 
   /**
-   * @property avgData
    * @type number
    */
   @avgBy('mappedData', 'sumData') avgData;
 
   /**
-   * @property medianSelected
    * @type number
    */
   @medianBy('mappedSelectedItems') medianSelected;
 
   /**
-   * @property medianData
    * @type number
    */
   @medianBy('mappedData') medianData;

--- a/addon/components/models-table/cell-content-display.js
+++ b/addon/components/models-table/cell-content-display.js
@@ -15,6 +15,130 @@ import {get, set} from '@ember/object';
 export default
 @templateLayout(layout)
 class CellContentDisplayComponent extends Component {
+
+  /**
+   * One of the [data](Components.ModelsTable.html#property_data)
+   *
+   * @default null
+   * @property record
+   * @type object
+   */
+  record = null;
+
+  /**
+   * Row's index where current cell is
+   *
+   * @property index
+   * @default null
+   * @type number
+   */
+  index = null;
+
+  /**
+   * @property column
+   * @default null
+   * @type Utils.ModelsTableColumn
+   */
+  column = null;
+
+  /**
+   * @property isEditRow
+   * @default null
+   * @protected
+   * @type boolean
+   */
+  isEditRow = null;
+
+  /**
+   * @property groupedLength
+   * @type number
+   * @default null
+   */
+  groupedLength = null;
+
+  /**
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
+   *
+   * @event expandRow
+   */
+  expandRow = null;
+
+  /**
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
+   *
+   * @event collapseRow
+   */
+  collapseRow = null;
+
+  /**
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   *
+   * @event expandAllRows
+   */
+  expandAllRows = null;
+
+  /**
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   *
+   * @event collapseAllRows
+   */
+  collapseAllRows = null;
+
+  /**
+   * Closure action [ModelsTableRow.editRow](Components.ModelsTableRow.html#event_editRow)
+   *
+   * @event editRow
+   */
+  editRow = null;
+
+  /**
+   * Closure action [ModelsTableRow.saveRow](Components.ModelsTableRow.html#event_saveRow)
+   *
+   * @event saveRow
+   */
+  saveRow = null;
+
+  /**
+   * Closure action [ModelsTableRow.cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow)
+   *
+   * @event cancelEditRow
+   */
+  cancelEditRow = null;
+
+  /**
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
+   *
+   * @property themeInstance
+   * @type object
+   * @default null
+   */
+  themeInstance = null;
+
+  /**
+   * Is current row expanded or not
+   *
+   * @default null
+   * @property isExpanded
+   * @type boolean
+   */
+  isExpanded = null;
+
+  /**
+   * Is current row selected or not
+   *
+   * @default null
+   * @property isSelected
+   * @type boolean
+   */
+  isSelected = null;
+
+  /**
+   * @property isColumnEditable
+   * @type boolean
+   * @default false
+   */
+  isColumnEditable = false;
+
   init() {
     set(this, 'tagName', get(this, 'themeInstance.cellContentTagName'));
     super.init(...arguments);

--- a/addon/components/models-table/cell-content-edit.js
+++ b/addon/components/models-table/cell-content-edit.js
@@ -15,6 +15,130 @@ import { get, set } from '@ember/object';
 export default
 @templateLayout(layout)
 class CellContentEditComponent extends Component {
+
+  /**
+   * One of the [data](Components.ModelsTable.html#property_data)
+   *
+   * @default null
+   * @property record
+   * @type object
+   */
+  record = null;
+
+  /**
+   * Row's index where current cell is
+   *
+   * @property index
+   * @default null
+   * @type number
+   */
+  index = null;
+
+  /**
+   * @property column
+   * @default null
+   * @type Utils.ModelsTableColumn
+   */
+  column = null;
+
+  /**
+   * @property isEditRow
+   * @default null
+   * @protected
+   * @type boolean
+   */
+  isEditRow = null;
+
+  /**
+   * @property groupedLength
+   * @type number
+   * @default null
+   */
+  groupedLength = null;
+
+  /**
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
+   *
+   * @event expandRow
+   */
+  expandRow = null;
+
+  /**
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
+   *
+   * @event collapseRow
+   */
+  collapseRow = null;
+
+  /**
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   *
+   * @event expandAllRows
+   */
+  expandAllRows = null;
+
+  /**
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   *
+   * @event collapseAllRows
+   */
+  collapseAllRows = null;
+
+  /**
+   * Closure action [ModelsTableRow.editRow](Components.ModelsTableRow.html#event_editRow)
+   *
+   * @event editRow
+   */
+  editRow = null;
+
+  /**
+   * Closure action [ModelsTableRow.saveRow](Components.ModelsTableRow.html#event_saveRow)
+   *
+   * @event saveRow
+   */
+  saveRow = null;
+
+  /**
+   * Closure action [ModelsTableRow.cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow)
+   *
+   * @event cancelEditRow
+   */
+  cancelEditRow = null;
+
+  /**
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
+   *
+   * @property themeInstance
+   * @type object
+   * @default null
+   */
+  themeInstance = null;
+
+  /**
+   * Is current row expanded or not
+   *
+   * @default null
+   * @property isExpanded
+   * @type boolean
+   */
+  isExpanded = null;
+
+  /**
+   * Is current row selected or not
+   *
+   * @default null
+   * @property isSelected
+   * @type boolean
+   */
+  isSelected = null;
+
+  /**
+   * @property isColumnEditable
+   * @type boolean
+   * @default false
+   */
+  isColumnEditable = false;
+
   init() {
     set(this, 'tagName', get(this, 'themeInstance.cellContentTagName'));
     super.init(...arguments);

--- a/addon/components/models-table/cell-edit-toggle.js
+++ b/addon/components/models-table/cell-edit-toggle.js
@@ -23,7 +23,6 @@ class CellEditToggleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -74,7 +73,6 @@ class CellEditToggleComponent extends Component {
   /**
    * The label for the Edit Button
    *
-   * @property editButtonLabel
    * @type string
    * @default themeInstance.editRowButtonLabelMsg
    */
@@ -84,7 +82,6 @@ class CellEditToggleComponent extends Component {
   /**
    * The label for the Cancel Button
    *
-   * @property cancelButtonLabel
    * @type string
    * @default themeInstance.cancelRowButtonLabelMsg
    */
@@ -94,7 +91,6 @@ class CellEditToggleComponent extends Component {
   /**
    * The label for the Save Button
    *
-   * @property saveButtonLabel
    * @type string
    * @default themeInstance.saveRowButtonLabelMsg
    */

--- a/addon/components/models-table/cell.js
+++ b/addon/components/models-table/cell.js
@@ -55,7 +55,6 @@ class CellComponent extends Component {
   /**
    * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
    *
-   * @property record
    * @default null
    */
   record = null;
@@ -63,23 +62,19 @@ class CellComponent extends Component {
   /**
    * Row's index where current cell is
    *
-   * @property index
    * @default null
    * @type number
    */
   index = null;
 
   /**
-   * @property column
    * @default null
    * @type ModelsTableColumn
    */
   column = null;
 
   /**
-   * @property isEditRow
    * @default null
-   * @type boolean
    * @private
    */
   isEditRow = null;
@@ -136,7 +131,6 @@ class CellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -145,18 +139,13 @@ class CellComponent extends Component {
   /**
    * Is current row expanded or not
    *
-   * @type boolean
    * @default null
-   * @property isExpanded
    */
   isExpanded = null;
 
   /**
    * Is this column editable
    *
-   * @type boolean
-   * @default true
-   * @property isColumnEditable
    * @private
    */
   @computed('column.editable', 'isEditRow')
@@ -176,7 +165,6 @@ class CellComponent extends Component {
   /**
    * Given the mode for a cell (Edit or not) will determine which component to render
    *
-   * @property componentToRender
    * @default null
    * @type ?string
    * @private

--- a/addon/components/models-table/cell.js
+++ b/addon/components/models-table/cell.js
@@ -26,7 +26,10 @@ import {isPresent, isNone} from '@ember/utils';
  *       {{#each Body.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} as |Row|>
  *           {{#each Row.visibleProcessedColumns as |column|}}
- *             <Row.Cell @column={{column}} />
+ *             <Row.Cell @column={{column}} @index={{index}} as |Cell|/>
+ *               {{#if Cell.componentToRender}}
+ *                 {{component Cell.componentToRender}}
+ *               {{/if}}
  *               {{! ... }}
  *             </Row.Cell>
  *           {{/each}}
@@ -49,88 +52,108 @@ export default
 @tagName('td')
 class CellComponent extends Component {
 
+  /**
+   * @property columnClassName
+   * @type string
+   * @default ''
+   * @protected
+   */
   @className
   @alias('column.className') columnClassName;
 
   /**
-   * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
+   * One of the [data](Components.ModelsTable.html#property_data)
    *
    * @default null
+   * @property record
+   * @type object
    */
   record = null;
 
   /**
    * Row's index where current cell is
    *
+   * @property index
    * @default null
    * @type number
    */
   index = null;
 
   /**
+   * @property column
    * @default null
-   * @type ModelsTableColumn
+   * @type Utils.ModelsTableColumn
    */
   column = null;
 
   /**
+   * @property isEditRow
    * @default null
-   * @private
+   * @protected
+   * @type boolean
    */
   isEditRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * @property groupedLength
+   * @type number
+   * @default null
+   */
+  groupedLength = null;
+
+  /**
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTableRow.actions.editRow{{/crossLink}}
+   * Closure action [ModelsTableRow.editRow](Components.ModelsTableRow.html#event_editRow)
    *
    * @event editRow
    */
   editRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTableRow/actions.saveRow:method"}}ModelsTableRow.actions.saveRow{{/crossLink}}
+   * Closure action [ModelsTableRow.saveRow](Components.ModelsTableRow.html#event_saveRow)
    *
    * @event saveRow
    */
   saveRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTableRow.actions.cancelEditRow{{/crossLink}}
+   * Closure action [ModelsTableRow.cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow)
    *
    * @event cancelEditRow
    */
   cancelEditRow = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
@@ -140,13 +163,27 @@ class CellComponent extends Component {
    * Is current row expanded or not
    *
    * @default null
+   * @property isExpanded
+   * @type boolean
    */
   isExpanded = null;
 
   /**
+   * Is current row selected or not
+   *
+   * @default null
+   * @property isSelected
+   * @type boolean
+   */
+  isSelected = null;
+
+  /**
    * Is this column editable
    *
-   * @private
+   * @protected
+   * @property isColumnEditable
+   * @type boolean
+   * @default false
    */
   @computed('column.editable', 'isEditRow')
   get isColumnEditable() {
@@ -165,9 +202,10 @@ class CellComponent extends Component {
   /**
    * Given the mode for a cell (Edit or not) will determine which component to render
    *
+   * @property componentToRender
    * @default null
    * @type ?string
-   * @private
+   * @protected
    */
   @computed('isColumnEditable', 'isEditRow', 'column.{propertyName,component,componentForEdit}')
   get componentToRender() {

--- a/addon/components/models-table/columns-dropdown.js
+++ b/addon/components/models-table/columns-dropdown.js
@@ -28,7 +28,6 @@ class ColumnsDropdownComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type object[]
    * @default null
    */
@@ -37,7 +36,6 @@ class ColumnsDropdownComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/columnDropdownOptions:property"}}ModelsTable.columnDropdownOptions{{/crossLink}}
    *
-   * @property columnDropdownOptions
    * @type object[]
    * @default null
    */
@@ -46,7 +44,6 @@ class ColumnsDropdownComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/columns-dropdown.js
+++ b/addon/components/models-table/columns-dropdown.js
@@ -17,6 +17,7 @@ import layout from '../../templates/components/models-table/columns-dropdown';
  *   <MT.ColumnsDropdown />
  *   {{! .... }}
  * </ModelsTable>
+ * ```
  *
  * @namespace Components
  * @class ModelsTableColumnsDropdown
@@ -25,86 +26,111 @@ import layout from '../../templates/components/models-table/columns-dropdown';
 export default
 @templateLayout(layout)
 class ColumnsDropdownComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Bound from [ModelsTable.processedColumns](Components.ModelsTable.html#property_processedColumns)
    *
-   * @type object[]
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   processedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/columnDropdownOptions:property"}}ModelsTable.columnDropdownOptions{{/crossLink}}
+   * Bound from [ModelsTable.columnDropdownOptions](Components.ModelsTable.html#property_columnDropdownOptions)
    *
-   * @type object[]
+   * @property columnDropdownOptions
+   * @type ColumnDropdownOptions
    * @default null
    */
   columnDropdownOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.showAllColumns:method"}}ModelsTable.actions.showAllColumns{{/crossLink}}
+   * Closure action [ModelsTable.showAllColumns](Components.ModelsTable.html#event_showAllColumns)
    *
    * @event showAllColumns
    */
   showAllColumns = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.hideAllColumns:method"}}ModelsTable.actions.hideAllColumns{{/crossLink}}
+   * Closure action [ModelsTable.hideAllColumns](Components.ModelsTable.html#event_hideAllColumns)
    *
    * @event hideAllColumns
    */
   hideAllColumns = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.restoreDefaultVisibility:method"}}ModelsTable.actions.restoreDefaultVisibility{{/crossLink}}
+   * Closure action [ModelsTable.restoreDefaultVisibility](Components.ModelsTable.html#event_restoreDefaultVisibility)
    *
    * @event restoreDefaultVisibility
    */
   restoreDefaultVisibility = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleColumnSet:method"}}ModelsTable.actions.toggleColumnSet{{/crossLink}}
+   * Closure action [ModelsTable.toggleColumnSet](Components.ModelsTable.html#event_toggleColumnSet)
    *
    * @event toggleColumnSet
    */
   toggleColumnSet = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleHidden:method"}}ModelsTable.actions.toggleHidden{{/crossLink}}
+   * Closure action [ModelsTable.toggleHidden](Components.ModelsTable.html#event_toggleHidden)
    *
    * @event toggleHidden
    */
   toggleHidden = null;
 
-
+  /**
+   * @event doShowAllColumns
+   * @protected
+   */
   @action
   doShowAllColumns() {
     this.showAllColumns();
   }
 
+  /**
+   * @event doHideAllColumns
+   * @protected
+   */
   @action
   doHideAllColumns() {
     this.hideAllColumns();
   }
 
+  /**
+   * @event doRestoreDefaultVisibility
+   * @protected
+   */
   @action
   doRestoreDefaultVisibility() {
     this.restoreDefaultVisibility();
   }
 
+  /**
+   * @event doToggleColumnSet
+   * @param {ColumnSet} columnSet
+   * @protected
+   */
   @action
   doToggleColumnSet(columnSet) {
     this.toggleColumnSet(columnSet);
   }
 
+  /**
+   * @event doToggleHidden
+   * @param {Utils.ModelsTableColumn} column
+   * @protected
+   */
   @action
   doToggleHidden(column) {
     this.toggleHidden(column);

--- a/addon/components/models-table/columns-hidden.js
+++ b/addon/components/models-table/columns-hidden.js
@@ -35,17 +35,20 @@ export default
 @templateLayout(layout)
 @tagName('tr')
 class ColumnsHiddenComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTableTable/columnsCount:property"}}ModelsTable.columnsCount{{/crossLink}}
+   * Bound from [ModelsTable.columnsCount](Components.ModelsTableTable.html#property_columnsCount)
    *
+   * @property columnsCount
    * @type number
    * @default null
    */
   columnsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/columns-hidden.js
+++ b/addon/components/models-table/columns-hidden.js
@@ -38,7 +38,6 @@ class ColumnsHiddenComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTableTable/columnsCount:property"}}ModelsTable.columnsCount{{/crossLink}}
    *
-   * @property columnsCount
    * @type number
    * @default null
    */
@@ -47,7 +46,6 @@ class ColumnsHiddenComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/data-group-by-select.js
+++ b/addon/components/models-table/data-group-by-select.js
@@ -27,7 +27,6 @@ class DataGroupBySelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property value
    * @type string
    * @default null
    */
@@ -36,7 +35,6 @@ class DataGroupBySelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -45,7 +43,6 @@ class DataGroupBySelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
    *
-   * @property options
    * @default null
    * @type object[]
    */
@@ -54,7 +51,6 @@ class DataGroupBySelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -63,7 +59,6 @@ class DataGroupBySelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/sortByGroupedFieldDirection:property"}}ModelsTable.sortByGroupedFieldDirection{{/crossLink}}
    *
-   * @property sortByGroupedFieldDirection
    * @type string
    * @default null
    */

--- a/addon/components/models-table/data-group-by-select.js
+++ b/addon/components/models-table/data-group-by-select.js
@@ -24,58 +24,72 @@ import layout from '../../templates/components/models-table/data-group-by-select
 export default
 @templateLayout(layout)
 class DataGroupBySelectComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
-   * @type string
+   * @property value
+   * @type string|number|boolean
    * @default null
    */
   value = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
+   * Bound from [ModelsTable.dataGroupOptions](Components.ModelsTable.html#property_dataGroupOptions)
    *
+   * @property options
    * @default null
-   * @type object[]
+   * @type SelectOption[]
    */
   options = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/sortByGroupedFieldDirection:property"}}ModelsTable.sortByGroupedFieldDirection{{/crossLink}}
+   * Bound from [ModelsTable.sortByGroupedFieldDirection](Components.ModelsTable.html#property_sortByGroupedFieldDirection)
    *
+   * @property sortByGroupedFieldDirection
    * @type string
    * @default null
    */
   sortByGroupedFieldDirection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
+  /**
+   * @event doSort
+   * @protected
+   */
   @action
   doSort() {
     this.sort({propertyName: this.currentGroupingPropertyName});
   }
 
+  /**
+   * @event noop
+   * @protected
+   */
   @action
   noop() {}
 }

--- a/addon/components/models-table/footer.js
+++ b/addon/components/models-table/footer.js
@@ -46,117 +46,140 @@ import layout from '../../templates/components/models-table/footer';
 export default
 @templateLayout(layout)
 class FooterComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/collapseNumPaginationForPagesCount:property"}}ModelsTable.collapseNumPaginationForPagesCount{{/crossLink}}
+   * Bound from [ModelsTable.collapseNumPaginationForPagesCount](Components.ModelsTable.html#property_collapseNumPaginationForPagesCount)
    *
+   * @property collapseNumPaginationForPagesCount
    * @type number
    * @default null
    */
   collapseNumPaginationForPagesCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/firstIndex:property"}}ModelsTable.firstIndex{{/crossLink}}
+   * Bound from [ModelsTable.firstIndex](Components.ModelsTable.html#property_firstIndex)
    *
+   * @property firstIndex
    * @type number
    * @default null
    */
   firstIndex = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/lastIndex:property"}}ModelsTable.lastIndex{{/crossLink}}
+   * Bound from [ModelsTable.lastIndex](Components.ModelsTable.html#property_lastIndex)
    *
+   * @property lastIndex
    * @type number
    * @default null
    */
   lastIndex = null;
 
+  /**
+   * @property recordsCount
+   * @type number
+   * @default null
+   */
   recordsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/anyFilterUsed:property"}}ModelsTable.anyFilterUsed{{/crossLink}}
+   * Bound from [ModelsTable.anyFilterUsed](Components.ModelsTable.html#property_anyFilterUsed)
    *
    * @default null
+   * @property anyFilterUsed
+   * @type boolean
    */
   anyFilterUsed = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumberOptions](Components.ModelsTable.html#property_currentPageNumberOptions)
    *
-   * @type object[]
+   * @property currentPageNumberOptions
+   * @type SelectOption[]
    * @default null
    */
   currentPageNumberOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSizeOptions:property"}}ModelsTable.pageSizeOptions{{/crossLink}}
+   * Bound from [ModelsTable.pageSizeOptions](Components.ModelsTable.html#property_pageSizeOptions)
    *
-   * @type object[]
+   * @property pageSizeOptions
+   * @type SelectOption[]
    * @default null
    */
   pageSizeOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
+   * Bound from [ModelsTable.pageSize](Components.ModelsTable.html#property_pageSize)
    *
+   * @property pageSize
    * @type number
-   * @default null
+   * @default 10
    */
-  pageSize = null;
+  pageSize = 10;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumber](Components.ModelsTable.html#property_currentPageNumber)
    *
+   * @property currentPageNumber
    * @type number
-   * @default null
+   * @default 1
    */
-  currentPageNumber = null;
+  currentPageNumber = 1;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
+   * Bound from [ModelsTable.showCurrentPageNumberSelect](Components.ModelsTable.html#property_showCurrentPageNumberSelect)
    *
+   * @property showCurrentPageNumberSelect
    * @default null
+   * @type boolean
    */
   showCurrentPageNumberSelect = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
+   * Bound from [ModelsTable.pagesCount](Components.ModelsTable.html#property_pagesCount)
    *
+   * @property pagesCount
    * @type number
    * @default null
    */
   pagesCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/showPageSize:property"}}ModelsTable.showPageSize{{/crossLink}}
+   * Bound from [ModelsTable.showPageSize](Components.ModelsTable.html#property_showPageSize)
    *
+   * @property showPageSize
+   * @type boolean
    * @default null
    */
   showPageSize = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}}
+   * Bound from [ModelsTable.useNumericPagination](Components.ModelsTable.html#property_useNumericPagination)
    *
+   * @property useNumericPagination
+   * @type boolean
    * @default null
    */
   useNumericPagination = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.goToPage:method"}}ModelsTable.actions.goToPage{{/crossLink}}
+   * Closure action [ModelsTable.goToPage](Components.ModelsTable.html#event_goToPage)
    *
    * @event goToPage
    */
   goToPage = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clearFilters:method"}}ModelsTable.actions.clearFilters{{/crossLink}}
+   * Closure action [ModelsTable.clearFilters](Components.ModelsTable.html#event_clearFilters)
    *
    * @event clearFilters
    */
   clearFilters = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/footer.js
+++ b/addon/components/models-table/footer.js
@@ -49,7 +49,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/collapseNumPaginationForPagesCount:property"}}ModelsTable.collapseNumPaginationForPagesCount{{/crossLink}}
    *
-   * @property collapseNumPaginationForPagesCount
    * @type number
    * @default null
    */
@@ -58,7 +57,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/firstIndex:property"}}ModelsTable.firstIndex{{/crossLink}}
    *
-   * @property firstIndex
    * @type number
    * @default null
    */
@@ -67,7 +65,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/lastIndex:property"}}ModelsTable.lastIndex{{/crossLink}}
    *
-   * @property lastIndex
    * @type number
    * @default null
    */
@@ -78,8 +75,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/anyFilterUsed:property"}}ModelsTable.anyFilterUsed{{/crossLink}}
    *
-   * @property anyFilterUsed
-   * @type boolean
    * @default null
    */
   anyFilterUsed = null;
@@ -87,7 +82,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
    *
-   * @property currentPageNumberOptions
    * @type object[]
    * @default null
    */
@@ -96,7 +90,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSizeOptions:property"}}ModelsTable.pageSizeOptions{{/crossLink}}
    *
-   * @property pageSizeOptions
    * @type object[]
    * @default null
    */
@@ -105,7 +98,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
    *
-   * @property pageSize
    * @type number
    * @default null
    */
@@ -114,7 +106,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
    *
-   * @property currentPageNumber
    * @type number
    * @default null
    */
@@ -123,8 +114,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
    *
-   * @property showCurrentPageNumberSelect
-   * @type boolean
    * @default null
    */
   showCurrentPageNumberSelect = null;
@@ -132,7 +121,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
    *
-   * @property pagesCount
    * @type number
    * @default null
    */
@@ -141,8 +129,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/showPageSize:property"}}ModelsTable.showPageSize{{/crossLink}}
    *
-   * @property showPageSize
-   * @type boolean
    * @default null
    */
   showPageSize = null;
@@ -150,8 +136,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}}
    *
-   * @property useNumericPagination
-   * @type boolean
    * @default null
    */
   useNumericPagination = null;
@@ -173,7 +157,6 @@ class FooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/global-filter.js
+++ b/addon/components/models-table/global-filter.js
@@ -24,31 +24,36 @@ import {action, computed} from '@ember/object';
 export default
 @templateLayout(layout)
 class GlobalFilterComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/filterString:property"}}ModelsTable.filterString{{/crossLink}}
+   * Bound from [ModelsTable.filterString](Components.ModelsTable.html#property_filterString)
    *
+   * @property value
    * @type string
    * @default null
    */
   value = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/globalFilterUsed:property"}}ModelsTable.globalFilterUsed{{/crossLink}}
+   * Bound from [ModelsTable.globalFilterUsed](Components.ModelsTable.html#property_globalFilterUsed)
    *
+   * @property globalFilterUsed
+   * @type boolean
    * @default null
    */
   globalFilterUsed = null;
 
-
   /**
+   * @property inputId
    * @type string
    * @private
    */
@@ -57,6 +62,10 @@ class GlobalFilterComponent extends Component {
     return `${this.elementId}-global-filter`;
   }
 
+  /**
+   * @event noop
+   * @protected
+   */
   @action
   noop() {}
 

--- a/addon/components/models-table/global-filter.js
+++ b/addon/components/models-table/global-filter.js
@@ -27,7 +27,6 @@ class GlobalFilterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/filterString:property"}}ModelsTable.filterString{{/crossLink}}
    *
-   * @property value
    * @type string
    * @default null
    */
@@ -36,7 +35,6 @@ class GlobalFilterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -45,15 +43,12 @@ class GlobalFilterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/globalFilterUsed:property"}}ModelsTable.globalFilterUsed{{/crossLink}}
    *
-   * @property globalFilterUsed
-   * @type boolean
    * @default null
    */
   globalFilterUsed = null;
 
 
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/group-summary-row.js
+++ b/addon/components/models-table/group-summary-row.js
@@ -16,7 +16,6 @@ class GroupSummaryRowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -24,7 +23,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property selectedItems
    * @default null
    * @private
    */
@@ -32,7 +30,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property expandedItems
    * @default null
    * @private
    */
@@ -40,7 +37,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property groupedItems
    * @default null
    * @private
    */
@@ -48,7 +44,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property visibleGroupedItems
    * @default null
    * @private
    */
@@ -56,7 +51,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property selectedGroupedItems
    * @default null
    */
   @intersect('selectedItems', 'groupedItems')
@@ -64,7 +58,6 @@ class GroupSummaryRowComponent extends Component {
 
   /**
    * @type object[]
-   * @property expandedGroupedItems
    * @default null
    */
   @intersect('expandedItems', 'groupedItems')
@@ -73,7 +66,6 @@ class GroupSummaryRowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/group-summary-row.js
+++ b/addon/components/models-table/group-summary-row.js
@@ -14,58 +14,70 @@ export default
 @tagName('tr')
 class GroupSummaryRowComponent extends Component {
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
+   *
+   * @property selectedItems
    * @type object[]
    * @default null
-   * @private
    */
   selectedItems = null;
 
   /**
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_expandedItems)
+   *
+   * @property expandedItems
    * @type object[]
    * @default null
-   * @private
    */
   expandedItems = null;
 
   /**
+   * Bound from [ModelsTable.groupedItems](Components.ModelsTable.html#property_groupedItems)
+   *
+   * @property groupedItems
    * @type object[]
    * @default null
-   * @private
    */
   groupedItems = null;
 
   /**
+   * @property visibleGroupedItems
    * @type object[]
    * @default null
-   * @private
    */
   visibleGroupedItems = null;
 
   /**
+   * @property selectedGroupedItems
    * @type object[]
    * @default null
+   * @protected
    */
   @intersect('selectedItems', 'groupedItems')
   selectedGroupedItems;
 
   /**
+   * @property expandedGroupedItems
    * @type object[]
    * @default null
+   * @protected
    */
   @intersect('expandedItems', 'groupedItems')
   expandedGroupedItems;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/grouped-header.js
+++ b/addon/components/models-table/grouped-header.js
@@ -32,16 +32,14 @@ export default
 @tagName('tr')
 class GroupedHeaderComponent extends Component {
   /**
-   * @type {groupedHeader}
+   * @type groupedHeader
    * @default null
-   * @property groupedHeader
    */
   groupedHeader = null;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @default null
    * @type object
    */
@@ -50,16 +48,13 @@ class GroupedHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
    * @default null
-   * @type boolean
    */
   useDataGrouping = null;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @default null
    * @type string
    */

--- a/addon/components/models-table/grouped-header.js
+++ b/addon/components/models-table/grouped-header.js
@@ -22,6 +22,7 @@ import layout from '../../templates/components/models-table/grouped-header';
  *   </MT.Table>
  *   {{! .... }}
  * </ModelsTable>
+ * ```
  *
  * @class ModelsTableGroupedHeader
  * @namespace Components
@@ -31,30 +32,38 @@ export default
 @templateLayout(layout)
 @tagName('tr')
 class GroupedHeaderComponent extends Component {
+
   /**
-   * @type groupedHeader
+   * One of the [ModelsTable.groupedHeaders](Components.ModelsTable.html#property_groupedHeaders)
+   *
+   * @property groupedHeader
+   * @type GroupedHeader[]
    * @default null
    */
   groupedHeader = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @default null
    * @type object
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @default null
    * @type string
    */

--- a/addon/components/models-table/no-data.js
+++ b/addon/components/models-table/no-data.js
@@ -54,26 +54,30 @@ export default
 @templateLayout(layout)
 @tagName('tr')
 class NoDataComponent extends Component {
+
   /**
+   * @property realColumnsCount
    * @type number
-   * @private
+   * @protected
    */
   @computed('columnsCount')
-  get realColumnsCount () {
+  get realColumnsCount() {
     return this.columnsCount + (this.displayGroupedValueAs === 'column' ? 1 : 0);
   }
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Equal to [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns).length
    *
-   * @type object[]
+   * @property columnsCount
+   * @type number
    * @default null
    */
   columnsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/no-data.js
+++ b/addon/components/models-table/no-data.js
@@ -55,8 +55,7 @@ export default
 @tagName('tr')
 class NoDataComponent extends Component {
   /**
-   * @property realColumnsCount
-   * @type {number}
+   * @type number
    * @private
    */
   @computed('columnsCount')
@@ -67,7 +66,6 @@ class NoDataComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type object[]
    * @default null
    */
@@ -76,7 +74,6 @@ class NoDataComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/page-size-select.js
+++ b/addon/components/models-table/page-size-select.js
@@ -28,30 +28,34 @@ export default
 @templateLayout(layout)
 class PageSizeSelectComponent extends Component {
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSizeOptions:property"}}ModelsTable.pageSizeOptions{{/crossLink}}
+   * Bound from [ModelsTable.pageSizeOptions](Components.ModelsTable.html#property_pageSizeOptions)
    *
-   * @type object[]
+   * @property pageSizeOptions
+   * @type SelectOption[]
    * @default null
    */
   pageSizeOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
+   * Bound from [ModelsTable.pageSize](Components.ModelsTable.html#property_pageSize)
    *
+   * @property pageSize
    * @type number
-   * @default null
+   * @default 10
    */
-  pageSize = null;
+  pageSize = 10;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
+   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/page-size-select.js
+++ b/addon/components/models-table/page-size-select.js
@@ -30,7 +30,6 @@ class PageSizeSelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSizeOptions:property"}}ModelsTable.pageSizeOptions{{/crossLink}}
    *
-   * @property pageSizeOptions
    * @type object[]
    * @default null
    */
@@ -39,7 +38,6 @@ class PageSizeSelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
    *
-   * @property pageSize
    * @type number
    * @default null
    */
@@ -48,14 +46,12 @@ class PageSizeSelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/pagination-numeric.js
+++ b/addon/components/models-table/pagination-numeric.js
@@ -28,77 +28,96 @@ export default
 @templateLayout(layout)
 class PaginationNumericComponent extends Component {
 
+  /**
+   * @property themePaginationWrapperClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.paginationWrapper') themePaginationWrapperClass;
 
+  /**
+   * @property themePaginationWrapperNumericClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.paginationWrapperNumeric') themePaginationWrapperNumericClass;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/collapseNumPaginationForPagesCount:property"}}ModelsTable.collapseNumPaginationForPagesCount{{/crossLink}}
+   * Bound from [ModelsTable.collapseNumPaginationForPagesCount](Components.ModelsTable.html#property_collapseNumPaginationForPagesCount)
    *
+   * @property collapseNumPaginationForPagesCount
    * @type number
    * @default null
    */
   collapseNumPaginationForPagesCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumber](Components.ModelsTable.html#property_currentPageNumber)
    *
+   * @property currentPageNumber
    * @type number
-   * @default null
+   * @default 1
    */
-  currentPageNumber = null;
+  currentPageNumber = 1;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
+   * Bound from [ModelsTable.showCurrentPageNumberSelect](Components.ModelsTable.html#property_showCurrentPageNumberSelect)
    *
+   * @property showCurrentPageNumberSelect
+   * @type boolean
    * @default null
    */
   showCurrentPageNumberSelect = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumberOptions](Components.ModelsTable.html#property_currentPageNumberOptions)
    *
-   * @type object[]
+   * @property currentPageNumberOptions
+   * @type SelectOption[]
    * @default null
    */
   currentPageNumberOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
+   * Bound from [ModelsTable.arrangedContentLength](Components.ModelsTable.html#property_arrangedContentLength)
    *
+   * @property recordsCount
    * @type number
    * @default null
    */
   recordsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
+   * Bound from [ModelsTable.pageSize](Components.ModelsTable.html#property_pageSize)
    *
+   * @property pageSize
    * @type number
-   * @default null
+   * @default 10
    */
-  pageSize = null;
+  pageSize = 10;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
+   * Bound from [ModelsTable.pagesCount](Components.ModelsTable.html#property_pagesCount)
    *
+   * @property pagesCount
    * @type number
    * @default null
    */
   pagesCount = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.gotoCustomPage:method"}}ModelsTable.actions.gotoCustomPage{{/crossLink}}
+   * Closure action [ModelsTable.gotoCustomPage](Components.ModelsTable.html#event_gotoCustomPage)
    *
    * @event goToPage
    */
   goToPage = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
@@ -106,11 +125,12 @@ class PaginationNumericComponent extends Component {
 
   /**
    * List of links to the page
-   * Used if {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}} is true
-   * @typedef {object} visiblePageNumber
-   * @property {boolean} isActive
+   * Used if [ModelsTable.useNumericPagination](Components.ModelsTable.html#property_useNumericPagination) is true
    *
-   * @type visiblePageNumber[]
+   * @type object[]
+   * @property visiblePageNumbers
+   * @default []
+   * @protected
    */
   @computed('pagesCount', 'currentPageNumber', 'collapseNumPaginationForPagesCount')
   get visiblePageNumbers() {
@@ -165,8 +185,8 @@ class PaginationNumericComponent extends Component {
     ));
   }
 
-
   /**
+   * @property inputId
    * @type string
    * @private
    */
@@ -175,6 +195,11 @@ class PaginationNumericComponent extends Component {
     return `${this.elementId}-page-number-select`;
   }
 
+  /**
+   * @event gotoCustomPage
+   * @param {number} pageNumber
+   * @protected
+   */
   @action
   gotoCustomPage(pageNumber) {
     this.goToPage(pageNumber);

--- a/addon/components/models-table/pagination-numeric.js
+++ b/addon/components/models-table/pagination-numeric.js
@@ -37,7 +37,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/collapseNumPaginationForPagesCount:property"}}ModelsTable.collapseNumPaginationForPagesCount{{/crossLink}}
    *
-   * @property collapseNumPaginationForPagesCount
    * @type number
    * @default null
    */
@@ -46,7 +45,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
    *
-   * @property currentPageNumber
    * @type number
    * @default null
    */
@@ -55,8 +53,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
    *
-   * @property showCurrentPageNumberSelect
-   * @type boolean
    * @default null
    */
   showCurrentPageNumberSelect = null;
@@ -64,7 +60,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
    *
-   * @property currentPageNumberOptions
    * @type object[]
    * @default null
    */
@@ -73,7 +68,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
    *
-   * @property recordsCount
    * @type number
    * @default null
    */
@@ -82,7 +76,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
    *
-   * @property pageSize
    * @type number
    * @default null
    */
@@ -91,7 +84,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
    *
-   * @property pagesCount
    * @type number
    * @default null
    */
@@ -107,7 +99,6 @@ class PaginationNumericComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -117,12 +108,9 @@ class PaginationNumericComponent extends Component {
    * List of links to the page
    * Used if {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}} is true
    * @typedef {object} visiblePageNumber
-   * @property {boolean} isLink
    * @property {boolean} isActive
-   * @property {string} label
    *
-   * @type {visiblePageNumber[]}
-   * @property visiblePageNumbers
+   * @type visiblePageNumber[]
    */
   @computed('pagesCount', 'currentPageNumber', 'collapseNumPaginationForPagesCount')
   get visiblePageNumbers() {
@@ -179,7 +167,6 @@ class PaginationNumericComponent extends Component {
 
 
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/pagination-simple.js
+++ b/addon/components/models-table/pagination-simple.js
@@ -27,69 +27,87 @@ export default
 @templateLayout(layout)
 class PaginationSimpleComponent extends Component {
 
+  /**
+   * @property themePaginationWrapperClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.paginationWrapper') themePaginationWrapperClass;
 
+  /**
+   * @property themePaginationWrapperDefaultClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.paginationWrapperDefault') themePaginationWrapperDefaultClass;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumber](Components.ModelsTable.html#property_currentPageNumber)
    *
+   * @property currentPageNumber
    * @type number
-   * @default null
+   * @default 1
    */
-  currentPageNumber = null;
+  currentPageNumber = 1;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
+   * Bound from [ModelsTable.arrangedContentLength](Components.ModelsTable.html#property_arrangedContentLength)
    *
+   * @property recordsCount
    * @type number
    * @default null
    */
   recordsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
+   * Bound from [ModelsTable.pagesCount](Components.ModelsTable.html#property_pagesCount)
    *
+   * @property pagesCount
    * @type number
    * @default null
    */
   pagesCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
+   * Bound from [ModelsTable.currentPageNumberOptions](Components.ModelsTable.html#property_currentPageNumberOptions)
    *
-   * @type object[]
+   * @property currentPageNumberOptions
+   * @type SelectOption[]
    * @default null
    */
   currentPageNumberOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
+   * Bound from [ModelsTable.showCurrentPageNumberSelect](Components.ModelsTable.html#property_showCurrentPageNumberSelect)
    *
+   * @property showCurrentPageNumberSelect
+   * @type boolean
    * @default null
    */
   showCurrentPageNumberSelect = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.gotoCustomPage:method"}}ModelsTable.actions.gotoCustomPage{{/crossLink}}
+   * Closure action [ModelsTable.gotoCustomPage](Components.ModelsTable.html#event_gotoCustomPage)
    *
    * @event goToPage
    */
   goToPage = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
+   * Bound from [ModelsTable.pageSize](Components.ModelsTable.html#property_pageSize)
    *
+   * @property pageSize
    * @type number
-   * @default null
+   * @default 10
    */
-  pageSize = null;
+  pageSize = 10;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
@@ -98,18 +116,27 @@ class PaginationSimpleComponent extends Component {
   /**
    * Are buttons "Back" and "First" enabled
    *
+   * @property gotoBackEnabled
+   * @type boolean
+   * @default false
+   * @protected
    */
   @gt('currentPageNumber', 1) gotoBackEnabled;
 
   /**
    * Are buttons "Next" and "Last" enabled
    *
+   * @property gotoForwardEnabled
+   * @type boolean
+   * @default false
+   * @protected
    */
   @computed('currentPageNumber', 'pagesCount')
   get gotoForwardEnabled() {
     return this.currentPageNumber < this.pagesCount;
   }
   /**
+   * @property inputId
    * @type string
    * @private
    */
@@ -118,6 +145,10 @@ class PaginationSimpleComponent extends Component {
     return `${this.elementId}-page-number-select`;
   }
 
+  /**
+   * @event gotoFirst
+   * @protected
+   */
   @action
   gotoFirst() {
     if (!this.gotoBackEnabled) {
@@ -126,6 +157,10 @@ class PaginationSimpleComponent extends Component {
     this.goToPage(1);
   }
 
+  /**
+   * @event gotoPrev
+   * @protected
+   */
   @action
   gotoPrev() {
     if (!this.gotoBackEnabled) {
@@ -136,6 +171,10 @@ class PaginationSimpleComponent extends Component {
     }
   }
 
+  /**
+   * @event gotoNext
+   * @protected
+   */
   @action
   gotoNext() {
     if (!this.gotoForwardEnabled) {
@@ -147,6 +186,10 @@ class PaginationSimpleComponent extends Component {
     }
   }
 
+  /**
+   * @event gotoLast
+   * @protected
+   */
   @action
   gotoLast() {
     if (!this.gotoForwardEnabled) {
@@ -158,11 +201,20 @@ class PaginationSimpleComponent extends Component {
     this.goToPage(pageNumber);
   }
 
+  /**
+   * @event gotoPage
+   * @param {number} pageNumber
+   * @protected
+   */
   @action
   gotoPage(pageNumber) {
     this.goToPage(pageNumber);
   }
 
+  /**
+   * @event noop
+   * @protected
+   */
   @action
   noop() {}
 }

--- a/addon/components/models-table/pagination-simple.js
+++ b/addon/components/models-table/pagination-simple.js
@@ -36,7 +36,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumber:property"}}ModelsTable.currentPageNumber{{/crossLink}}
    *
-   * @property currentPageNumber
    * @type number
    * @default null
    */
@@ -45,7 +44,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
    *
-   * @property recordsCount
    * @type number
    * @default null
    */
@@ -54,7 +52,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pagesCount:property"}}ModelsTable.pagesCount{{/crossLink}}
    *
-   * @property pagesCount
    * @type number
    * @default null
    */
@@ -63,7 +60,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentPageNumberOptions:property"}}ModelsTable.currentPageNumberOptions{{/crossLink}}
    *
-   * @property currentPageNumberOptions
    * @type object[]
    * @default null
    */
@@ -72,8 +68,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/showCurrentPageNumberSelect:property"}}ModelsTable.showCurrentPageNumberSelect{{/crossLink}}
    *
-   * @property showCurrentPageNumberSelect
-   * @type boolean
    * @default null
    */
   showCurrentPageNumberSelect = null;
@@ -88,7 +82,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/pageSize:property"}}ModelsTable.pageSize{{/crossLink}}
    *
-   * @property pageSize
    * @type number
    * @default null
    */
@@ -97,7 +90,6 @@ class PaginationSimpleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -106,23 +98,18 @@ class PaginationSimpleComponent extends Component {
   /**
    * Are buttons "Back" and "First" enabled
    *
-   * @type boolean
-   * @property gotoBackEnabled
    */
   @gt('currentPageNumber', 1) gotoBackEnabled;
 
   /**
    * Are buttons "Next" and "Last" enabled
    *
-   * @type boolean
-   * @property gotoForwardEnabled
    */
   @computed('currentPageNumber', 'pagesCount')
   get gotoForwardEnabled() {
     return this.currentPageNumber < this.pagesCount;
   }
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/row-expand.js
+++ b/addon/components/models-table/row-expand.js
@@ -39,7 +39,6 @@ export default
 class RowExpandComponent extends Component {
 
   /**
-   * @property indexedClass
    * @type string
    * @default ''
    */
@@ -50,9 +49,6 @@ class RowExpandComponent extends Component {
   }
 
   /**
-   * @type boolean
-   * @property isSelected
-   * @default false
    */
   @className('selected-expand')
   @computed('selectedItems.[]', 'record')
@@ -63,7 +59,6 @@ class RowExpandComponent extends Component {
   /**
    * Row's index
    *
-   * @property index
    * @type number
    * @default null
    */
@@ -72,7 +67,6 @@ class RowExpandComponent extends Component {
   /**
    * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
    *
-   * @property record
    * @type object
    * @default null
    */
@@ -81,7 +75,6 @@ class RowExpandComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedRowComponent:property"}}ModelsTable.expandedRowComponent{{/crossLink}}
    *
-   * @property expandedRowComponent
    * @type string
    * @default null
    */
@@ -90,7 +83,6 @@ class RowExpandComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -106,7 +98,6 @@ class RowExpandComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/row-expand.js
+++ b/addon/components/models-table/row-expand.js
@@ -39,8 +39,9 @@ export default
 class RowExpandComponent extends Component {
 
   /**
+   * @property indexedClass
    * @type string
-   * @default ''
+   * @protected
    */
   @className
   @computed('index')
@@ -49,6 +50,9 @@ class RowExpandComponent extends Component {
   }
 
   /**
+   * @property isSelected
+   * @type boolean
+   * @protected
    */
   @className('selected-expand')
   @computed('selectedItems.[]', 'record')
@@ -59,45 +63,49 @@ class RowExpandComponent extends Component {
   /**
    * Row's index
    *
+   * @property index
    * @type number
    * @default null
    */
   index = null;
 
   /**
-   * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
+   * One of the [data](Components.ModelsTable.html#property_data)
    *
+   * @property record
    * @type object
    * @default null
    */
   record = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedRowComponent:property"}}ModelsTable.expandedRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.expandedRowComponent](Components.ModelsTable.html#property_expandedRowComponent)
    *
-   * @type string
+   * @property expandedRowComponent
    * @default null
    */
   expandedRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
    *
    * @event clickOnRow
    */
   clickOnRow = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/row-filtering-cell.js
+++ b/addon/components/models-table/row-filtering-cell.js
@@ -51,14 +51,12 @@ class RowFilteringCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * @property column
    * @default null
    * @type ModelsTableColumn
    */
@@ -67,7 +65,6 @@ class RowFilteringCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @default null
    * @type object[]
    */
@@ -76,7 +73,6 @@ class RowFilteringCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @default null
    * @type object[]
    */
@@ -104,7 +100,6 @@ class RowFilteringCellComponent extends Component {
   toggleAllSelection = null;
 
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/row-filtering-cell.js
+++ b/addon/components/models-table/row-filtering-cell.js
@@ -33,15 +33,35 @@ export default
 @tagName('th')
 class RowFilteringCellComponent extends Component {
 
+  /**
+   * @property themeTheadCellClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.theadCell') themeTheadCellClass;
 
+  /**
+   * @property columnClassName
+   * @type string
+   * @protected
+   */
   @className
   @alias('column.className') columnClassName;
 
+  /**
+   * @property colspan
+   * @type number
+   * @protected
+   */
   @attribute
   @readOnly('column.realColspanForFilterCell') colspan;
 
+  /**
+   * @property filteringClassName
+   * @type string
+   * @protected
+   */
   @className
   @computed('column.useFilter', 'themeInstance.theadCellNoFiltering')
   get filteringClassName () {
@@ -49,65 +69,74 @@ class RowFilteringCellComponent extends Component {
   }
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
+   * @property column
    * @default null
-   * @type ModelsTableColumn
+   * @type Utils.ModelsTableColumn
    */
   column = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @default null
    * @type object[]
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @default null
    * @type object[]
    */
   expandedItems = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */
   toggleAllSelection = null;
 
   /**
+   * @property inputId
    * @type string
-   * @private
+   * @protected
    */
   @computed('elementId')
   get inputId() {
     return `${this.elementId}-global-filter`;
   }
 
+  /**
+   * @event noop
+   * @protected
+   */
   @action
   noop() {}
 }

--- a/addon/components/models-table/row-filtering.js
+++ b/addon/components/models-table/row-filtering.js
@@ -57,92 +57,100 @@ export default
 @tagName('tr')
 class RowFilteringComponent extends Component {
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Bound from [ModelsTable.processedColumns](Components.ModelsTable.html#property_processedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   processedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @default null
    * @type object[]
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @default null
    * @type object[]
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @default null
    * @type string
    */
   displayGroupedValueAs = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */
   toggleAllSelection = null;
 
   /**
+   * @property shownColumns
    * @type object[]
-   * @private
-   * @readonly
+   * @protected
    */
   @shownColumns('colspanForFilterCell') shownColumns;
 }

--- a/addon/components/models-table/row-filtering.js
+++ b/addon/components/models-table/row-filtering.js
@@ -59,7 +59,6 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -68,7 +67,6 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -77,7 +75,6 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -86,7 +83,6 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @default null
    * @type object[]
    */
@@ -95,7 +91,6 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @default null
    * @type object[]
    */
@@ -104,16 +99,13 @@ class RowFilteringComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
    * @default null
-   * @type boolean
    */
   useDataGrouping = null;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @default null
    * @type string
    */
@@ -148,7 +140,6 @@ class RowFilteringComponent extends Component {
   toggleAllSelection = null;
 
   /**
-   * @property shownColumns
    * @type object[]
    * @private
    * @readonly

--- a/addon/components/models-table/row-group-toggle.js
+++ b/addon/components/models-table/row-group-toggle.js
@@ -15,22 +15,29 @@ import {action} from '@ember/object';
 export default
 @templateLayout(layout)
 class RowGroupToggleComponent extends Component {
+
   /**
    * Determines if `stopPropagation` should be called for event-handlers in the current component
    *
+   * @property stopEventsPropagation
+   * @type boolean
+   * @default true
    */
   stopEventsPropagation = true;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTableRowGrouping/groupIsCollapsed:property"}}groupIsCollapsed{{/crossLink}}
+   * Bound from [groupIsCollapsed](Components.ModelsTableRowGrouping.html#property_groupIsCollapsed)
    *
+   * @property groupIsCollapsed
+   * @type boolean
    * @default null
    */
   groupIsCollapsed = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTableRowGrouping/groupedValue:property"}}groupedValue{{/crossLink}}
+   * Bound from [groupedValue](Components.ModelsTableRowGrouping.html#property_groupedValue)
    *
+   * @property groupedValue
    * @type *
    * @default null
    */
@@ -41,6 +48,7 @@ class RowGroupToggleComponent extends Component {
    *
    * If rows group is last on the page, not all it's items may be shown. Use `visibleGroupedItems` to get rows group items shown on the current table's page
    *
+   * @property groupedItems
    * @type object[]
    * @default null
    */
@@ -49,6 +57,7 @@ class RowGroupToggleComponent extends Component {
   /**
    * List of rows group items shown on the current table page
    *
+   * @property visibleGroupedItems
    * @type object[]
    * @default null
    */
@@ -57,6 +66,7 @@ class RowGroupToggleComponent extends Component {
   /**
    * List of selected rows group items
    *
+   * @property selectedGroupedItems
    * @type object[]
    * @default null
    */
@@ -65,59 +75,64 @@ class RowGroupToggleComponent extends Component {
   /**
    * List of expanded rows group items
    *
+   * @property expandedGroupedItems
    * @type object[]
    * @default null
    */
   expandedGroupedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
   displayGroupedValueAs = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRows:method"}}ModelsTable.actions.toggleGroupedRows{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
    *
    * @event toggleGroupedRows
    */
   toggleGroupedRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsSelection:method"}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
    *
    * @event toggleGroupedRowsSelection
    */
   toggleGroupedRowsSelection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsExpands:method"}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
    *
    * @event toggleGroupedRowsExpands
    */
@@ -126,9 +141,8 @@ class RowGroupToggleComponent extends Component {
   /**
    * Calls passed `toggleGroupedRows`
    *
-   * @method actions.toggleGroupedRows
+   * @event toggleGroupedRows
    * @param {Event} e user-interaction event
-   * @returns {undefined}
    */
   @action
   doToggleGroupedRows(e) {
@@ -141,9 +155,8 @@ class RowGroupToggleComponent extends Component {
   /**
    * Calls passed `toggleGroupedRowsSelection`
    *
-   * @method actions.toggleGroupedRowsSelection
+   * @event toggleGroupedRowsSelection
    * @param {Event} e user-interaction event
-   * @returns {undefined}
    */
   @action
   doToggleGroupedRowsSelection(e) {
@@ -156,9 +169,8 @@ class RowGroupToggleComponent extends Component {
   /**
    * Calls passed `toggleGroupedRowsExpands`
    *
-   * @method actions.toggleGroupedRowsExpands
+   * @event toggleGroupedRowsExpands
    * @param {Event} e user-interaction event
-   * @returns {undefined}
    */
   @action
   doToggleGroupedRowsExpands(e) {

--- a/addon/components/models-table/row-group-toggle.js
+++ b/addon/components/models-table/row-group-toggle.js
@@ -18,17 +18,12 @@ class RowGroupToggleComponent extends Component {
   /**
    * Determines if `stopPropagation` should be called for event-handlers in the current component
    *
-   * @property stopEventsPropagation
-   * @type boolean
-   * @default true
    */
   stopEventsPropagation = true;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTableRowGrouping/groupIsCollapsed:property"}}groupIsCollapsed{{/crossLink}}
    *
-   * @property groupIsCollapsed
-   * @type boolean
    * @default null
    */
   groupIsCollapsed = null;
@@ -37,7 +32,6 @@ class RowGroupToggleComponent extends Component {
    * Bound from {{#crossLink "Components.ModelsTableRowGrouping/groupedValue:property"}}groupedValue{{/crossLink}}
    *
    * @type *
-   * @property groupedValue
    * @default null
    */
   groupedValue = null;
@@ -48,7 +42,6 @@ class RowGroupToggleComponent extends Component {
    * If rows group is last on the page, not all it's items may be shown. Use `visibleGroupedItems` to get rows group items shown on the current table's page
    *
    * @type object[]
-   * @property groupedItems
    * @default null
    */
   groupedItems = null;
@@ -57,7 +50,6 @@ class RowGroupToggleComponent extends Component {
    * List of rows group items shown on the current table page
    *
    * @type object[]
-   * @property visibleGroupedItems
    * @default null
    */
   visibleGroupedItems = null;
@@ -66,7 +58,6 @@ class RowGroupToggleComponent extends Component {
    * List of selected rows group items
    *
    * @type object[]
-   * @property selectedGroupedItems
    * @default null
    */
   selectedGroupedItems = null;
@@ -75,7 +66,6 @@ class RowGroupToggleComponent extends Component {
    * List of expanded rows group items
    *
    * @type object[]
-   * @property expandedGroupedItems
    * @default null
    */
   expandedGroupedItems = null;
@@ -83,7 +73,6 @@ class RowGroupToggleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -92,7 +81,6 @@ class RowGroupToggleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
@@ -101,7 +89,6 @@ class RowGroupToggleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -110,7 +97,6 @@ class RowGroupToggleComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/row-grouping.js
+++ b/addon/components/models-table/row-grouping.js
@@ -20,10 +20,16 @@ export default
 @tagName('tr')
 class RowGroupingComponent extends Component {
 
+  /**
+   * @property themeGroupingRowClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.groupingRow') themeGroupingRowClass;
 
   /**
+   * @property groupedValue
    * @type *
    * @default null
    */
@@ -32,6 +38,8 @@ class RowGroupingComponent extends Component {
   /**
    * Determines if rows group is collapsed (bound from the parent component template)
    *
+   * @property groupIsCollapsed
+   * @type boolean
    * @default null
    */
   groupIsCollapsed = null;
@@ -39,16 +47,17 @@ class RowGroupingComponent extends Component {
   /**
    * Rows count in the rows group
    *
+   * @property groupedLength
    * @type number
    * @default null
    */
   groupedLength = null;
 
   /**
+   * @property cellColspan
    * @type number
    * @default null
-   * @private
-   * @readonly
+   * @protected
    */
   @computed('displayGroupedValueAs', 'visibleProcessedColumns.length')
   get cellColspan() {
@@ -56,87 +65,98 @@ class RowGroupingComponent extends Component {
   }
 
   /**
+   * @property groupedItems
    * @type object[]
    * @default null
    */
   groupedItems = null;
 
   /**
+   * @property visibleGroupedItems
    * @type object[]
    * @default null
    */
   visibleGroupedItems = null;
 
   /**
+   * @property selectedGroupedItems
    * @type object[]
-   * @default null
+   * @default []
+   * @protected
    */
   @intersect('selectedItems', 'groupedItems')
   selectedGroupedItems;
 
   /**
+   * @property expandedGroupedItems
    * @type object[]
-   * @default null
+   * @default []
+   * @protected
    */
   @intersect('expandedItems', 'groupedItems')
   expandedGroupedItems;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRows:method"}}ModelsTable.actions.toggleGroupedRows{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
    *
    * @event toggleGroupedRows
    */
   toggleGroupedRows = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
   displayGroupedValueAs = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupingRowComponent:property"}}ModelsTable.groupingRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupingRowComponent](Components.ModelsTable.html#property_groupingRowComponent)
    *
+   * @property groupingRowComponent
    * @type string
    * @default null
    */
   groupingRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsSelection:method"}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
    *
    * @event toggleGroupedRowsSelection
    */
   toggleGroupedRowsSelection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsExpands:method"}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
    *
    * @event toggleGroupedRowsExpands
    */

--- a/addon/components/models-table/row-grouping.js
+++ b/addon/components/models-table/row-grouping.js
@@ -24,7 +24,6 @@ class RowGroupingComponent extends Component {
   @alias('themeInstance.groupingRow') themeGroupingRowClass;
 
   /**
-   * @property groupedValue
    * @type *
    * @default null
    */
@@ -33,9 +32,7 @@ class RowGroupingComponent extends Component {
   /**
    * Determines if rows group is collapsed (bound from the parent component template)
    *
-   * @type boolean
    * @default null
-   * @property groupIsCollapsed
    */
   groupIsCollapsed = null;
 
@@ -44,12 +41,10 @@ class RowGroupingComponent extends Component {
    *
    * @type number
    * @default null
-   * @property groupedLength
    */
   groupedLength = null;
 
   /**
-   * @property cellColspan
    * @type number
    * @default null
    * @private
@@ -62,21 +57,18 @@ class RowGroupingComponent extends Component {
 
   /**
    * @type object[]
-   * @property groupedItems
    * @default null
    */
   groupedItems = null;
 
   /**
    * @type object[]
-   * @property visibleGroupedItems
    * @default null
    */
   visibleGroupedItems = null;
 
   /**
    * @type object[]
-   * @property selectedGroupedItems
    * @default null
    */
   @intersect('selectedItems', 'groupedItems')
@@ -84,7 +76,6 @@ class RowGroupingComponent extends Component {
 
   /**
    * @type object[]
-   * @property expandedGroupedItems
    * @default null
    */
   @intersect('expandedItems', 'groupedItems')
@@ -93,7 +84,6 @@ class RowGroupingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -102,7 +92,6 @@ class RowGroupingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -118,7 +107,6 @@ class RowGroupingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
@@ -129,14 +117,12 @@ class RowGroupingComponent extends Component {
    *
    * @type string
    * @default null
-   * @property groupingRowComponent
    */
   groupingRowComponent = null;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/row-sorting-cell.js
+++ b/addon/components/models-table/row-sorting-cell.js
@@ -33,12 +33,27 @@ export default
 @tagName('th')
 class RowSortingCellComponent extends Component {
 
+  /**
+   * @property themeTheadCellClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.theadCell') themeTheadCellClass;
 
+  /**
+   * @property columnClassName
+   * @type string
+   * @protected
+   */
   @className
   @alias('column.className') columnClassName;
 
+  /**
+   * @property colspan
+   * @type number
+   * @protected
+   */
   @attribute
   @readOnly('column.realColspanForSortCell') colspan;
 
@@ -49,66 +64,71 @@ class RowSortingCellComponent extends Component {
   }
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @default null
    * @type object[]
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @default null
    * @type object[]
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property data
    * @default null
    * @type object[]
    */
   data = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
   /**
+   * @property column
    * @default null
-   * @type ModelsTableColumn
+   * @type Utils.ModelsTableColumn
    */
   column = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */

--- a/addon/components/models-table/row-sorting-cell.js
+++ b/addon/components/models-table/row-sorting-cell.js
@@ -51,7 +51,6 @@ class RowSortingCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -60,7 +59,6 @@ class RowSortingCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @default null
    * @type object[]
    */
@@ -69,7 +67,6 @@ class RowSortingCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @default null
    * @type object[]
    */
@@ -78,7 +75,6 @@ class RowSortingCellComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @default null
    * @type object[]
    */
@@ -92,7 +88,6 @@ class RowSortingCellComponent extends Component {
   sort = null;
 
   /**
-   * @property column
    * @default null
    * @type ModelsTableColumn
    */

--- a/addon/components/models-table/row-sorting.js
+++ b/addon/components/models-table/row-sorting.js
@@ -58,129 +58,146 @@ export default
 @templateLayout(layout)
 @tagName('tr')
 class RowSortingComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type object[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Bound from [ModelsTable.processedColumns](Components.ModelsTable.html#property_processedColumns)
    *
-   * @type object[]
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   processedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @default null
    * @type object[]
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @default null
    * @type object[]
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @default null
    * @type object[]
    */
   data = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @default null
    * @type string
    */
   displayGroupedValueAs = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupHeaderCellComponent](Components.ModelsTable.html#property_groupHeaderCellComponent)
    *
+   * @property groupHeaderCellComponent
    * @default null
    * @type object
    */
   groupHeaderCellComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @default null
    * @type object
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */
   toggleAllSelection = null;
 
   /**
-   * @type object[]
-   * @private
-   * @readonly
+   * @property shownColumns
+   * @type Utils.ModelsTableColumn[]
+   * @protected
    */
   @shownColumns('colspanForSortCell') shownColumns;
 
   /**
+   * @property currentGroupingPropertyNameTitlelized
    * @type string
-   * @private
+   * @protected
    */
   @computed('currentGroupingPropertyName')
   get currentGroupingPropertyNameTitlelized() {
     return propertyNameToTitle(this.currentGroupingPropertyName);
   }
 
+  /**
+   * @event doSort
+   * @param {Utils.ModelsTableColumn} column
+   */
   @action
   doSort(column) {
     this.sort(column);

--- a/addon/components/models-table/row-sorting.js
+++ b/addon/components/models-table/row-sorting.js
@@ -61,7 +61,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type object[]
    * @default null
    */
@@ -70,7 +69,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type object[]
    * @default null
    */
@@ -79,7 +77,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -88,7 +85,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @default null
    * @type object[]
    */
@@ -97,7 +93,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @default null
    * @type object[]
    */
@@ -106,7 +101,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @default null
    * @type object[]
    */
@@ -115,16 +109,13 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
    * @default null
-   * @type boolean
    */
   useDataGrouping = null;
 
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @default null
    * @type string
    */
@@ -133,7 +124,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
    *
-   * @property groupHeaderCellComponent
    * @default null
    * @type object
    */
@@ -142,7 +132,6 @@ class RowSortingComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @default null
    * @type object
    */
@@ -177,7 +166,6 @@ class RowSortingComponent extends Component {
   toggleAllSelection = null;
 
   /**
-   * @property shownColumns
    * @type object[]
    * @private
    * @readonly
@@ -185,7 +173,6 @@ class RowSortingComponent extends Component {
   @shownColumns('colspanForSortCell') shownColumns;
 
   /**
-   * @property currentGroupingPropertyNameTitlelized
    * @type string
    * @private
    */

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -63,7 +63,6 @@ export default
 @tagName('tr')
 class RowComponent extends Component {
   /**
-   * @property rowSelectedClass
    * @private
    * @type string
    */
@@ -74,7 +73,6 @@ class RowComponent extends Component {
   }
 
   /**
-   * @property rowExpandedClass
    * @private
    * @type string
    */
@@ -85,7 +83,6 @@ class RowComponent extends Component {
   }
 
   /**
-   * @property rowspanForFirstCell
    * @type number
    * @private
    */
@@ -98,7 +95,6 @@ class RowComponent extends Component {
   /**
    * Row's index
    *
-   * @property index
    * @type number
    * @default null
    */
@@ -107,7 +103,6 @@ class RowComponent extends Component {
   /**
    * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
    *
-   * @property record
    * @type object
    * @default null
    */
@@ -116,7 +111,6 @@ class RowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -125,7 +119,6 @@ class RowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -134,7 +127,6 @@ class RowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/collapsedGroupValues:property"}}ModelsTable.collapsedGroupValues{{/crossLink}}
    *
-   * @property collapsedGroupValues
    * @type array
    * @default null
    */
@@ -142,7 +134,6 @@ class RowComponent extends Component {
 
   /**
    * @type object[]
-   * @property groupedItems
    * @default null
    * @private
    */
@@ -150,7 +141,6 @@ class RowComponent extends Component {
 
   /**
    * @type object[]
-   * @property visibleGroupedItems
    * @default null
    * @private
    */
@@ -158,7 +148,6 @@ class RowComponent extends Component {
 
   /**
    * @type object[]
-   * @property selectedGroupedItems
    * @default null
    */
   @intersect('selectedItems', 'groupedItems')
@@ -166,7 +155,6 @@ class RowComponent extends Component {
 
   /**
    * @type object[]
-   * @property expandedGroupedItems
    * @default null
    */
   @intersect('expandedItems', 'groupedItems')
@@ -174,24 +162,17 @@ class RowComponent extends Component {
 
   /**
    * @type object[]
-   * @property expandedGroupItems
    * @default null
    */
   @intersect('expandedItems', 'visibleGroupedItems')
   expandedGroupItems;
 
   /**
-   * @property isFirstGroupedRow
-   * @type boolean
-   * @default false
    */
   @equal('index', 0)
   isFirstGroupedRow;
 
   /**
-   * @type boolean
-   * @property isSelected
-   * @default false
    */
   @computed('selectedItems.[]', 'record')
   get isSelected() {
@@ -199,9 +180,6 @@ class RowComponent extends Component {
   }
 
   /**
-   * @type boolean
-   * @property isExpanded
-   * @default false
    */
   @computed('expandedItems.[]', 'record')
   get isExpanded() {
@@ -210,7 +188,6 @@ class RowComponent extends Component {
 
   /**
    * @type *
-   * @property groupedValue
    * @default null
    */
   groupedValue = null;
@@ -219,7 +196,6 @@ class RowComponent extends Component {
    * Rows group size where current row is
    *
    * @type number
-   * @property groupedLength
    * @default null
    */
   groupedLength = null;
@@ -297,7 +273,6 @@ class RowComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -306,9 +281,6 @@ class RowComponent extends Component {
   /**
    * Is the row in edit mode
    *
-   * @property isEditRow
-   * @type boolean
-   * @default false
    */
   isEditRow = false;
 

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -62,9 +62,12 @@ export default
 @templateLayout(layout)
 @tagName('tr')
 class RowComponent extends Component {
+
   /**
-   * @private
+   * @property rowSelectedClass
+   * @protected
    * @type string
+   * @default ''
    */
   @className
   @computed('isSelected', 'themeInstance.selectedRow')
@@ -73,8 +76,10 @@ class RowComponent extends Component {
   }
 
   /**
-   * @private
+   * @property rowExpandedClass
+   * @protected
    * @type string
+   * @default ''
    */
   @className
   @computed('isExpanded', 'themeInstance.expandedRow')
@@ -83,8 +88,9 @@ class RowComponent extends Component {
   }
 
   /**
+   * @property rowspanForFirstCell
    * @type number
-   * @private
+   * @protected
    */
   @computed('visibleGroupedItems.length', 'expandedGroupItems.length', 'groupSummaryRowComponent')
   get rowspanForFirstCell() {
@@ -95,44 +101,50 @@ class RowComponent extends Component {
   /**
    * Row's index
    *
+   * @property index
    * @type number
    * @default null
    */
   index = null;
 
   /**
-   * One of the {{#crossLink "Components.ModelsTable/data:property"}}data{{/crossLink}}
+   * One of the [data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @type object
    * @default null
    */
   record = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/collapsedGroupValues:property"}}ModelsTable.collapsedGroupValues{{/crossLink}}
+   * Bound from [ModelsTable.collapsedGroupValues](Components.ModelsTable.html#property_collapsedGroupValues)
    *
+   * @property collapsedGroupValues
    * @type array
    * @default null
    */
   collapsedGroupValues = null;
 
   /**
+   * @property groupedItems
    * @type object[]
    * @default null
    * @private
@@ -140,6 +152,7 @@ class RowComponent extends Component {
   groupedItems = null;
 
   /**
+   * @property visibleGroupedItems
    * @type object[]
    * @default null
    * @private
@@ -147,32 +160,46 @@ class RowComponent extends Component {
   visibleGroupedItems = null;
 
   /**
+   * @protected
+   * @property selectedGroupedItems
    * @type object[]
-   * @default null
+   * @default []
    */
   @intersect('selectedItems', 'groupedItems')
   selectedGroupedItems;
 
   /**
+   * @protected
+   * @property expandedGroupedItems
    * @type object[]
-   * @default null
+   * @default []
    */
   @intersect('expandedItems', 'groupedItems')
   expandedGroupedItems;
 
   /**
+   * @property expandedGroupItems
+   * @protected
    * @type object[]
-   * @default null
+   * @default []
    */
   @intersect('expandedItems', 'visibleGroupedItems')
   expandedGroupItems;
 
   /**
+   * @property isFirstGroupedRow
+   * @protected
+   * @type number
+   * @default false
    */
   @equal('index', 0)
   isFirstGroupedRow;
 
   /**
+   * @protected
+   * @property isSelected
+   * @type boolean
+   * @default false
    */
   @computed('selectedItems.[]', 'record')
   get isSelected() {
@@ -180,6 +207,10 @@ class RowComponent extends Component {
   }
 
   /**
+   * @protected
+   * @property isExpanded
+   * @type boolean
+   * @default false
    */
   @computed('expandedItems.[]', 'record')
   get isExpanded() {
@@ -187,6 +218,7 @@ class RowComponent extends Component {
   }
 
   /**
+   * @property groupedValue
    * @type *
    * @default null
    */
@@ -195,83 +227,84 @@ class RowComponent extends Component {
   /**
    * Rows group size where current row is
    *
+   * @property groupedLength
    * @type number
    * @default null
    */
   groupedLength = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
    *
    * @event clickOnRow
    */
   clickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.doubleClickOnRow:method"}}ModelsTable.actions.doubleClickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.doubleClickOnRow](Components.ModelsTable.html#event_doubleClickOnRow)
    *
    * @event doubleClickOnRow
    */
   doubleClickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.hoverOnRow:method"}}ModelsTable.actions.hoverOnRow{{/crossLink}}
+   * Closure action [ModelsTable.hoverOnRow](Components.ModelsTable.html#event_hoverOnRow)
    *
    * @event hoverOnRow
    */
   hoverOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.outRow:method"}}ModelsTable.actions.outRow{{/crossLink}}
+   * Closure action [ModelsTable.outRow](Components.ModelsTable.html#event_outRow)
    *
    * @event outRow
    */
   outRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsSelection:method"}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
    *
    * @event toggleGroupedRowsSelection
    */
   toggleGroupedRowsSelection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsExpands:method"}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
    *
    * @event toggleGroupedRowsExpands
    */
   toggleGroupedRowsExpands = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
    * @type object
    * @default null
@@ -312,16 +345,28 @@ class RowComponent extends Component {
     super.willDestroyElement(...arguments);
   }
 
+  /**
+   * @protected
+   * @event handleMouseEnter
+   */
   @action
   handleMouseEnter() {
     this.enter();
   }
 
+  /**
+   * @protected
+   * @event handleMouseLeave
+   */
   @action
   handleMouseLeave() {
     this.leave();
   }
 
+  /**
+   * @protected
+   * @event doToggleGroupedRows
+   */
   @action
   doToggleGroupedRows() {
     this.toggleGroupedRows(this.groupedValue);
@@ -330,8 +375,7 @@ class RowComponent extends Component {
   /**
    * Place a row into edit mode
    *
-   * @returns {undefined}
-   * @method actions.editRow
+   * @event editRow
    */
   @action
   editRow() {
@@ -341,8 +385,7 @@ class RowComponent extends Component {
   /**
    * Indicate a row has been saved, the row is no longer in edit mode
    *
-   * @returns {undefined}
-   * @method actions.saveRow
+   * @event saveRow
    */
   @action
   saveRow() {
@@ -352,8 +395,7 @@ class RowComponent extends Component {
   /**
    * Indicate the edit on the row has been cancelled, the row is no longer in edit mode
    *
-   * @returns {undefined}
-   * @method actions.cancelEditRow
+   * @event cancelEditRow
    */
   @action
   cancelEditRow() {

--- a/addon/components/models-table/select.js
+++ b/addon/components/models-table/select.js
@@ -10,29 +10,45 @@ import layout from '../../templates/components/models-table/select';
  * @class ModelsTableSelect
  * @namespace Components
  * @extends Ember.Component
- * @private
  */
 export default
 @templateLayout(layout)
 @tagName('select')
 class SelectComponent extends Component {
 
+  /**
+   * @property disabled
+   * @type boolean
+   * @protected
+   */
   @attribute
   @empty('options') disabled;
 
+  /**
+   * @property themeInputClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.input') themeInputClass;
 
+  /**
+   * @property themeSelectClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.select') themeSelectClass;
 
   /**
+   * @property type
    * @type string
    * @default ''
    */
   type = '';
 
   /**
+   * @property cssPropertyName
    * @type string
    * @default ''
    */
@@ -40,8 +56,9 @@ class SelectComponent extends Component {
   cssPropertyName = '';
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/select.js
+++ b/addon/components/models-table/select.js
@@ -29,14 +29,12 @@ class SelectComponent extends Component {
   /**
    * @type string
    * @default ''
-   * @property type
    */
   type = '';
 
   /**
    * @type string
    * @default ''
-   * @property cssPropertyName
    */
   @className
   cssPropertyName = '';
@@ -44,7 +42,6 @@ class SelectComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */

--- a/addon/components/models-table/summary.js
+++ b/addon/components/models-table/summary.js
@@ -32,7 +32,6 @@ class SummaryComponent extends Component {
   @alias('themeInstance.footerSummary') themeFooterSummaryClass;
 
   /**
-   * @property paginationTypeClass
    * @type string
    * @private
    * @readonly
@@ -48,7 +47,6 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/firstIndex:property"}}ModelsTable.firstIndex{{/crossLink}}
    *
-   * @property firstIndex
    * @type number
    * @default null
    */
@@ -57,7 +55,6 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/lastIndex:property"}}ModelsTable.lastIndex{{/crossLink}}
    *
-   * @property lastIndex
    * @type number
    * @default null
    */
@@ -66,7 +63,6 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
    *
-   * @property recordsCount
    * @type number
    * @default null
    */
@@ -75,8 +71,6 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/anyFilterUsed:property"}}ModelsTable.anyFilterUsed{{/crossLink}}
    *
-   * @property anyFilterUsed
-   * @type boolean
    * @default null
    */
   anyFilterUsed = null;
@@ -84,7 +78,6 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -100,14 +93,11 @@ class SummaryComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}}
    *
-   * @property useNumericPagination
-   * @type boolean
    * @default null
    */
   useNumericPagination = null;
 
   /**
-   * @property summary
    * @type string
    * @private
    * @readonly
@@ -118,7 +108,6 @@ class SummaryComponent extends Component {
   }
 
   /**
-   * @property inputId
    * @type string
    * @private
    */

--- a/addon/components/models-table/summary.js
+++ b/addon/components/models-table/summary.js
@@ -28,13 +28,18 @@ export default
 @templateLayout(layout)
 class SummaryComponent extends Component {
 
+  /**
+   * @property themeFooterSummaryClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.footerSummary') themeFooterSummaryClass;
 
   /**
+   * @property paginationTypeClass
    * @type string
-   * @private
-   * @readonly
+   * @protected
    */
   @className
   @computed('useNumericPagination', 'themeInstance.{footerSummaryNumericPagination,footerSummaryDefaultPagination}')
@@ -45,62 +50,70 @@ class SummaryComponent extends Component {
   }
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/firstIndex:property"}}ModelsTable.firstIndex{{/crossLink}}
+   * Bound from [ModelsTable.firstIndex](Components.ModelsTable.html#property_firstIndex)
    *
+   * @property firstIndex
    * @type number
    * @default null
    */
   firstIndex = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/lastIndex:property"}}ModelsTable.lastIndex{{/crossLink}}
+   * Bound from [ModelsTable.lastIndex](Components.ModelsTable.html#property_lastIndex)
    *
+   * @property lastIndex
    * @type number
    * @default null
    */
   lastIndex = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/arrangedContentLength:property"}}ModelsTable.arrangedContentLength{{/crossLink}}
+   * Bound from [ModelsTable.arrangedContentLength](Components.ModelsTable.html#property_arrangedContentLength)
    *
+   * @property recordsCount
    * @type number
    * @default null
    */
   recordsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/anyFilterUsed:property"}}ModelsTable.anyFilterUsed{{/crossLink}}
+   * Bound from [ModelsTable.anyFilterUsed](Components.ModelsTable.html#property_anyFilterUsed)
    *
+   * @property anyFilterUsed
+   * @type boolean
    * @default null
    */
   anyFilterUsed = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clearFilters:method"}}ModelsTable.actions.clearFilters{{/crossLink}}
+   * Closure action [ModelsTable.clearFilters](Components.ModelsTable.html#event_clearFilters)
    *
    * @event clearFilters
    */
   clearFilters = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useNumericPagination:property"}}ModelsTable.useNumericPagination{{/crossLink}}
+   * Bound from [ModelsTable.useNumericPagination](Components.ModelsTable.html#property_useNumericPagination)
    *
+   * @property useNumericPagination
+   * @type boolean
    * @default null
    */
   useNumericPagination = null;
 
   /**
+   * @property summary
    * @type string
-   * @private
-   * @readonly
+   * @protected
    */
   @computed('firstIndex', 'lastIndex', 'recordsCount', 'msg')
   get summary() {
@@ -108,19 +121,28 @@ class SummaryComponent extends Component {
   }
 
   /**
+   * @property inputId
    * @type string
-   * @private
+   * @protected
    */
   @computed('elementId')
   get inputId() {
     return `${this.elementId}-summary-input`;
   }
 
+  /**
+   * @event doClearFilters
+   * @protected
+   */
   @action
   doClearFilters() {
     this.clearFilters();
   }
 
+  /**
+   * @event noop
+   * @protected
+   */
   @action
   noop() {}
 }

--- a/addon/components/models-table/table-body.js
+++ b/addon/components/models-table/table-body.js
@@ -66,233 +66,261 @@ export default
 @templateLayout(layout)
 @tagName('tbody')
 class TableBodyComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTableTable/columnsCount:property"}}ModelsTable.columnsCount{{/crossLink}}
+   * Bound from [ModelsTable.columnsCount](Components.ModelsTableTable.html#property_columnsCount)
    *
+   * @property columnsCount
    * @type number
    * @default null
    */
   columnsCount = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleContent:property"}}ModelsTable.visibleContent{{/crossLink}}
+   * Bound from [ModelsTable.visibleContent](Components.ModelsTable.html#property_visibleContent)
    *
+   * @property visibleContent
    * @type object[]
    * @default null
    */
   visibleContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @type object[]
    * @default null
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @type number[]
    * @default null
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedRowComponent:property"}}ModelsTable.expandedRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.expandedRowComponent](Components.ModelsTable.html#property_expandedRowComponent)
    *
-   * @type string
+   * @property expandedRowComponent
+   * @type object
    * @default null
    */
   expandedRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupingRowComponent:property"}}ModelsTable.groupingRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupingRowComponent](Components.ModelsTable.html#property_groupingRowComponent)
    *
+   * @property groupingRowComponent
    * @type object
    * @default null
    */
   groupingRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupSummaryRowComponent:property"}}ModelsTable.groupSummaryRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupSummaryRowComponent](Components.ModelsTable.html#property_groupSummaryRowComponent)
    *
+   * @property groupSummaryRowComponent
    * @type object
    * @default null
    */
   groupSummaryRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/allColumnsAreHidden:property"}}ModelsTable.allColumnsAreHidden{{/crossLink}}
+   * Bound from [ModelsTable.allColumnsAreHidden](Components.ModelsTable.html#property_allColumnsAreHidden)
    *
+   * @property allColumnsAreHidden
+   * @type boolean
    * @default null
    */
   allColumnsAreHidden = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @type object[]
    * @default null
    */
   data = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/collapsedGroupValues:property"}}ModelsTable.collapsedGroupValues{{/crossLink}}
+   * Bound from [ModelsTable.collapsedGroupValues](Components.ModelsTable.html#property_collapsedGroupValues)
    *
+   * @property collapsedGroupValues
    * @type array
    * @default null
    */
   collapsedGroupValues = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
+   * Bound from [ModelsTable.dataGroupOptions](Components.ModelsTable.html#property_dataGroupOptions)
    *
-   * @type object[]
+   * @property dataGroupOptions
+   * @type SelectOption[]
    * @default null
    */
   dataGroupOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContentValuesOrder:property"}}ModelsTable.groupedVisibleContentValuesOrder{{/crossLink}}
+   * Bound from [ModelsTable.groupedVisibleContentValuesOrder](Components.ModelsTable.html#property_groupedVisibleContentValuesOrder)
    *
+   * @property groupedVisibleContentValuesOrder
    * @type array
    * @default null
    */
   groupedVisibleContentValuesOrder = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContent:property"}}ModelsTable.groupedVisibleContent{{/crossLink}}
+   * Bound from [ModelsTable.groupedVisibleContent](Components.ModelsTable.html#property_groupedVisibleContent)
    *
-   * @type object
+   * @property groupedVisibleContent
+   * @type object[]
    * @default null
    */
   groupedVisibleContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedArrangedContent:property"}}ModelsTable.groupedArrangedContent{{/crossLink}}
+   * Bound from [ModelsTable.groupedArrangedContent](Components.ModelsTable.html#property_groupedArrangedContent)
    *
+   * @property groupedArrangedContent
    * @type object[]
    * @default null
    */
   groupedArrangedContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
   displayGroupedValueAs = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRows:method"}}ModelsTable.actions.toggleGroupedRows{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
    *
    * @event toggleGroupedRows
    */
   toggleGroupedRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsSelection:method"}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
    *
    * @event toggleGroupedRowsSelection
    */
   toggleGroupedRowsSelection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsExpands:method"}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
    *
    * @event toggleGroupedRowsExpands
    */
   toggleGroupedRowsExpands = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
    *
    * @event clickOnRow
    */
   clickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.doubleClickOnRow:method"}}ModelsTable.actions.doubleClickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.doubleClickOnRow](Components.ModelsTable.html#event_doubleClickOnRow)
    *
    * @event doubleClickOnRow
    */
   doubleClickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.hoverOnRow:method"}}ModelsTable.actions.hoverOnRow{{/crossLink}}
+   * Closure action [ModelsTable.hoverOnRow](Components.ModelsTable.html#event_hoverOnRow)
    *
    * @event hoverOnRow
    */
   hoverOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.outRow:method"}}ModelsTable.actions.outRow{{/crossLink}}
+   * Closure action [ModelsTable.outRow](Components.ModelsTable.html#event_outRow)
    *
    * @event outRow
    */
   outRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
+  /**
+   * @event doClickOnRow
+   * @param {number} index
+   * @param {object} row
+   * @protected
+   */
   @action
   doClickOnRow(index, row) {
     this.clickOnRow(index, row);

--- a/addon/components/models-table/table-body.js
+++ b/addon/components/models-table/table-body.js
@@ -69,7 +69,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTableTable/columnsCount:property"}}ModelsTable.columnsCount{{/crossLink}}
    *
-   * @property columnsCount
    * @type number
    * @default null
    */
@@ -78,7 +77,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleContent:property"}}ModelsTable.visibleContent{{/crossLink}}
    *
-   * @property visibleContent
    * @type object[]
    * @default null
    */
@@ -87,7 +85,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @type object[]
    * @default null
    */
@@ -96,7 +93,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @type number[]
    * @default null
    */
@@ -105,7 +101,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedRowComponent:property"}}ModelsTable.expandedRowComponent{{/crossLink}}
    *
-   * @property expandedRowComponent
    * @type string
    * @default null
    */
@@ -114,7 +109,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupingRowComponent:property"}}ModelsTable.groupingRowComponent{{/crossLink}}
    *
-   * @property groupingRowComponent
    * @type object
    * @default null
    */
@@ -123,7 +117,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupSummaryRowComponent:property"}}ModelsTable.groupSummaryRowComponent{{/crossLink}}
    *
-   * @property groupSummaryRowComponent
    * @type object
    * @default null
    */
@@ -132,7 +125,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -141,8 +133,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/allColumnsAreHidden:property"}}ModelsTable.allColumnsAreHidden{{/crossLink}}
    *
-   * @property allColumnsAreHidden
-   * @type boolean
    * @default null
    */
   allColumnsAreHidden = null;
@@ -150,7 +140,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -159,7 +148,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @type object[]
    * @default null
    */
@@ -168,8 +156,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
-   * @type boolean
    * @default null
    */
   useDataGrouping = null;
@@ -177,7 +163,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/collapsedGroupValues:property"}}ModelsTable.collapsedGroupValues{{/crossLink}}
    *
-   * @property collapsedGroupValues
    * @type array
    * @default null
    */
@@ -186,7 +171,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -195,7 +179,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
    *
-   * @property dataGroupOptions
    * @type object[]
    * @default null
    */
@@ -204,7 +187,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContentValuesOrder:property"}}ModelsTable.groupedVisibleContentValuesOrder{{/crossLink}}
    *
-   * @property groupedVisibleContentValuesOrder
    * @type array
    * @default null
    */
@@ -213,7 +195,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContent:property"}}ModelsTable.groupedVisibleContent{{/crossLink}}
    *
-   * @property groupedVisibleContent
    * @type object
    * @default null
    */
@@ -222,7 +203,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedArrangedContent:property"}}ModelsTable.groupedArrangedContent{{/crossLink}}
    *
-   * @property groupedArrangedContent
    * @type object[]
    * @default null
    */
@@ -231,7 +211,6 @@ class TableBodyComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @type string
    * @default null
    */

--- a/addon/components/models-table/table-footer.js
+++ b/addon/components/models-table/table-footer.js
@@ -27,83 +27,89 @@ export default
 @templateLayout(layout)
 @tagName('tfoot')
 class TableFooterComponent extends Component {
+
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @type object
    * @default null
    */
   data = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @type object[]
    * @default null
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @type object[]
    * @default null
    */
   expandedItems = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.goToPage:method"}}ModelsTable.actions.goToPage{{/crossLink}}
+   * Closure action [ModelsTable.goToPage](Components.ModelsTable.html#event_goToPage)
    *
    * @event goToPage
    */
   goToPage = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clearFilters:method"}}ModelsTable.actions.clearFilters{{/crossLink}}
+   * Closure action [ModelsTable.clearFilters](Components.ModelsTable.html#event_clearFilters)
    *
    * @event clearFilters
    */
   clearFilters = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */

--- a/addon/components/models-table/table-footer.js
+++ b/addon/components/models-table/table-footer.js
@@ -30,7 +30,6 @@ class TableFooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @type object
    * @default null
    */
@@ -39,7 +38,6 @@ class TableFooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -48,7 +46,6 @@ class TableFooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -57,7 +54,6 @@ class TableFooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @type object[]
    * @default null
    */
@@ -66,7 +62,6 @@ class TableFooterComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @type object[]
    * @default null
    */

--- a/addon/components/models-table/table-header.js
+++ b/addon/components/models-table/table-header.js
@@ -62,8 +62,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/noHeaderFilteringAndSorting:property"}}ModelsTable.noHeaderFilteringAndSorting{{/crossLink}}
    *
-   * @property noHeaderFilteringAndSorting
-   * @type boolean
    * @default null
    */
   @className('table-header-no-filtering-and-sorting')
@@ -72,7 +70,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedHeaders:property"}}ModelsTable.groupedHeaders{{/crossLink}}
    *
-   * @property groupedHeaders
    * @type groupedHeader[][]
    * @default null
    */
@@ -81,7 +78,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -90,7 +86,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type ModelsTableColumn[]
    * @default null
    */
@@ -99,8 +94,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useFilteringByColumns:property"}}ModelsTable.useFilteringByColumns{{/crossLink}}
    *
-   * @property useFilteringByColumns
-   * @type boolean
    * @default null
    */
   useFilteringByColumns = null;
@@ -108,7 +101,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -117,8 +109,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
-   * @type boolean
    * @default null
    */
   useDataGrouping = null;
@@ -126,7 +116,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
@@ -135,7 +124,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -144,7 +132,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
    *
-   * @property groupHeaderCellComponent
    * @type object
    * @default null
    */
@@ -195,7 +182,6 @@ class TableHeaderComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @default null
    * @type object[]
    */

--- a/addon/components/models-table/table-header.js
+++ b/addon/components/models-table/table-header.js
@@ -56,137 +56,162 @@ export default
 @tagName('thead')
 class TableHeaderComponent extends Component {
 
+  /**
+   * @property themeTheadClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.thead') themeTheadClass;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/noHeaderFilteringAndSorting:property"}}ModelsTable.noHeaderFilteringAndSorting{{/crossLink}}
+   * Bound from [ModelsTable.noHeaderFilteringAndSorting](Components.ModelsTable.html#property_noHeaderFilteringAndSorting)
    *
+   * @property noHeaderFilteringAndSorting
+   * @type string
    * @default null
+   * @protected
    */
   @className('table-header-no-filtering-and-sorting')
   noHeaderFilteringAndSorting = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedHeaders:property"}}ModelsTable.groupedHeaders{{/crossLink}}
+   * Bound from [ModelsTable.groupedHeaders](Components.ModelsTable.html#property_groupedHeaders)
    *
-   * @type groupedHeader[][]
+   * @property groupedHeaders
+   * @type GroupedHeader[]
    * @default null
    */
   groupedHeaders = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Bound from [ModelsTable.processedColumns](Components.ModelsTable.html#property_processedColumns)
    *
-   * @type ModelsTableColumn[]
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   processedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useFilteringByColumns:property"}}ModelsTable.useFilteringByColumns{{/crossLink}}
+   * Bound from [ModelsTable.useFilteringByColumns](Components.ModelsTable.html#property_useFilteringByColumns)
    *
+   * @property useFilteringByColumns
+   * @type boolean
    * @default null
    */
   useFilteringByColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
   displayGroupedValueAs = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupHeaderCellComponent](Components.ModelsTable.html#property_groupHeaderCellComponent)
    *
+   * @property groupHeaderCellComponent
    * @type object
    * @default null
    */
   groupHeaderCellComponent = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */
   toggleAllSelection = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property data
    * @default null
    * @type object[]
    */
   data = null;
 
+  /**
+   * @event doSort
+   * @param {Utils.ModelsTableColumn} column
+   * @protected
+   */
   @action
   doSort(column) {
     this.sort(column);

--- a/addon/components/models-table/table.js
+++ b/addon/components/models-table/table.js
@@ -52,8 +52,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/noHeaderFilteringAndSorting:property"}}ModelsTable.noHeaderFilteringAndSorting{{/crossLink}}
    *
-   * @property noHeaderFilteringAndSorting
-   * @type boolean
    * @default null
    */
   noHeaderFilteringAndSorting = null;
@@ -61,7 +59,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedHeaders:property"}}ModelsTable.groupedHeaders{{/crossLink}}
    *
-   * @property groupedHeaders
    * @type groupedHeader[][]
    * @default null
    */
@@ -70,7 +67,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
    *
-   * @property processedColumns
    * @type object[]
    * @default null
    */
@@ -84,7 +80,6 @@ class TableComponent extends Component {
   sort = null;
 
   /**
-   * @property columnsCount
    * @type number
    * @default null
    */
@@ -93,7 +88,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleContent:property"}}ModelsTable.visibleContent{{/crossLink}}
    *
-   * @property visibleContent
    * @type object[]
    * @default null
    */
@@ -102,7 +96,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
    *
-   * @property selectedItems
    * @type object[]
    * @default null
    */
@@ -111,7 +104,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
    *
-   * @property expandedItems
    * @type number[]
    * @default null
    */
@@ -120,7 +112,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
    *
-   * @property visibleProcessedColumns
    * @type object[]
    * @default null
    */
@@ -129,8 +120,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/allColumnsAreHidden:property"}}ModelsTable.allColumnsAreHidden{{/crossLink}}
    *
-   * @property allColumnsAreHidden
-   * @type boolean
    * @default null
    */
   allColumnsAreHidden = null;
@@ -138,7 +127,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
    *
-   * @property data
    * @type object[]
    * @default null
    */
@@ -147,8 +135,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useFilteringByColumns:property"}}ModelsTable.useFilteringByColumns{{/crossLink}}
    *
-   * @property useFilteringByColumns
-   * @type boolean
    * @default null
    */
   useFilteringByColumns = null;
@@ -156,7 +142,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupingRowComponent:property"}}ModelsTable.groupingRowComponent{{/crossLink}}
    *
-   * @property groupingRowComponent
    * @type object
    * @default null
    */
@@ -165,7 +150,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupSummaryRowComponent:property"}}ModelsTable.groupSummaryRowComponent{{/crossLink}}
    *
-   * @property groupSummaryRowComponent
    * @type object
    * @default null
    */
@@ -174,7 +158,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
    *
-   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
@@ -183,7 +166,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
    *
-   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
@@ -192,7 +174,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/_collapsedGroupValues:property"}}ModelsTable._collapsedGroupValues{{/crossLink}}
    *
-   * @property collapsedGroupValues
    * @type array
    * @default null
    */
@@ -201,7 +182,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
    *
-   * @property dataGroupOptions
    * @type object[]
    * @default null
    */
@@ -210,7 +190,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContentValuesOrder:property"}}ModelsTable.groupedVisibleContentValuesOrder{{/crossLink}}
    *
-   * @property groupedVisibleContentValuesOrder
    * @type array
    * @default null
    */
@@ -219,8 +198,7 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContent:property"}}ModelsTable.groupedVisibleContent{{/crossLink}}
    *
-   * @property groupedVisibleContent
-   * @type {}
+   * @type
    * @default null
    */
   groupedVisibleContent = null;
@@ -228,7 +206,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupedArrangedContent:property"}}ModelsTable.groupedArrangedContent{{/crossLink}}
    *
-   * @property groupedArrangedContent
    * @type object[]
    * @default null
    */
@@ -237,8 +214,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
    *
-   * @property useDataGrouping
-   * @type boolean
    * @default null
    */
   useDataGrouping = null;
@@ -295,7 +270,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
    *
-   * @property themeInstance
    * @type object
    * @default null
    */
@@ -304,7 +278,6 @@ class TableComponent extends Component {
   /**
    * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
    *
-   * @property groupHeaderCellComponent
    * @type object
    * @default null
    */
@@ -346,9 +319,6 @@ class TableComponent extends Component {
   toggleAllSelection = null;
 
   /**
-   * @property showTableFooter
-   * @type boolean
-   * @default false
    * @readonly
    */
   @computed('visibleProcessedColumns.@each.componentForFooterCell')

--- a/addon/components/models-table/table.js
+++ b/addon/components/models-table/table.js
@@ -46,291 +46,338 @@ export default
 @tagName('table')
 class TableComponent extends Component {
 
+  /**
+   * @property themeTableClass
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.table') themeTableClass;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/noHeaderFilteringAndSorting:property"}}ModelsTable.noHeaderFilteringAndSorting{{/crossLink}}
+   * Bound from [ModelsTable.noHeaderFilteringAndSorting](Components.ModelsTable.html#property_noHeaderFilteringAndSorting)
    *
+   * @property noHeaderFilteringAndSorting
+   * @type boolean
    * @default null
    */
   noHeaderFilteringAndSorting = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedHeaders:property"}}ModelsTable.groupedHeaders{{/crossLink}}
+   * Bound from [ModelsTable.groupedHeaders](Components.ModelsTable.html#property_groupedHeaders)
    *
-   * @type groupedHeader[][]
+   * @property groupedHeaders
+   * @type GroupedHeader[][]
    * @default null
    */
   groupedHeaders = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/processedColumns:property"}}ModelsTable.processedColumns{{/crossLink}}
+   * Bound from [ModelsTable.processedColumns](Components.ModelsTable.html#property_processedColumns)
    *
-   * @type object[]
+   * @property processedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   processedColumns = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.sort:method"}}ModelsTable.actions.sort{{/crossLink}}
+   * Closure action [ModelsTable.sort](Components.ModelsTable.html#event_sort)
    *
    * @event sort
    */
   sort = null;
 
   /**
+   * @property columnsCount
    * @type number
-   * @default null
+   * @default 0
+   * @protected
    */
   @alias('processedColumns.length') columnsCount;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleContent:property"}}ModelsTable.visibleContent{{/crossLink}}
+   * Bound from [ModelsTable.visibleContent](Components.ModelsTable.html#property_visibleContent)
    *
+   * @property visibleContent
    * @type object[]
    * @default null
    */
   visibleContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
+   * Bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
    *
+   * @property selectedItems
    * @type object[]
    * @default null
    */
   selectedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * Bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    *
+   * @property expandedItems
    * @type number[]
    * @default null
    */
   expandedItems = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/visibleProcessedColumns:property"}}ModelsTable.visibleProcessedColumns{{/crossLink}}
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
    *
-   * @type object[]
+   * @property visibleProcessedColumns
+   * @type Utils.ModelsTableColumn[]
    * @default null
    */
   visibleProcessedColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/allColumnsAreHidden:property"}}ModelsTable.allColumnsAreHidden{{/crossLink}}
+   * Bound from [ModelsTable.allColumnsAreHidden](Components.ModelsTable.html#property_allColumnsAreHidden)
    *
+   * @property allColumnsAreHidden
+   * @type boolean
    * @default null
    */
   allColumnsAreHidden = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/data:property"}}ModelsTable.data{{/crossLink}}
+   * Bound from [ModelsTable.data](Components.ModelsTable.html#property_data)
    *
+   * @property data
    * @type object[]
    * @default null
    */
   data = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useFilteringByColumns:property"}}ModelsTable.useFilteringByColumns{{/crossLink}}
+   * Bound from [ModelsTable.useFilteringByColumns](Components.ModelsTable.html#property_useFilteringByColumns)
    *
+   * @property useFilteringByColumns
+   * @type boolean
    * @default null
    */
   useFilteringByColumns = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupingRowComponent:property"}}ModelsTable.groupingRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupingRowComponent](Components.ModelsTable.html#property_groupingRowComponent)
    *
+   * @property groupingRowComponent
    * @type object
    * @default null
    */
   groupingRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupSummaryRowComponent:property"}}ModelsTable.groupSummaryRowComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupSummaryRowComponent](Components.ModelsTable.html#property_groupSummaryRowComponent)
    *
+   * @property groupSummaryRowComponent
    * @type object
    * @default null
    */
   groupSummaryRowComponent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/displayGroupedValueAs:property"}}ModelsTable.displayGroupedValueAs{{/crossLink}}
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
    *
+   * @property displayGroupedValueAs
    * @type string
    * @default null
    */
   displayGroupedValueAs = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/currentGroupingPropertyName:property"}}ModelsTable.currentGroupingPropertyName{{/crossLink}}
+   * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)
    *
+   * @property currentGroupingPropertyName
    * @type string
    * @default null
    */
   currentGroupingPropertyName = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/_collapsedGroupValues:property"}}ModelsTable._collapsedGroupValues{{/crossLink}}
+   * Bound from [ModelsTable._collapsedGroupValues](Components.ModelsTable.html#property__collapsedGroupValues)
    *
+   * @property collapsedGroupValues
    * @type array
    * @default null
    */
   collapsedGroupValues = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/dataGroupOptions:property"}}ModelsTable.dataGroupOptions{{/crossLink}}
+   * Bound from [ModelsTable.dataGroupOptions](Components.ModelsTable.html#property_dataGroupOptions)
    *
+   * @property dataGroupOptions
    * @type object[]
    * @default null
    */
   dataGroupOptions = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContentValuesOrder:property"}}ModelsTable.groupedVisibleContentValuesOrder{{/crossLink}}
+   * Bound from [ModelsTable.groupedVisibleContentValuesOrder](Components.ModelsTable.html#property_groupedVisibleContentValuesOrder)
    *
+   * @property groupedVisibleContentValuesOrder
    * @type array
    * @default null
    */
   groupedVisibleContentValuesOrder = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedVisibleContent:property"}}ModelsTable.groupedVisibleContent{{/crossLink}}
+   * Bound from [ModelsTable.groupedVisibleContent](Components.ModelsTable.html#property_groupedVisibleContent)
    *
-   * @type
+   * @property groupedVisibleContent
+   * @type object[]
    * @default null
    */
   groupedVisibleContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupedArrangedContent:property"}}ModelsTable.groupedArrangedContent{{/crossLink}}
+   * Bound from [ModelsTable.groupedArrangedContent](Components.ModelsTable.html#property_groupedArrangedContent)
    *
+   * @property groupedArrangedContent
    * @type object[]
    * @default null
    */
   groupedArrangedContent = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/useDataGrouping:property"}}ModelsTable.useDataGrouping{{/crossLink}}
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
    *
+   * @property useDataGrouping
+   * @type boolean
    * @default null
    */
   useDataGrouping = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRows:method"}}ModelsTable.actions.toggleGroupedRows{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
    *
    * @event toggleGroupedRows
    */
   toggleGroupedRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsSelection:method"}}ModelsTable.actions.toggleGroupedRowsSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)
    *
    * @event toggleGroupedRowsSelection
    */
   toggleGroupedRowsSelection = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleGroupedRowsExpands:method"}}ModelsTable.actions.toggleGroupedRowsExpands{{/crossLink}}
+   * Closure action [ModelsTable.toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands)
    *
    * @event toggleGroupedRowsExpands
    */
   toggleGroupedRowsExpands = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
    *
    * @event clickOnRow
    */
   clickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.doubleClickOnRow:method"}}ModelsTable.actions.doubleClickOnRow{{/crossLink}}
+   * Closure action [ModelsTable.doubleClickOnRow](Components.ModelsTable.html#event_doubleClickOnRow)
    *
    * @event doubleClickOnRow
    */
   doubleClickOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.hoverOnRow:method"}}ModelsTable.actions.hoverOnRow{{/crossLink}}
+   * Closure action [ModelsTable.hoverOnRow](Components.ModelsTable.html#event_hoverOnRow)
    *
    * @event hoverOnRow
    */
   hoverOnRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.outRow:method"}}ModelsTable.actions.outRow{{/crossLink}}
+   * Closure action [ModelsTable.outRow](Components.ModelsTable.html#event_outRow)
    *
    * @event outRow
    */
   outRow = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
+   * @property themeInstance
    * @type object
    * @default null
    */
   themeInstance = null;
 
   /**
-   * Bound from {{#crossLink "Components.ModelsTable/groupHeaderCellComponent:property"}}ModelsTable.groupHeaderCellComponent{{/crossLink}}
+   * Bound from [ModelsTable.groupHeaderCellComponent](Components.ModelsTable.html#property_groupHeaderCellComponent)
    *
+   * @property groupHeaderCellComponent
    * @type object
    * @default null
    */
   groupHeaderCellComponent = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
+   * Closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
    *
    * @event expandRow
    */
   expandRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
+   * Closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
    *
    * @event collapseRow
    */
   collapseRow = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
+   * Closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
    *
    * @event expandAllRows
    */
   expandAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
+   * Closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
    *
    * @event collapseAllRows
    */
   collapseAllRows = null;
 
   /**
-   * Closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * Closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
    * @event toggleAllSelection
    */
   toggleAllSelection = null;
 
   /**
-   * @readonly
+   * @property showTableFooter
+   * @type boolean
+   * @default false
+   * @protected
    */
   @computed('visibleProcessedColumns.@each.componentForFooterCell')
   get showTableFooter() {
     return A(this.visibleProcessedColumns).isAny('componentForFooterCell');
   }
 
+  /**
+   * @event doSort
+   * @param {Utils.ModelsTableColumn} column
+   * @protected
+   */
   @action
   doSort(column) {
     this.sort(column);
   }
 
+  /**
+   * @event doClickOnRow
+   * @param {number} index
+   * @param {object} row
+   * @protected
+   */
   @action
   doClickOnRow(index, row) {
     this.clickOnRow(index, row);

--- a/addon/components/models-table/themes/bootstrap4/columns-dropdown.js
+++ b/addon/components/models-table/themes/bootstrap4/columns-dropdown.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultColumnsDropdown from '../../columns-dropdown';
+import ModelsTableColumnsDropdownComponent from '../../columns-dropdown';
 import layout from '../../../../templates/components/models-table/themes/bootstrap4/columns-dropdown';
 
+/**
+ * @class Bs4ModelsTableColumnsDropdown
+ * @extends Components.ModelsTableColumnsDropdown
+ * @namespace Components
+ */
 export default
 @templateLayout(layout)
-class ColumnsDropdownComponent extends DefaultColumnsDropdown {
+class Bs4ModelsTableColumnsDropdownComponent extends ModelsTableColumnsDropdownComponent {
 }

--- a/addon/components/models-table/themes/bootstrap4/data-group-by-select.js
+++ b/addon/components/models-table/themes/bootstrap4/data-group-by-select.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
 import layout from '../../../../templates/components/models-table/themes/bootstrap4/data-group-by-select';
-import DefaultDataGroupBySelect from '../../data-group-by-select';
+import ModelsTableDataGroupBySelectComponent from '../../data-group-by-select';
 
+/**
+ * @class Bs4ModelsTableDataGroupBySelect
+ * @extends Components.ModelsTableDataGroupBySelect
+ * @namespace Components
+ */
 export default
 @templateLayout(layout)
-class DataGroupBySelectComponent extends DefaultDataGroupBySelect {
+class Bs4ModelsTableDataGroupBySelectComponent extends ModelsTableDataGroupBySelectComponent {
 }

--- a/addon/components/models-table/themes/bootstrap4/global-filter.js
+++ b/addon/components/models-table/themes/bootstrap4/global-filter.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
 import layout from '../../../../templates/components/models-table/themes/bootstrap4/global-filter';
-import DefaultGlobalFilter from '../../global-filter';
+import ModelsTableGlobalFilterComponent from '../../global-filter';
 
+/**
+ * @class Bs4ModelsTableGlobalFilter
+ * @namespace Components
+ * @extends Components.ModelsTableGlobalFilter
+ */
 export default
 @templateLayout(layout)
-class GlobalFilterComponent extends DefaultGlobalFilter {
+class Bs4ModelsTableGlobalFilterComponent extends ModelsTableGlobalFilterComponent {
 }

--- a/addon/components/models-table/themes/bootstrap4/row-filtering-cell.js
+++ b/addon/components/models-table/themes/bootstrap4/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowFilteringCell from '../../row-filtering-cell';
+import ModelsTableRowFilteringCellComponent from '../../row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/bootstrap4/row-filtering-cell';
 
+/**
+ * @class Bs4ModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends DefaultRowFilteringCell {
+class Bs4ModelsTableRowFilteringCellComponent extends ModelsTableRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultColumnsDropdown from '../../columns-dropdown';
+import ModelsTableColumnsDropdownComponent from '../../columns-dropdown';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v3/columns-dropdown';
 
+/**
+ * @class Ebs3ModelsTableColumnsDropdown
+ * @namespace Components
+ * @extends Components.ModelsTableColumnsDropdown
+ */
 export default
 @templateLayout(layout)
-class ColumnsDropdownComponent extends DefaultColumnsDropdown {
+class Ebs3ModelsTableColumnsDropdownComponent extends ModelsTableColumnsDropdownComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultDataGroupBySelect from '../../data-group-by-select';
+import ModelsTableDataGroupBySelectComponent from '../../data-group-by-select';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select';
 
+/**
+ * @class Ebs3ModelsTableDataGroupBySelect
+ * @namespace Components
+ * @extends Components.ModelsTableDataGroupBySelect
+ */
 export default
 @templateLayout(layout)
-class DataGroupBySelectComponent extends DefaultDataGroupBySelect {
+class Ebs4ModelsTableDataGroupBySelectComponent extends ModelsTableDataGroupBySelectComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v3/global-filter.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v3/global-filter.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultGlobalFilter from '../../global-filter';
+import ModelsTableGlobalFilterComponent from '../../global-filter';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v3/global-filter';
 
+/**
+ * @class Ebs3ModelsTableGlobalFilter
+ * @namespace Components
+ * @extends Components.ModelsTableGlobalFilter
+ */
 export default
 @templateLayout(layout)
-class GlobalFilterComponent extends DefaultGlobalFilter {
+class Ebs4ModelsTableGlobalFilterComponent extends ModelsTableGlobalFilterComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v3/row-filtering-cell.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v3/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowFilteringCell from '../../row-filtering-cell';
+import DefaultRowFilteringCellComponent from '../../row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v3/row-filtering-cell';
 
+/**
+ * @class Ebs3ModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends DefaultRowFilteringCell {
+class Ebs3ModelsTableRowFilteringCellComponent extends DefaultRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v3/summary.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v3/summary.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultSummary from '../../summary';
+import ModelsTableSummaryComponent from '../../summary';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v3/summary';
 
+/**
+ * @class Ebs3ModelsTableSummary
+ * @namespace Components
+ * @extends Components.ModelsTableSummary
+ */
 export default
 @templateLayout(layout)
-class SummaryComponent extends DefaultSummary {
+class Ebs3ModelsTableSummaryComponent extends ModelsTableSummaryComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultColumnsDropdown from '../../columns-dropdown';
+import ModelsTableColumnsDropdownComponent from '../../columns-dropdown';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown';
 
+/**
+ * @class Ebs4ModelsTableColumnsDropdown
+ * @namespace Components
+ * @extends Components.ModelsTableColumnsDropdown
+ */
 export default
 @templateLayout(layout)
-class ColumnsDropdownComponent extends DefaultColumnsDropdown {
+class Ebs4ModelsTableColumnsDropdownComponent extends ModelsTableColumnsDropdownComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultDataGroupBySelect from '../../data-group-by-select';
+import ModelsTableDataGroupBySelectComponent from '../../data-group-by-select';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select';
 
+/**
+ * @class Ebs4ModelsTableDataGroupBySelect
+ * @namespace Components
+ * @extends Components.ModelsTableDataGroupBySelect
+ */
 export default
 @templateLayout(layout)
-class DataGroupBySelectComponent extends DefaultDataGroupBySelect {
+class Ebs4ModelsTableDataGroupBySelectComponent extends ModelsTableDataGroupBySelectComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v4/global-filter.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/global-filter.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultGlobalFilter from '../../global-filter';
+import ModelsTableGlobalFilterComponent from '../../global-filter';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v4/global-filter';
 
+/**
+ * @class Ebs4ModelsTableGlobalFilter
+ * @namespace Components
+ * @extends Components.ModelsTableGlobalFilter
+ */
 export default
 @templateLayout(layout)
-class GlobalFilterComponent extends DefaultGlobalFilter {
+class Ebs4ModelsTableGlobalFilterComponent extends ModelsTableGlobalFilterComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowFilteringCell from '../../row-filtering-cell';
+import ModelsTableRowFilteringCellComponent from '../../row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell';
 
+/**
+ * @class Ebs4ModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends DefaultRowFilteringCell {
+class Ebs4ModelsTableRowFilteringCellComponent extends ModelsTableRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/ember-bootstrap-v4/summary.js
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/summary.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultSummary from '../../summary';
+import ModelsTableSummaryComponent from '../../summary';
 import layout from '../../../../templates/components/models-table/themes/ember-bootstrap-v4/summary';
 
+/**
+ * @class Ebs4ModelsTableSummary
+ * @namespace Components
+ * @extends Components.ModelsTableSummary
+ */
 export default
 @templateLayout(layout)
-class SummaryComponent extends DefaultSummary {
+class Ebs4ModelsTableSummaryComponent extends ModelsTableSummaryComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/columns-dropdown.js
+++ b/addon/components/models-table/themes/ember-paper/columns-dropdown.js
@@ -1,12 +1,23 @@
 import {layout as templateLayout} from '@ember-decorators/component';
 import {alias} from '@ember/object/computed';
 import {className} from '@ember-decorators/component';
-import DefaultColumnsDropdown from '../../columns-dropdown';
+import ModelsTableColumnsDropdownComponent from '../../columns-dropdown';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/columns-dropdown';
 
+/**
+ * @class EpModelsTableColumnsDropdown
+ * @namespace Components
+ * @extends Components.ModelsTableColumnsDropdown
+ */
 export default
 @templateLayout(layout)
-class ColumnsDropdownComponent extends DefaultColumnsDropdown {
+class EpModelsTableColumnsDropdownComponent extends ModelsTableColumnsDropdownComponent {
+
+  /**
+   * @property columnsDropdownWrapper
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.columnsDropdownWrapper')
   columnsDropdownWrapper;

--- a/addon/components/models-table/themes/ember-paper/data-group-by-select.js
+++ b/addon/components/models-table/themes/ember-paper/data-group-by-select.js
@@ -1,12 +1,17 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultDataGroupBySelect from '../../data-group-by-select';
+import ModelsTableDataGroupBySelectComponent from '../../data-group-by-select';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/data-group-by-select';
 import {alias} from '@ember/object/computed';
 import {className} from '@ember-decorators/component';
 
+/**
+ * @class EpModelsTableDataGroupBySelect
+ * @namespace Components
+ * @extends Components.ModelsTableDataGroupBySelect
+ */
 export default
 @templateLayout(layout)
-class DataGroupBySelectComponent extends DefaultDataGroupBySelect {
+class EpModelsTableDataGroupBySelectComponent extends ModelsTableDataGroupBySelectComponent {
   @className
   @alias('themeInstance.dataGroupBySelectWrapper')
   dataGroupBySelectWrapper;

--- a/addon/components/models-table/themes/ember-paper/global-filter.js
+++ b/addon/components/models-table/themes/ember-paper/global-filter.js
@@ -1,13 +1,24 @@
 import {classNames, layout as templateLayout} from '@ember-decorators/component';
-import DefaultGlobalFilter from '../../global-filter';
+import ModelsTableGlobalFilterComponent from '../../global-filter';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/global-filter';
 import {alias} from '@ember/object/computed';
 import {className} from '@ember-decorators/component';
 
+/**
+ * @class EpModelsTableGlobalFilter
+ * @namespace Components
+ * @extends Components.ModelsTableGlobalFilter
+ */
 export default
 @templateLayout(layout)
 @classNames('globalSearch')
-class GlobalFilterComponent extends DefaultGlobalFilter {
+class EpModelsTableGlobalFilterComponent extends ModelsTableGlobalFilterComponent {
+
+  /**
+   * @property globalFilterWrapper
+   * @type string
+   * @protected
+   */
   @className
   @alias('themeInstance.globalFilterWrapper')
   globalFilterWrapper;

--- a/addon/components/models-table/themes/ember-paper/page-size-select.js
+++ b/addon/components/models-table/themes/ember-paper/page-size-select.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultPageSizeSelectComponent from '../../page-size-select';
+import ModelsTablePageSizeSelectComponent from '../../page-size-select';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/page-size-select';
 
+/**
+ * @class EpModelsTablePageSizeSelect
+ * @namespace Components
+ * @extends Components.ModelsTablePageSizeSelect
+ */
 export default
 @templateLayout(layout)
-class PageSizeSelectComponent extends DefaultPageSizeSelectComponent {
+class EpModelsTablePageSizeSelectComponent extends ModelsTablePageSizeSelectComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/pagination-numeric.js
+++ b/addon/components/models-table/themes/ember-paper/pagination-numeric.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultPaginationNumeric from '../../pagination-numeric';
+import ModelsTablePaginationNumericComponent from '../../pagination-numeric';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/pagination-numeric';
 
+/**
+ * @class EpModelsTablePaginationNumeric
+ * @namespace Components
+ * @extends Components.ModelsTablePaginationNumeric
+ */
 export default
 @templateLayout(layout)
-class PaginationNumericComponent extends DefaultPaginationNumeric {
+class EpModelsTablePaginationNumericComponent extends ModelsTablePaginationNumericComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/pagination-simple.js
+++ b/addon/components/models-table/themes/ember-paper/pagination-simple.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultPaginationSimple from '../../pagination-simple';
+import ModelsTablePaginationSimpleComponent from '../../pagination-simple';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/pagination-simple';
 
+/**
+ * @class EpModelsTablePaginationSimple
+ * @namespace Components
+ * @extends Components.ModelsTablePaginationSimple
+ */
 export default
 @templateLayout(layout)
-class PaginationSimpleComponent extends DefaultPaginationSimple {
+class EpModelsTablePaginationSimpleComponent extends ModelsTablePaginationSimpleComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/row-filtering-cell.js
+++ b/addon/components/models-table/themes/ember-paper/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowFilteringCell from '../../row-filtering-cell';
+import ModelsTableRowFilteringCellComponent from '../../row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/row-filtering-cell';
 
+/**
+ * @class EpModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends DefaultRowFilteringCell {
+class EpModelsTableRowFilteringCellComponent extends ModelsTableRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/row-sorting-cell.js
+++ b/addon/components/models-table/themes/ember-paper/row-sorting-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowSortingCell from '../../row-sorting-cell';
+import ModelsTableRowSortingCellComponent from '../../row-sorting-cell';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/row-sorting-cell';
 
+/**
+ * @class EpModelsTableRowSortingCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowSortingCell
+ */
 export default
 @templateLayout(layout)
-class RowSortingCellComponent extends DefaultRowSortingCell {
+class EpModelsTableRowSortingCellComponent extends ModelsTableRowSortingCellComponent {
 }

--- a/addon/components/models-table/themes/ember-paper/select.js
+++ b/addon/components/models-table/themes/ember-paper/select.js
@@ -11,23 +11,16 @@ class SelectComponent extends Component {
   @empty('options') disabled;
 
   /**
-   * @property label
    * @type string
    * @default ''
    */
   label = '';
 
   /**
-   * @property clearable
-   * @type boolean
-   * @default false
    */
   clearable = false;
 
   /**
-   * @property wide
-   * @type boolean
-   * @default false
    */
   wide = false;
 

--- a/addon/components/models-table/themes/ember-paper/select.js
+++ b/addon/components/models-table/themes/ember-paper/select.js
@@ -4,26 +4,49 @@ import {empty} from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/select';
 
+/**
+ * @class EpModelsTableSelect
+ * @namespace Components
+ * @extends Ember.Component
+ */
 export default
 @templateLayout(layout)
 class SelectComponent extends Component {
 
+  /**
+   * @property disabled
+   * @type boolean
+   * @default true
+   * @protected
+   */
   @empty('options') disabled;
 
   /**
+   * @property label
    * @type string
    * @default ''
    */
   label = '';
 
   /**
+   * @property clearable
+   * @type boolean
+   * @default false
    */
   clearable = false;
 
   /**
+   * @property wide
+   * @type boolean
+   * @default false
    */
   wide = false;
 
+  /**
+   * @event updateValue
+   * @param {*} val
+   * @protected
+   */
   @action
   updateValue(val) {
     let v = 'value' in val ? val.value : val;

--- a/addon/components/models-table/themes/ember-paper/summary.js
+++ b/addon/components/models-table/themes/ember-paper/summary.js
@@ -1,9 +1,14 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultSummary from '../../summary';
+import ModelsTableSummaryComponent from '../../summary';
 import layout from '../../../../templates/components/models-table/themes/ember-paper/summary';
 
+/**
+ * @class EpModelsTableSummary
+ * @namespace Components
+ * @extends Components.ModelsTableSummary
+ */
 export default
 @templateLayout(layout)
-class SummaryComponent extends DefaultSummary {
+class EpModelsTableSummaryComponent extends ModelsTableSummaryComponent {
 
 }

--- a/addon/components/models-table/themes/ember-semanticui/row-filtering-cell.js
+++ b/addon/components/models-table/themes/ember-semanticui/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import SemanticUIRowFilterCell from '../semanticui/row-filtering-cell';
+import SuiModelsTableRowFilteringCellComponent from '../semanticui/row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/ember-semanticui/row-filtering-cell';
 
+/**
+ * @class EsuiModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.SuiModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends SemanticUIRowFilterCell {
+class EsuiModelsTableRowFilteringCellComponent extends SuiModelsTableRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/ember-semanticui/select.js
+++ b/addon/components/models-table/themes/ember-semanticui/select.js
@@ -8,16 +8,10 @@ export default
 @templateLayout(layout)
 class SelectComponent extends Component {
   /**
-   * @property clearable
-   * @type boolean
-   * @default false
    */
   clearable = false;
 
   /**
-   * @property wide
-   * @type boolean
-   * @default false
    */
   wide = false;
 

--- a/addon/components/models-table/themes/ember-semanticui/select.js
+++ b/addon/components/models-table/themes/ember-semanticui/select.js
@@ -4,17 +4,34 @@ import {set} from '@ember/object';
 import Component from '@ember/component';
 import layout from '../../../../templates/components/models-table/themes/ember-semanticui/select';
 
+/**
+ * @class EsuiModelsTableSelect
+ * @namespace Components
+ * @extends Ember.Component
+ */
 export default
 @templateLayout(layout)
 class SelectComponent extends Component {
+
   /**
+   * @property clearable
+   * @type boolean
+   * @default false
    */
   clearable = false;
 
   /**
+   * @property wide
+   * @type boolean
+   * @default false
    */
   wide = false;
 
+  /**
+   * @event updateValue
+   * @param {*} val
+   * @protected
+   */
   @action
   updateValue(val) {
     if (this.type === 'number') {

--- a/addon/components/models-table/themes/semanticui/columns-dropdown.js
+++ b/addon/components/models-table/themes/semanticui/columns-dropdown.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultColumnsDropdown from '../../columns-dropdown';
+import ModelsTableColumnsDropdownComponent from '../../columns-dropdown';
 import layout from '../../../../templates/components/models-table/themes/semanticui/columns-dropdown';
 
+/**
+ * @class SuiModelsTableColumnsDropdown
+ * @namespace Components
+ * @extends Components.ModelsTableColumnsDropdown
+ */
 export default
 @templateLayout(layout)
-class ColumnsDropdownComponent extends DefaultColumnsDropdown {
+class SuiModelsTableColumnsDropdownComponent extends ModelsTableColumnsDropdownComponent {
 }

--- a/addon/components/models-table/themes/semanticui/data-group-by-select.js
+++ b/addon/components/models-table/themes/semanticui/data-group-by-select.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
 import layout from '../../../../templates/components/models-table/themes/semanticui/data-group-by-select';
-import DefaultDataGroupBySelect from '../../data-group-by-select';
+import ModelsTableDataGroupBySelectComponent from '../../data-group-by-select';
 
+/**
+ * @class SuiModelsTableDataGroupBySelect
+ * @namespace Components
+ * @extends Components.ModelsTableDataGroupBySelect
+ */
 export default
 @templateLayout(layout)
-class DataGroupBySelectComponent extends DefaultDataGroupBySelect {
+class SuiModelsTableDataGroupBySelectComponent extends ModelsTableDataGroupBySelectComponent {
 }

--- a/addon/components/models-table/themes/semanticui/global-filter.js
+++ b/addon/components/models-table/themes/semanticui/global-filter.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
 import layout from '../../../../templates/components/models-table/themes/semanticui/global-filter';
-import DefaultGlobalFilter from '../../global-filter';
+import ModelsTableGlobalFilterComponent from '../../global-filter';
 
+/**
+ * @class SuiModelsTableGlobalFilter
+ * @namespace Components
+ * @extends Components.ModelsTableGlobalFilter
+ */
 export default
 @templateLayout(layout)
-class GlobalFilterComponent extends DefaultGlobalFilter {
+class SuiModelsTableGlobalFilterComponent extends ModelsTableGlobalFilterComponent {
 }

--- a/addon/components/models-table/themes/semanticui/pagination-numeric.js
+++ b/addon/components/models-table/themes/semanticui/pagination-numeric.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultPaginationNumeric from '../../pagination-numeric';
+import ModelsTablePaginationNumericComponent from '../../pagination-numeric';
 import layout from '../../../../templates/components/models-table/themes/semanticui/pagination-numeric';
 
+/**
+ * @class SuiModelsTablePaginationNumeric
+ * @namespace Components
+ * @extends Components.ModelsTablePaginationNumeric
+ */
 export default
 @templateLayout(layout)
-class PaginationNumericComponent extends DefaultPaginationNumeric {
+class SuiModelsTablePaginationNumericComponent extends ModelsTablePaginationNumericComponent {
 }

--- a/addon/components/models-table/themes/semanticui/pagination-simple.js
+++ b/addon/components/models-table/themes/semanticui/pagination-simple.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultPaginationSimple from '../../pagination-simple';
+import ModelsTablePaginationSimpleComponent from '../../pagination-simple';
 import layout from '../../../../templates/components/models-table/themes/semanticui/pagination-simple';
 
+/**
+ * @class SuiModelsTablePaginationSimple
+ * @namespace Components
+ * @extends Components.ModelsTablePaginationSimple
+ */
 export default
 @templateLayout(layout)
-class PaginationSimpleComponent extends DefaultPaginationSimple {
+class SuiModelsTablePaginationSimpleComponent extends ModelsTablePaginationSimpleComponent {
 }

--- a/addon/components/models-table/themes/semanticui/row-filtering-cell.js
+++ b/addon/components/models-table/themes/semanticui/row-filtering-cell.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultRowFilteringCell from '../../row-filtering-cell';
+import ModelsTableRowFilteringCellComponent from '../../row-filtering-cell';
 import layout from '../../../../templates/components/models-table/themes/semanticui/row-filtering-cell';
 
+/**
+ * @class SuiModelsTableRowFilteringCell
+ * @namespace Components
+ * @extends Components.ModelsTableRowFilteringCell
+ */
 export default
 @templateLayout(layout)
-class RowFilteringCellComponent extends DefaultRowFilteringCell {
+class SuiModelsTableRowFilteringCellComponent extends ModelsTableRowFilteringCellComponent {
 }

--- a/addon/components/models-table/themes/semanticui/select.js
+++ b/addon/components/models-table/themes/semanticui/select.js
@@ -1,10 +1,15 @@
 import {classNames, classNameBindings, layout as templateLayout} from '@ember-decorators/component';
-import DefaultSelect from 'ember-models-table/components/models-table/select';
+import ModelsTableSelectComponent from 'ember-models-table/components/models-table/select';
 import layout from '../../../../templates/components/models-table/select';
 
+/**
+ * @class SuiModelsTableSelect
+ * @namespace Components
+ * @extends Components.ModelsTableSelect
+ */
 export default
 @templateLayout(layout)
 @classNames('ui', 'fluid', 'dropdown')
 @classNameBindings('options.length::disabled')
-class SelectComponent extends DefaultSelect {
+class SuiModelsTableSelectComponent extends ModelsTableSelectComponent {
 }

--- a/addon/components/models-table/themes/semanticui/summary.js
+++ b/addon/components/models-table/themes/semanticui/summary.js
@@ -1,8 +1,13 @@
 import {layout as templateLayout} from '@ember-decorators/component';
-import DefaultSummary from '../../summary';
+import ModelsTableSummaryComponent from '../../summary';
 import layout from '../../../../templates/components/models-table/themes/semanticui/summary';
 
+/**
+ * @class SuiModelsTableSummary
+ * @namespace Components
+ * @extends Components.ModelsTableSummary
+ */
 export default
 @templateLayout(layout)
-class SummaryComponent extends DefaultSummary {
+class SuiModelsTableSummaryComponent extends ModelsTableSummaryComponent {
 }

--- a/addon/templates/components/models-table/cell-edit-toggle.hbs
+++ b/addon/templates/components/models-table/cell-edit-toggle.hbs
@@ -1,17 +1,17 @@
 {{#if isEditRow}}
   <button
-    class={{themeInstance.cancel-row-button}}
+    class={{themeInstance.cancelRowButton}}
     onclick={{action "cancelClicked"}}>
     {{cancelButtonLabel}}
   </button>
   <button
-    class={{themeInstance.save-row-button}}
+    class={{themeInstance.saveRowButton}}
     onclick={{action "saveClicked"}}>
     {{saveButtonLabel}}
   </button>
 {{else}}
   <button
-    class={{themeInstance.edit-row-button}}
+    class={{themeInstance.editRowButton}}
     onclick={{action "editClicked"}}>
     {{editButtonLabel}}
   </button>

--- a/addon/templates/components/models-table/cell.hbs
+++ b/addon/templates/components/models-table/cell.hbs
@@ -5,6 +5,7 @@
       index=index
       column=column
       componentToRender=componentToRender
+      groupedLength=groupedLength
       expandRow=expandRow
       collapseRow=collapseRow
       expandAllRows=expandAllRows
@@ -38,6 +39,7 @@
         @isExpanded={{isExpanded}}
         @isSelected={{isSelected}}
         @isColumnEditable={{isColumnEditable}}
+        @groupedLength={{groupedLength}}
         @themeInstance={{themeInstance}} />
     {{/let}}
   {{/if}}

--- a/addon/templates/components/models-table/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/columns-dropdown.hbs
@@ -19,7 +19,7 @@
         data-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false">
-        {{themeInstance.columnsTitleMsg}} <i class={{themeInstance.caret}}></i>
+        {{themeInstance.columnsTitleMsg}} <i class={{themeInstance.caretIcon}}></i>
       </button>
       <ul class={{themeInstance.columnsDropdown}} data-role="dropdown">
 
@@ -60,7 +60,7 @@
             <li>
               <a {{action "doToggleHidden" column bubbles=false}} href="#">
                 <i
-                  class={{if column.isVisible themeInstance.column-visible themeInstance.column-hidden}}>
+                  class={{if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon}}>
                 </i> {{column.title}}
               </a>
             </li>

--- a/addon/templates/components/models-table/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/data-group-by-select.hbs
@@ -28,8 +28,8 @@ as |DataGroupBySelect|}}
             <i
               class={{if
                 (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sort-asc
-                themeInstance.sort-desc}}>
+                themeInstance.sortAsc
+                themeInstance.sortDescIcon}}>
             </i>
           </button>
         </div>

--- a/addon/templates/components/models-table/grouped-header.hbs
+++ b/addon/templates/components/models-table/grouped-header.hbs
@@ -1,10 +1,10 @@
 {{#if (has-block)}}
-  {{yield}}
+  {{yield (hash groupedHeader=@groupedHeader)}}
 {{else}}
-  {{#if (and (is-equal displayGroupedValueAs "column") useDataGrouping)}}
+  {{#if (and (is-equal @displayGroupedValueAs "column") @useDataGrouping)}}
     <th></th>
   {{/if}}
-  {{#each groupedHeader as |cell|}}
+  {{#each @groupedHeader as |cell|}}
     <th colspan={{cell.colspan}} rowspan={{cell.rowspan}}>{{cell.title}}</th>
   {{/each}}
 {{/if}}

--- a/addon/templates/components/models-table/pagination-simple.hbs
+++ b/addon/templates/components/models-table/pagination-simple.hbs
@@ -28,25 +28,25 @@ as |Pagination|}}
           class="{{if gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
           {{action "gotoFirst"}}>
-          <i class={{themeInstance.nav-first}}></i>
+          <i class={{themeInstance.navFirstIcon}}></i>
         </button>
         <button
           class="{{if gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
           {{action "gotoPrev"}}>
-          <i class={{themeInstance.nav-prev}}></i>
+          <i class={{themeInstance.navPrevIcon}}></i>
         </button>
         <button
           class="{{if gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToNextPageButtonTextMsg}}
           {{action "gotoNext"}}>
-          <i class={{themeInstance.nav-next}}></i>
+          <i class={{themeInstance.navNextIcon}}></i>
         </button>
         <button
           class="{{if gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToLastPageButtonTextMsg}}
           {{action "gotoLast"}}>
-          <i class={{themeInstance.nav-last}}></i>
+          <i class={{themeInstance.navLastIcon}}></i>
         </button>
       </div>
     </div>

--- a/addon/templates/components/models-table/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/row-sorting-cell.hbs
@@ -34,7 +34,7 @@
     {{column.title}}
     {{#if column.useSorting}}
       <i
-        class="{{if column.sortAsc themeInstance.sort-asc}} {{if column.sortDesc themeInstance.sort-desc}}">
+        class="{{if column.sortAsc themeInstance.sortAscIcon}} {{if column.sortDesc themeInstance.sortDescIcon}}">
       </i>
     {{/if}}
   {{/if}}

--- a/addon/templates/components/models-table/themes/bootstrap4/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/columns-dropdown.hbs
@@ -19,7 +19,7 @@
       aria-haspopup="true"
       aria-expanded="false">
       {{themeInstance.columnsTitleMsg}}
-      <i class={{themeInstance.caret}}></i>
+      <i class={{themeInstance.caretIcon}}></i>
     </button>
     <div class={{themeInstance.columnsDropdown}}>
       {{#if columnDropdownOptions.showAll}}
@@ -62,7 +62,7 @@
             class="dropdown-item"
             {{action "doToggleHidden" column bubbles=false}}>
             <i
-              class={{if column.isVisible themeInstance.column-visible themeInstance.column-hidden}}>
+              class={{if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon}}>
             </i>
             {{column.title}}
           </a>

--- a/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
@@ -29,8 +29,8 @@ as |DataGroupBySelect|}}
             <i
               class={{if
                 (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sort-asc
-                themeInstance.sort-desc}}>
+                themeInstance.sortAscIcon
+                themeInstance.sortDescIcon}}>
             </i>
           </button>
         </span>

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.hbs
@@ -17,7 +17,7 @@
   as |Dropdown|>
     <Dropdown.toggle class={{themeInstance.buttonDefault}}>
       {{themeInstance.columnsTitleMsg}}
-      <span class="caret"></span>
+      <span class={{themeInstance.caretIcon}}></span>
     </Dropdown.toggle>
     <Dropdown.menu
       align="right"
@@ -71,7 +71,7 @@
               class="dropdown-item"
               {{action "doToggleHidden" column bubbles=false}}>
               <i
-                class={{if column.isVisible themeInstance.column-visible themeInstance.column-hidden}}>
+                class={{if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon}}>
               </i>
               {{column.title}}
             </a>

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
@@ -40,8 +40,8 @@ as |DataGroupBySelect|}}
               <i
                 class={{if
                 (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sort-asc
-                themeInstance.sort-desc}}>
+                themeInstance.sortAscIcon
+                themeInstance.sortDescIcon}}>
               </i>
             </BsButton>
           </span>

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
@@ -70,7 +70,7 @@
               class="dropdown-item"
               {{action "doToggleHidden" column bubbles=false}}>
               <i
-                class={{if column.isVisible themeInstance.column-visible themeInstance.column-hidden}}>
+                class={{if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon}}>
               </i>
               {{column.title}}
             </a>

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
@@ -43,8 +43,8 @@ as |DataGroupBySelect|}}
               <i
                 class={{if
                 (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sort-asc
-                themeInstance.sort-desc}}>
+                themeInstance.sortAscIcon
+                themeInstance.sortDescIcon}}>
               </i>
             </BsButton>
           </div>

--- a/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
@@ -39,8 +39,8 @@
         {{#if column.mayBeHidden}}
           <content.menu-item @onClick={{action "doToggleHidden" column bubbles=false}}>
             {{paper-icon
-              (if column.isVisible themeInstance.column-visible themeInstance.column-hidden)
-              class=(if column.isVisible themeInstance.column-visible themeInstance.column-hidden)
+              (if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon)
+              class=(if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon)
             }}
             {{column.title}}
           </content.menu-item>

--- a/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
@@ -25,8 +25,8 @@ as |DataGroupBySelect|}}
         @onClick={{action "doSort"}}>
         {{paper-icon (if
           (is-equal "asc" sortByGroupedFieldDirection)
-            themeInstance.sort-asc
-            themeInstance.sort-desc)}}
+            themeInstance.sortAscIcon
+            themeInstance.sortDescIcon)}}
       </PaperButton>
     </div>
   {{/if}}

--- a/addon/templates/components/models-table/themes/ember-paper/pagination-simple.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/pagination-simple.hbs
@@ -33,7 +33,7 @@ as |Pagination|}}
           @onClick={{action "gotoFirst"}}
           @disabled={{not gotoBackEnabled}}
           @iconButton={{true}}>
-          {{paper-icon themeInstance.nav-first class=themeInstance.nav-first}}
+          {{paper-icon themeInstance.navFirstIcon class=themeInstance.navFirstIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
@@ -41,7 +41,7 @@ as |Pagination|}}
           @onClick={{action "gotoPrev"}}
           @disabled={{not gotoBackEnabled}}
           @iconButton={{true}}>
-          {{paper-icon themeInstance.nav-prev class=themeInstance.nav-prev}}
+          {{paper-icon themeInstance.navPrevIcon class=themeInstance.navPrevIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToNextPageButtonTextMsg}}
@@ -49,7 +49,7 @@ as |Pagination|}}
           @onClick={{action "gotoNext"}}
           @disabled={{not gotoForwardEnabled}}
           @iconButton={{true}}>
-          {{paper-icon themeInstance.nav-next class=themeInstance.nav-next}}
+          {{paper-icon themeInstance.navNextIcon class=themeInstance.navNextIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToLastPageButtonTextMsg}}
@@ -57,7 +57,7 @@ as |Pagination|}}
           @onClick={{action "gotoLast"}}
           @disabled={{not gotoForwardEnabled}}
           @iconButton={{true}}>
-          {{paper-icon themeInstance.nav-last class=themeInstance.nav-last}}
+          {{paper-icon themeInstance.navLastIcon class=themeInstance.navLastIcon}}
         </PaperButton>
       </div>
     </div>

--- a/addon/templates/components/models-table/themes/ember-paper/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/row-filtering-cell.hbs
@@ -26,7 +26,7 @@
     {{/let}}
   {{else}}
     {{#if column.useFilter}}
-      <div class={{themeInstance.filtering-cell-internal-wrapper}}>
+      <div class={{themeInstance.filteringCellInternalWrapper}}>
         {{#if column.filterWithSelect}}
           {{#let
             (component

--- a/addon/templates/components/models-table/themes/ember-paper/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/row-sorting-cell.hbs
@@ -34,8 +34,8 @@
     {{column.title}}
     {{#if column.useSorting}}
       {{#if (or column.sortAsc column.sortDesc)}}
-        {{paper-icon (if column.sortAsc themeInstance.sort-asc (if column.sortDesc themeInstance.sort-desc))
-         class=(if column.sortAsc themeInstance.sort-asc (if column.sortDesc themeInstance.sort-desc))
+        {{paper-icon (if column.sortAsc themeInstance.sortAscIcon (if column.sortDesc themeInstance.sortDescIcon))
+         class=(if column.sortAsc themeInstance.sortAscIcon (if column.sortDesc themeInstance.sortDescIcon))
         }}
       {{/if}}
     {{/if}}

--- a/addon/templates/components/models-table/themes/semanticui/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/columns-dropdown.hbs
@@ -14,7 +14,7 @@
   <div class={{themeInstance.columnsDropdownWrapper}}>
     <div class="ui simple dropdown item">
       <div class="text">{{themeInstance.columnsTitleMsg}}</div>
-      <i class={{themeInstance.caret}}></i>
+      <i class={{themeInstance.caretIcon}}></i>
       <div class="menu floating left">
         {{#if columnDropdownOptions.showAll}}
           <div class="item" {{action "doShowAllColumns" bubbles=false}}>
@@ -41,7 +41,7 @@
           {{#if column.mayBeHidden}}
             <div class="item" {{action "doToggleHidden" column bubbles=false}}>
               <i
-                class={{if column.isVisible themeInstance.column-visible themeInstance.column-hidden}}>
+                class={{if column.isVisible themeInstance.columnVisibleIcon themeInstance.columnHiddenIcon}}>
               </i>
               {{column.title}}
             </div>

--- a/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
@@ -23,8 +23,8 @@ as |DataGroupBySelect|}}
         <i
           class={{if
             (is-equal "asc" sortByGroupedFieldDirection)
-            themeInstance.sort-asc
-            themeInstance.sort-desc}}>
+            themeInstance.sortAscIcon
+            themeInstance.sortDescIcon}}>
         </i>
       </button>
     </div>

--- a/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
@@ -35,25 +35,25 @@
             class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
             aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
             {{action "gotoFirst"}}>
-            <i class={{themeInstance.nav-first}}></i>
+            <i class={{themeInstance.navFirstIcon}}></i>
           </button>
           <button
             class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
             aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
             {{action "gotoPrev"}}>
-            <i class={{themeInstance.nav-prev}}></i>
+            <i class={{themeInstance.navPrevIcon}}></i>
           </button>
           <button
             class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
             aria-label={{themeInstance.goToNextPageButtonTextMsg}}
             {{action "gotoNext"}}>
-            <i class={{themeInstance.nav-next}}></i>
+            <i class={{themeInstance.navNextIcon}}></i>
           </button>
           <button
             class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
             aria-label={{themeInstance.goToLastPageButtonTextMsg}}
             {{action "gotoLast"}}>
-            <i class={{themeInstance.nav-last}}></i>
+            <i class={{themeInstance.navLastIcon}}></i>
           </button>
         </div>
       </div>

--- a/addon/themes/bootstrap3.js
+++ b/addon/themes/bootstrap3.js
@@ -8,371 +8,336 @@ import DefaultTheme from './default';
 export default class Bootstrap3Theme extends DefaultTheme {
 
   /**
-   * List of classes added to the table-tag
+   * @property table
    * @type string
    * @default 'table table-striped table-bordered table-condensed'
    */
   table = 'table table-striped table-bordered table-condensed';
 
   /**
-   * Wrapper for grouped buttons
-   *
+   * @property buttonsGroup
    * @type string
    * @default 'btn-group'
    */
   buttonsGroup = 'btn-group';
 
   /**
-   * Wrapper for global filter
-   *
+   * @property globalFilterWrapper
    * @type string
    * @default 'pull-left'
    */
   globalFilterWrapper = 'pull-left';
 
   /**
+   * @property sortGroupedPropertyBtn
    * @type string
    * @default 'btn btn-default'
    */
   sortGroupedPropertyBtn = 'btn btn-default';
 
   /**
-   * Wrapper for dropdown with list of columns
-   *
+   * @property columnsDropdownWrapper
    * @type string
    * @default 'pull-right columns-dropdown'
    */
   columnsDropdownWrapper = 'pull-right columns-dropdown';
 
   /**
-   * Dropdown with list of columns itself
-   *
+   * @property columnsDropdown
    * @type string
    * @default 'dropdown-menu pull-right'
    */
   columnsDropdown = 'dropdown-menu pull-right';
 
   /**
-   * Class for dropdown item used as a divider between "group" actions and "single" column actions
-   *
+   * @property columnsDropdownDivider
    * @type string
    * @default 'divider'
    */
   columnsDropdownDivider = 'divider';
 
   /**
-   * Class for select field for grouped property
-   *
+   * @property dataGroupBySelectWrapper
    * @type string
    * @default 'pull-left'
    */
   dataGroupBySelectWrapper = 'data-group-by-wrapper pull-left';
 
   /**
-   * Wrapper for numeric pagination
-   *
+   * @property footerSummaryNumericPagination
    * @type string
    * @default 'col-md-4 col-sm-4 col-xs-4'
    */
   footerSummaryNumericPagination = 'col-md-4 col-sm-4 col-xs-4';
 
   /**
-   * Wrapper for simple pagination
-   *
+   * @property footerSummaryDefaultPagination
    * @type string
    * @default 'col-md-5 col-sm-5 col-xs-5'
    */
   footerSummaryDefaultPagination = 'col-md-5 col-sm-5 col-xs-5';
 
   /**
-   * Wrapper for page selection block
-   *
+   * @property pageSizeWrapper
    * @type string
    * @default 'col-md-2 col-sm-2 col-xs-2'
    */
   pageSizeWrapper = 'col-md-2 col-sm-2 col-xs-2';
 
   /**
-   * Wrapper for select-tag in the page-size-select component
-   *
+   * @property pageSizeSelectWrapper
    * @type string
    * @default 'pull-right'
    */
   pageSizeSelectWrapper = 'pull-left';
 
   /**
-   * Wrapper for select-tag in the current-page-number-select component
-   *
+   * @property currentPageSizeSelectWrapper
    * @type string
    * @default 'pull-right'
    */
   currentPageSizeSelectWrapper = 'pull-right';
 
   /**
-   * Wrapper for pagination buttons. Used for numeric and simple pagination components
-   *
+   * @property paginationInternalWrapper
    * @type string
    * @default 'btn-toolbar pull-right'
    */
   paginationInternalWrapper = 'btn-toolbar pull-right';
 
   /**
-   * Wrapper for numeric pagination component
-   *
+   * @property paginationWrapperNumeric
    * @type string
    * @default 'col-md-6 col-sm-6 col-xs-6'
    */
   paginationWrapperNumeric = 'col-md-6 col-sm-6 col-xs-6';
 
   /**
-   * Wrapper for simple pagination component
-   *
+   * @property paginationWrapperDefault
    * @type string
    * @default 'col-md-5 col-sm-5 col-xs-5'
    */
   paginationWrapperDefault = 'col-md-5 col-sm-5 col-xs-5';
 
   /**
+   * @property paginationBlock
    * @type string
    * @default 'btn-group'
    */
   paginationBlock = 'btn-group';
 
   /**
-   * CSS-class for active item in the numeric pagination
-   *
+   * @property paginationNumericItemActive
    * @type string
    * @default 'active'
    */
   paginationNumericItemActive = 'active';
 
   /**
-   * Css-class for any button
-   *
+   * @property buttonDefault
    * @type string
    * @default 'btn btn-default'
    */
   buttonDefault = 'btn btn-default';
 
   /**
-   * CSS-class for link-like buttons
-   *
+   * @property buttonLink
    * @type string
    * @default 'btn btn-link'
    */
   buttonLink = 'btn btn-link';
 
   /**
+   * @property form
    * @type string
    * @default 'form-inline'
    */
   form = 'form-inline';
 
   /**
+   * @property formElementWrapper
    * @type string
    * @default 'form-group'
    */
   formElementWrapper = 'form-group';
 
   /**
-   * CSS-class for all form-input items
-   *
+   * @property input
    * @type string
    * @default 'form-control'
    */
   input = 'form-control';
 
   /**
-   * Extra CSS-class for select elements
-   *
+   * @property select
    * @type string
    * @default ''
    */
   select = '';
 
   /**
-   * Wrapper for component footer (contains pagination, summary and pager)
-   *
+   * @property tfooterWrapper
    * @type string
    * @default 'table-footer clearfix'
    */
   tfooterWrapper = 'table-footer clearfix';
 
   /**
-   * Internal wrapper for table footer content
-   *
-   * Internal wrapper contains pagination, summary and pager. It's needed to provide a grid
-   *
+   * @property tfooterInternalWrapper
    * @type string
    * @default 'row'
    */
   tfooterInternalWrapper = 'row';
 
   /**
-   * Icon for clear column filters
-   *
+   * @property clearFilterIcon
    * @type string
    * @default 'glyphicon glyphicon-remove-sign form-control-feedback'
    */
   clearFilterIcon = 'glyphicon glyphicon-remove-sign form-control-feedback';
 
   /**
-   * Icon for clear all filters button
-   *
+   * @property clearAllFiltersIcon
    * @type string
    * @default 'glyphicon glyphicon-remove-circle'
    */
   clearAllFiltersIcon = 'glyphicon glyphicon-remove-circle';
 
   /**
-   * Icon for columns sorted asc
-   *
+   * @property sortAscIcon
    * @type string
    * @default 'glyphicon glyphicon-triangle-top'
    */
   sortAscIcon = 'glyphicon glyphicon-triangle-top';
 
   /**
-   * Icon for columns sorted desc
-   *
+   * @property sortDescIcon
    * @type string
    * @default 'glyphicon glyphicon-triangle-bottom'
    */
   sortDescIcon = 'glyphicon glyphicon-triangle-bottom';
 
   /**
-   * Icon for columns dropdown. It's used for currently visible columns
-   *
+   * @property columnVisibleIcon
    * @type string
    * @default 'glyphicon glyphicon-check'
    */
   columnVisibleIcon = 'glyphicon glyphicon-check';
 
   /**
-   * Icon for columns dropdown. It's used for currently hidden columns
-   *
+   * @property columnHiddenIcon
    * @type string
    * @default 'glyphicon glyphicon-unchecked'
    */
   columnHiddenIcon = 'glyphicon glyphicon-unchecked';
 
   /**
-   * Icon for simple pagination item "Go to first page"
-   *
+   * @property navFirstIcon
    * @type string
    * @default 'glyphicon glyphicon-chevron-left'
    */
   navFirstIcon = 'glyphicon glyphicon-chevron-left';
 
   /**
-   * Icon for simple pagination item "Go to prev page"
-   *
+   * @property navPrevIcon
    * @type string
    * @default 'glyphicon glyphicon-menu-left'
    */
   navPrevIcon = 'glyphicon glyphicon-menu-left';
 
   /**
-   * Icon for simple pagination item "Go to next page"
-   *
+   * @property navNextIcon
    * @type string
    * @default 'glyphicon glyphicon-menu-right'
    */
   navNextIcon = 'glyphicon glyphicon-menu-right';
 
   /**
-   * Icon for simple pagination item "Go to last page"
-   *
+   * @property navLastIcon
    * @type string
    * @default 'glyphicon glyphicon-chevron-right'
    */
   navLastIcon = 'glyphicon glyphicon-chevron-right';
 
   /**
-   * Caret for columns dropdown
-   *
+   * @property caretIcon
    * @type string
    * @default 'caretIcon'
    */
   caretIcon = 'caret';
 
   /**
-   * Icon for expanding row (used in the tbody tr internally)
-   *
+   * @property expandRowIcon
    * @type string
    * @default 'glyphicon glyphicon-plus'
    */
   expandRowIcon = 'glyphicon glyphicon-plus';
 
   /**
-   * Icon for expanding all rows (used in the thead)
-   *
+   * @property expandAllRowsIcon
    * @type string
    * @default 'glyphicon glyphicon-plus'
    */
   expandAllRowsIcon = 'glyphicon glyphicon-plus';
 
   /**
-   * Icon for collapsing row (used in the tbody tr internally)
-   *
+   * @property collapseRowIcon
    * @type string
    * @default 'glyphicon glyphicon-minus'
    */
   collapseRowIcon = 'glyphicon glyphicon-minus';
 
   /**
-   * Icon for collapsing all rows (used in the thead)
-   *
+   * @property collapseAllRowsIcon
    * @type string
    * @default 'glyphicon glyphicon-plus'
    */
   collapseAllRowsIcon = 'glyphicon glyphicon-minus';
 
   /**
-   * Icon for selection all rows (used in the thead)
-   *
+   * @property selectAllRowsIcon
    * @type string
    * @default 'glyphicon glyphicon-check'
    */
   selectAllRowsIcon = 'glyphicon glyphicon-check';
 
   /**
-   * Icon for deselection all rows (used in the thead)
-   *
+   * @property deselectAllRowsIcon
    * @type string
    * @default 'glyphicon glyphicon-unchecked'
    */
   deselectAllRowsIcon = 'glyphicon glyphicon-unchecked';
 
   /**
-   * Icon for selection row (used in the tbody tr internally)
-   *
+   * @property selectRowIcon
    * @type string
    * @default 'glyphicon glyphicon-check'
    */
   selectRowIcon = 'glyphicon glyphicon-check';
 
   /**
-   * Icon for deselection row (used in the tbody tr internally)
-   *
+   * @property deselectRowIcon
    * @type string
    * @default 'glyphicon glyphicon-unchecked'
    */
   deselectRowIcon = 'glyphicon glyphicon-unchecked';
 
   /**
+   * @property editRowButton
    * @type string
    * @default 'btn btn-default'
    */
   editRowButton = 'btn btn-default';
 
   /**
+   * @property saveRowButton
    * @type string
    * @default 'btn btn-default'
    */
   saveRowButton = 'btn btn-default';
 
   /**
+   * @property cancelRowButton
    * @type string
    * @default 'btn btn-default'
    */

--- a/addon/themes/bootstrap3.js
+++ b/addon/themes/bootstrap3.js
@@ -1,16 +1,15 @@
 import DefaultTheme from './default';
 
 /**
- * @class Bootstrap3
+ * @class Bootstrap3Theme
  * @namespace Themes
- * @extends Themes.Default
+ * @extends Themes.DefaultTheme
  */
 export default class Bootstrap3Theme extends DefaultTheme {
 
   /**
    * List of classes added to the table-tag
    * @type string
-   * @property table
    * @default 'table table-striped table-bordered table-condensed'
    */
   table = 'table table-striped table-bordered table-condensed';
@@ -19,7 +18,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for grouped buttons
    *
    * @type string
-   * @property buttonsGroup
    * @default 'btn-group'
    */
   buttonsGroup = 'btn-group';
@@ -27,15 +25,13 @@ export default class Bootstrap3Theme extends DefaultTheme {
   /**
    * Wrapper for global filter
    *
-   * @property globalFilterWrapper
    * @type string
    * @default 'pull-left'
    */
   globalFilterWrapper = 'pull-left';
 
   /**
-   * @property sortGroupedPropertyBtn
-   * @type {string}
+   * @type string
    * @default 'btn btn-default'
    */
   sortGroupedPropertyBtn = 'btn btn-default';
@@ -43,7 +39,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
   /**
    * Wrapper for dropdown with list of columns
    *
-   * @property columnsDropdownWrapper
    * @type string
    * @default 'pull-right columns-dropdown'
    */
@@ -52,7 +47,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
   /**
    * Dropdown with list of columns itself
    *
-   * @property columnsDropdown
    * @type string
    * @default 'dropdown-menu pull-right'
    */
@@ -61,7 +55,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
   /**
    * Class for dropdown item used as a divider between "group" actions and "single" column actions
    *
-   * @property columnsDropdownDivider
    * @type string
    * @default 'divider'
    */
@@ -70,7 +63,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
   /**
    * Class for select field for grouped property
    *
-   * @property dataGroupBySelectWrapper
    * @type string
    * @default 'pull-left'
    */
@@ -80,7 +72,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for numeric pagination
    *
    * @type string
-   * @property footerSummaryNumericPagination
    * @default 'col-md-4 col-sm-4 col-xs-4'
    */
   footerSummaryNumericPagination = 'col-md-4 col-sm-4 col-xs-4';
@@ -89,7 +80,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for simple pagination
    *
    * @type string
-   * @property footerSummaryDefaultPagination
    * @default 'col-md-5 col-sm-5 col-xs-5'
    */
   footerSummaryDefaultPagination = 'col-md-5 col-sm-5 col-xs-5';
@@ -98,7 +88,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for page selection block
    *
    * @type string
-   * @property pageSizeWrapper
    * @default 'col-md-2 col-sm-2 col-xs-2'
    */
   pageSizeWrapper = 'col-md-2 col-sm-2 col-xs-2';
@@ -107,7 +96,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for select-tag in the page-size-select component
    *
    * @type string
-   * @property pageSizeSelectWrapper
    * @default 'pull-right'
    */
   pageSizeSelectWrapper = 'pull-left';
@@ -116,7 +104,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for select-tag in the current-page-number-select component
    *
    * @type string
-   * @property currentPageSizeSelectWrapper
    * @default 'pull-right'
    */
   currentPageSizeSelectWrapper = 'pull-right';
@@ -125,7 +112,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for pagination buttons. Used for numeric and simple pagination components
    *
    * @type string
-   * @property paginationInternalWrapper
    * @default 'btn-toolbar pull-right'
    */
   paginationInternalWrapper = 'btn-toolbar pull-right';
@@ -134,7 +120,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for numeric pagination component
    *
    * @type string
-   * @property paginationWrapperNumeric
    * @default 'col-md-6 col-sm-6 col-xs-6'
    */
   paginationWrapperNumeric = 'col-md-6 col-sm-6 col-xs-6';
@@ -143,14 +128,12 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for simple pagination component
    *
    * @type string
-   * @property paginationWrapperDefault
    * @default 'col-md-5 col-sm-5 col-xs-5'
    */
   paginationWrapperDefault = 'col-md-5 col-sm-5 col-xs-5';
 
   /**
    * @type string
-   * @property paginationBlock
    * @default 'btn-group'
    */
   paginationBlock = 'btn-group';
@@ -159,7 +142,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * CSS-class for active item in the numeric pagination
    *
    * @type string
-   * @property paginationNumericItemActive
    * @default 'active'
    */
   paginationNumericItemActive = 'active';
@@ -168,7 +150,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Css-class for any button
    *
    * @type string
-   * @property buttonDefault
    * @default 'btn btn-default'
    */
   buttonDefault = 'btn btn-default';
@@ -177,20 +158,17 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * CSS-class for link-like buttons
    *
    * @type string
-   * @property buttonLink
    * @default 'btn btn-link'
    */
   buttonLink = 'btn btn-link';
 
   /**
    * @type string
-   * @property form
    * @default 'form-inline'
    */
   form = 'form-inline';
 
   /**
-   * @property formElementWrapper
    * @type string
    * @default 'form-group'
    */
@@ -200,7 +178,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * CSS-class for all form-input items
    *
    * @type string
-   * @property input
    * @default 'form-control'
    */
   input = 'form-control';
@@ -209,7 +186,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Extra CSS-class for select elements
    *
    * @type string
-   * @property select
    * @default ''
    */
   select = '';
@@ -218,7 +194,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Wrapper for component footer (contains pagination, summary and pager)
    *
    * @type string
-   * @property tfooterWrapper
    * @default 'table-footer clearfix'
    */
   tfooterWrapper = 'table-footer clearfix';
@@ -229,7 +204,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Internal wrapper contains pagination, summary and pager. It's needed to provide a grid
    *
    * @type string
-   * @property tfooterInternalWrapper
    * @default 'row'
    */
   tfooterInternalWrapper = 'row';
@@ -238,7 +212,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Icon for clear column filters
    *
    * @type string
-   * @property clearFilterIcon
    * @default 'glyphicon glyphicon-remove-sign form-control-feedback'
    */
   clearFilterIcon = 'glyphicon glyphicon-remove-sign form-control-feedback';
@@ -247,7 +220,6 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Icon for clear all filters button
    *
    * @type string
-   * @property clearAllFiltersIcon
    * @default 'glyphicon glyphicon-remove-circle'
    */
   clearAllFiltersIcon = 'glyphicon glyphicon-remove-circle';
@@ -256,174 +228,154 @@ export default class Bootstrap3Theme extends DefaultTheme {
    * Icon for columns sorted asc
    *
    * @type string
-   * @property sort-asc
    * @default 'glyphicon glyphicon-triangle-top'
    */
-  'sort-asc' = 'glyphicon glyphicon-triangle-top';
+  sortAscIcon = 'glyphicon glyphicon-triangle-top';
 
   /**
    * Icon for columns sorted desc
    *
    * @type string
-   * @property sort-desc
    * @default 'glyphicon glyphicon-triangle-bottom'
    */
-  'sort-desc' = 'glyphicon glyphicon-triangle-bottom';
+  sortDescIcon = 'glyphicon glyphicon-triangle-bottom';
 
   /**
    * Icon for columns dropdown. It's used for currently visible columns
    *
    * @type string
-   * @property column-visible
    * @default 'glyphicon glyphicon-check'
    */
-  'column-visible' = 'glyphicon glyphicon-check';
+  columnVisibleIcon = 'glyphicon glyphicon-check';
 
   /**
    * Icon for columns dropdown. It's used for currently hidden columns
    *
    * @type string
-   * @property column-hidden
    * @default 'glyphicon glyphicon-unchecked'
    */
-  'column-hidden' = 'glyphicon glyphicon-unchecked';
+  columnHiddenIcon = 'glyphicon glyphicon-unchecked';
 
   /**
    * Icon for simple pagination item "Go to first page"
    *
    * @type string
-   * @property nav-first
    * @default 'glyphicon glyphicon-chevron-left'
    */
-  'nav-first' = 'glyphicon glyphicon-chevron-left';
+  navFirstIcon = 'glyphicon glyphicon-chevron-left';
 
   /**
    * Icon for simple pagination item "Go to prev page"
    *
    * @type string
-   * @property nav-prev
    * @default 'glyphicon glyphicon-menu-left'
    */
-  'nav-prev' = 'glyphicon glyphicon-menu-left';
+  navPrevIcon = 'glyphicon glyphicon-menu-left';
 
   /**
    * Icon for simple pagination item "Go to next page"
    *
    * @type string
-   * @property nav-next
    * @default 'glyphicon glyphicon-menu-right'
    */
-  'nav-next' = 'glyphicon glyphicon-menu-right';
+  navNextIcon = 'glyphicon glyphicon-menu-right';
 
   /**
    * Icon for simple pagination item "Go to last page"
    *
    * @type string
-   * @property nav-last
    * @default 'glyphicon glyphicon-chevron-right'
    */
-  'nav-last' = 'glyphicon glyphicon-chevron-right';
+  navLastIcon = 'glyphicon glyphicon-chevron-right';
 
   /**
    * Caret for columns dropdown
    *
    * @type string
-   * @property caret
-   * @default 'caret'
+   * @default 'caretIcon'
    */
-  'caret' = 'caret';
+  caretIcon = 'caret';
 
   /**
    * Icon for expanding row (used in the tbody tr internally)
    *
    * @type string
-   * @property expand-row
    * @default 'glyphicon glyphicon-plus'
    */
-  'expand-row' = 'glyphicon glyphicon-plus';
+  expandRowIcon = 'glyphicon glyphicon-plus';
 
   /**
    * Icon for expanding all rows (used in the thead)
    *
    * @type string
-   * @property expand-all-rows
    * @default 'glyphicon glyphicon-plus'
    */
-  'expand-all-rows' = 'glyphicon glyphicon-plus';
+  expandAllRowsIcon = 'glyphicon glyphicon-plus';
 
   /**
    * Icon for collapsing row (used in the tbody tr internally)
    *
    * @type string
-   * @property collapse-row
    * @default 'glyphicon glyphicon-minus'
    */
-  'collapse-row' = 'glyphicon glyphicon-minus';
+  collapseRowIcon = 'glyphicon glyphicon-minus';
 
   /**
    * Icon for collapsing all rows (used in the thead)
    *
    * @type string
-   * @property collapse-all-rows
    * @default 'glyphicon glyphicon-plus'
    */
-  'collapse-all-rows' = 'glyphicon glyphicon-minus';
+  collapseAllRowsIcon = 'glyphicon glyphicon-minus';
 
   /**
    * Icon for selection all rows (used in the thead)
    *
    * @type string
-   * @property select-all-rows
    * @default 'glyphicon glyphicon-check'
    */
-  'select-all-rows' = 'glyphicon glyphicon-check';
+  selectAllRowsIcon = 'glyphicon glyphicon-check';
 
   /**
    * Icon for deselection all rows (used in the thead)
    *
    * @type string
-   * @property deselect-all-rows
    * @default 'glyphicon glyphicon-unchecked'
    */
-  'deselect-all-rows' = 'glyphicon glyphicon-unchecked';
+  deselectAllRowsIcon = 'glyphicon glyphicon-unchecked';
 
   /**
    * Icon for selection row (used in the tbody tr internally)
    *
    * @type string
-   * @property select-row
    * @default 'glyphicon glyphicon-check'
    */
-  'select-row' = 'glyphicon glyphicon-check';
+  selectRowIcon = 'glyphicon glyphicon-check';
 
   /**
    * Icon for deselection row (used in the tbody tr internally)
    *
    * @type string
-   * @property deselect-row
    * @default 'glyphicon glyphicon-unchecked'
    */
-  'deselect-row' = 'glyphicon glyphicon-unchecked';
+  deselectRowIcon = 'glyphicon glyphicon-unchecked';
 
   /**
    * @type string
-   * @property edit-row-button
    * @default 'btn btn-default'
    */
-  'edit-row-button' = 'btn btn-default';
+  editRowButton = 'btn btn-default';
 
   /**
    * @type string
-   * @property save-row-button
    * @default 'btn btn-default'
    */
-  'save-row-button' = 'btn btn-default';
+  saveRowButton = 'btn btn-default';
 
   /**
    * @type string
-   * @property cancel-row-button
    * @default 'btn btn-default'
    */
-  'cancel-row-button' = 'btn btn-default';
+  cancelRowButton = 'btn btn-default';
 
 }

--- a/addon/themes/bootstrap4.js
+++ b/addon/themes/bootstrap4.js
@@ -7,50 +7,290 @@ import {computed} from '@ember/object';
  * @extends Themes.Bootstrap3Theme
  */
 export default class Bootstrap4Theme extends Bootstrap3Theme {
+
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default 'models-table/themes/bootstrap4/columns-dropdown'
+   */
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/bootstrap4/data-group-by-select'
+   */
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/bootstrap4/global-filter'
+   */
+
+  /**
+   * @property rowFilteringCellComponent
+   * @type string
+   * @default 'models-table/themes/bootstrap4/row-filtering-cell'
+   */
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/bootstrap4/'
+   */
   componentsPath = 'models-table/themes/bootstrap4/';
+
+  /**
+   * @property table
+   * @type string
+   * @default 'table table-striped table-bordered table-condensed table-sm'
+   */
   table = 'table table-striped table-bordered table-condensed table-sm';
+
+  /**
+   * @property globalFilterWrapper
+   * @type string
+   * @default 'float-left'
+   */
   globalFilterWrapper = 'float-left';
+
+  /**
+   * @property columnsDropdown
+   * @type string
+   * @default 'dropdown-menu dropdown-menu-right'
+   */
   columnsDropdown = 'dropdown-menu dropdown-menu-right';
+
+  /**
+   * @property columnsDropdownWrapper
+   * @type string
+   * @default 'float-right columns-dropdown dropdown'
+   */
   columnsDropdownWrapper = 'float-right columns-dropdown dropdown';
+
+  /**
+   * @property columnsDropdownDivider
+   * @type string
+   * @default 'dropdown-divider'
+   */
   columnsDropdownDivider = 'dropdown-divider';
+
+  /**
+   * @property buttonDefault
+   * @type string
+   * @default 'btn btn-secondary'
+   */
   buttonDefault = 'btn btn-secondary';
 
+  /**
+   * @property buttonDefaultSmall
+   * @type string
+   * @default 'btn btn-secondary btn-sm'
+   */
   @computed('buttonDefault')
   get buttonDefaultSmall() {
     return `${this.buttonDefault} btn-sm`;
   }
 
-  buttonLink = 'btn btn-link';
-
+  /**
+   * @property footerSummaryNumericPagination
+   * @type string
+   * @default 'col-4'
+   */
   footerSummaryNumericPagination = 'col-4';
+
+  /**
+   * @property footerSummaryDefaultPagination
+   * @type string
+   * @default  'col-5'
+   */
   footerSummaryDefaultPagination = 'col-5';
+
+  /**
+   * @property pageSizeWrapper
+   * @type string
+   * @default 'col-2'
+   */
   pageSizeWrapper = 'col-2';
+
+  /**
+   * @property pageSizeSelectWrapper
+   * @type string
+   * @default 'float-right'
+   */
   pageSizeSelectWrapper = 'float-right';
+
+  /**
+   * @property paginationInternalWrapper
+   * @type string
+   * @default 'btn-toolbar float-right'
+   */
   paginationInternalWrapper = 'btn-toolbar float-right';
+
+  /**
+   * @property paginationWrapperNumeric
+   * @type string
+   * @default 'col-6'
+   */
   paginationWrapperNumeric = 'col-6';
+
+  /**
+   * @property paginationWrapperDefault
+   * @type string
+   * @default 'col-5'
+   */
   paginationWrapperDefault = 'col-5';
 
-  // font-awesome is used by default. Feel free to override with any font-icons library
+  /**
+   * @property clearFilterIcon
+   * @type string
+   * @default 'fa fa-times form-control-feedback'
+   */
   clearFilterIcon = 'fa fa-times form-control-feedback';
+
+  /**
+   * @property clearAllFiltersIcon
+   * @type string
+   * @default 'fa fa-times'
+   */
   clearAllFiltersIcon = 'fa fa-times';
+
+  /**
+   * @property sortGroupedPropertyBtn
+   * @type string
+   * @default 'btn'
+   */
   sortGroupedPropertyBtn = 'btn';
+
+  /**
+   * @property input
+   * @type string
+   * @default 'form-control'
+   */
   input = 'form-control';
+
+  /**
+   * @property inputGroup
+   * @type string
+   * @default 'input-group'
+   */
   inputGroup = 'input-group';
+
+  /**
+   * @property sortAscIcon
+   * @type string
+   * @default 'fa fa-sort-asc'
+   */
   sortAscIcon = 'fa fa-sort-asc';
+
+  /**
+   * @property sortDescIcon
+   * @type string
+   * @default 'fa fa-sort-desc'
+   */
   sortDescIcon = 'fa fa-sort-desc';
+
+  /**
+   * @property columnVisibleIcon
+   * @type string
+   * @default 'fa fa-check-square-o'
+   */
   columnVisibleIcon = 'fa fa-check-square-o';
+
+  /**
+   * @property columnHiddenIcon
+   * @type string
+   * @default 'fa fa-square-o'
+   */
   columnHiddenIcon = 'fa fa-square-o';
+
+  /**
+   * @property navFirstIcon
+   * @type string
+   * @default 'fa fa-angle-double-left'
+   */
   navFirstIcon = 'fa fa-angle-double-left';
+
+  /**
+   * @property navPrevIcon
+   * @type string
+   * @default 'fa fa-angle-left'
+   */
   navPrevIcon = 'fa fa-angle-left';
+
+  /**
+   * @property navNextIcon
+   * @type string
+   * @default 'fa fa-angle-right'
+   */
   navNextIcon = 'fa fa-angle-right';
+
+  /**
+   * @property navLastIcon
+   * @type string
+   * @default 'fa fa-angle-double-right'
+   */
   navLastIcon = 'fa fa-angle-double-right';
+
+  /**
+   * @property caretIcon
+   * @type string
+   * @default 'caret'
+   */
   caretIcon = 'caret';
+
+  /**
+   * @property expandRowIcon
+   * @type string
+   * @default 'fa fa-plus'
+   */
   expandRowIcon = 'fa fa-plus';
+
+  /**
+   * @property expandAllRowsIcon
+   * @type string
+   * @default 'fa fa-plus'
+   */
   expandAllRowsIcon = 'fa fa-plus';
+
+  /**
+   * @property collapseRowIcon
+   * @type string
+   * @default 'fa fa-minus'
+   */
   collapseRowIcon = 'fa fa-minus';
+
+  /**
+   * @property collapseAllRowsIcon
+   * @type string
+   * @default 'fa fa-minus'
+   */
   collapseAllRowsIcon = 'fa fa-minus';
+
+  /**
+   * @property selectAllRowsIcon
+   * @type string
+   * @default 'fa fa-check-square-o'
+   */
   selectAllRowsIcon = 'fa fa-check-square-o';
+
+  /**
+   * @property deselectAllRowsIcon
+   * @type string
+   * @default 'fa fa-square-o'
+   */
   deselectAllRowsIcon = 'fa fa-square-o';
+
+  /**
+   * @property selectRowIcon
+   * @type string
+   * @default 'fa fa-check-square-o'
+   */
   selectRowIcon = 'fa fa-check-square-o';
+
+  /**
+   * @property deselectRowIcon
+   * @type string
+   * @default 'fa fa-square-o'
+   */
   deselectRowIcon = 'fa fa-square-o';
 }

--- a/addon/themes/bootstrap4.js
+++ b/addon/themes/bootstrap4.js
@@ -2,9 +2,9 @@ import Bootstrap3Theme from './bootstrap3';
 import {computed} from '@ember/object';
 
 /**
- * @class Bootstrap4
+ * @class Bootstrap4Theme
  * @namespace Themes
- * @extends Themes.Bootstrap3
+ * @extends Themes.Bootstrap3Theme
  */
 export default class Bootstrap4Theme extends Bootstrap3Theme {
   componentsPath = 'models-table/themes/bootstrap4/';
@@ -16,7 +16,7 @@ export default class Bootstrap4Theme extends Bootstrap3Theme {
   buttonDefault = 'btn btn-secondary';
 
   @computed('buttonDefault')
-  get buttonDefaultSmall () {
+  get buttonDefaultSmall() {
     return `${this.buttonDefault} btn-sm`;
   }
 
@@ -36,21 +36,21 @@ export default class Bootstrap4Theme extends Bootstrap3Theme {
   sortGroupedPropertyBtn = 'btn';
   input = 'form-control';
   inputGroup = 'input-group';
-  'sort-asc' = 'fa fa-sort-asc';
-  'sort-desc' = 'fa fa-sort-desc';
-  'column-visible' = 'fa fa-check-square-o';
-  'column-hidden' = 'fa fa-square-o';
-  'nav-first' = 'fa fa-angle-double-left';
-  'nav-prev' = 'fa fa-angle-left';
-  'nav-next' = 'fa fa-angle-right';
-  'nav-last' = 'fa fa-angle-double-right';
-  'caret' = 'caret';
-  'expand-row' = 'fa fa-plus';
-  'expand-all-rows' = 'fa fa-plus';
-  'collapse-row' = 'fa fa-minus';
-  'collapse-all-rows' = 'fa fa-minus';
-  'select-all-rows' = 'fa fa-check-square-o';
-  'deselect-all-rows' = 'fa fa-square-o';
-  'select-row' = 'fa fa-check-square-o';
-  'deselect-row' = 'fa fa-square-o';
+  sortAscIcon = 'fa fa-sort-asc';
+  sortDescIcon = 'fa fa-sort-desc';
+  columnVisibleIcon = 'fa fa-check-square-o';
+  columnHiddenIcon = 'fa fa-square-o';
+  navFirstIcon = 'fa fa-angle-double-left';
+  navPrevIcon = 'fa fa-angle-left';
+  navNextIcon = 'fa fa-angle-right';
+  navLastIcon = 'fa fa-angle-double-right';
+  caretIcon = 'caret';
+  expandRowIcon = 'fa fa-plus';
+  expandAllRowsIcon = 'fa fa-plus';
+  collapseRowIcon = 'fa fa-minus';
+  collapseAllRowsIcon = 'fa fa-minus';
+  selectAllRowsIcon = 'fa fa-check-square-o';
+  deselectAllRowsIcon = 'fa fa-square-o';
+  selectRowIcon = 'fa fa-check-square-o';
+  deselectRowIcon = 'fa fa-square-o';
 }

--- a/addon/themes/default.js
+++ b/addon/themes/default.js
@@ -12,384 +12,568 @@ export const componentPath = (componentName) =>
 /**
  * Almost empty skeleton for themes. Extend it to provide custom css-classes for table items and icons.
  *
- * Check [BootstrapTheme](Themes.Bootstrap3.html) for implementation example.
+ * Check [BootstrapTheme](Themes.Bootstrap3Theme.html) for implementation example.
  *
  * Check [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance) for usage example.
  *
- * @class Default
+ * @class DefaultTheme
  * @namespace Themes
  */
 export default class DefaultTheme extends EmberObject {
 
   /**
-   * @property componentsPath
+   * Path to theme's components. It's used in the child-themes
+   *
    * @default 'models-table/'
-   * @type {string}
+   * @type string
    */
   componentsPath = 'models-table/';
 
   /**
-   * @property defaultComponentsPath
+   * Default path to theme's components
+   *
    * @default 'models-table/'
-   * @type {string}
+   * @type string
    */
   defaultComponentsPath = 'models-table/';
 
+  /**
+   * @type string
+   * @default 'models-table/cell'
+   */
   @componentPath('cell')
   cellComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/cell-content-display'
+   */
   @componentPath('cell-content-display')
   cellContentDisplayComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/cell-content-edit'
+   */
   @componentPath('cell-content-edit')
   cellContentEditComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/cell-column-summary'
+   */
   @componentPath('cell-column-summary')
   cellContentSummaryComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/columns-dropdown'
+   */
   @componentPath('columns-dropdown')
   columnsDropdownComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/columns-hidden'
+   */
   @componentPath('columns-hidden')
   columnsHiddenComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/data-group-by-select'
+   */
   @componentPath('data-group-by-select')
   dataGroupBySelectComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/footer'
+   */
   @componentPath('footer')
   footerComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/global-filter'
+   */
   @componentPath('global-filter')
   globalFilterComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/grouped-header'
+   */
   @componentPath('grouped-header')
   groupedHeaderComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/no-data'
+   */
   @componentPath('no-data')
   noDataComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/page-size-select'
+   */
   @componentPath('page-size-select')
   pageSizeSelectComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/pagination-numeric'
+   */
   @componentPath('pagination-numeric')
   paginationNumericComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/pagination-simple'
+   */
   @componentPath('pagination-simple')
   paginationSimpleComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row'
+   */
   @componentPath('row')
   rowComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-expand'
+   */
   @componentPath('row-expand')
   rowExpandComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-filtering'
+   */
   @componentPath('row-filtering')
   rowFilteringComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-filtering-cell'
+   */
   @componentPath('row-filtering-cell')
   rowFilteringCellComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-grouping'
+   */
   @componentPath('row-grouping')
   rowGroupingComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-group-toggle'
+   */
   @componentPath('row-group-toggle')
   rowGroupToggleComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-sorting'
+   */
   @componentPath('row-sorting')
   rowSortingComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/row-sorting-cell'
+   */
   @componentPath('row-sorting-cell')
   rowSortingCellComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/select'
+   */
   @componentPath('select')
   selectComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/summary'
+   */
   @componentPath('summary')
   summaryComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/table'
+   */
   @componentPath('table')
   tableComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/table-body'
+   */
   @componentPath('table-body')
   tableBodyComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/table-footer'
+   */
   @componentPath('table-footer')
   tableFooterComponent;
 
+  /**
+   * @type string
+   * @default 'models-table/table-header'
+   */
   @componentPath('table-header')
   tableHeaderComponent;
 
+  /**
+   * @type string
+   * @default ''
+   */
   cellContentTagName = '';
 
+  /**
+   * Label for global filter
+   *
+   * @type string
+   * @default 'Search:'
+   */
   searchLabelMsg = 'Search:';
+
+  /**
+   * Placeholder for global filter
+   *
+   * @type string
+   * @default ''
+   */
   searchPlaceholderMsg = '';
+
+  /**
+   * Label for dropdown with columns for rows grouping
+   *
+   * @type string
+   * @default 'Group by:'
+   */
   groupByLabelMsg = 'Group by:';
+
+  /**
+   * Text on toggle for columns dropdown
+   *
+   * @type string
+   * @default 'Columns'
+   */
   columnsTitleMsg = 'Columns';
+
+  /**
+   * Label for button to show all table columns (under columns dropdown)
+   *
+   * @type string
+   * @default 'Show All'
+   */
   columnsShowAllMsg = 'Show All';
+
+  /**
+   * Label for button to hide all table columns (under columns dropdown)
+   *
+   * @type string
+   * @default 'Hide All'
+   */
   columnsHideAllMsg = 'Hide All';
+
+  /**
+   * Label for button to restore default visibility for table columns (under columns dropdown)
+   *
+   * @type string
+   * @default 'Restore Defaults'
+   */
   columnsRestoreDefaultsMsg = 'Restore Defaults';
+
+  /**
+   * Message shown in the table summary. It's used with three options:
+   *
+   * 1. First row's index
+   * 2. Last row's index
+   * 3. Overall rows count
+   *
+   * @type string
+   * @default 'Show %@ - %@ of %@'
+   */
   tableSummaryMsg = 'Show %@ - %@ of %@';
+
+  /**
+   * Message shown when all columns are hidden. It's shown inside table body
+   */
   allColumnsAreHiddenMsg = 'All columns are hidden. Use <strong>columns</strong>-dropdown to show some of them';
+
+  /**
+   * Message shown when there are not data to display in the table. It's shown inside table body in cases when initial `data` is empty or when all records are filtered out
+   *
+   * @type string
+   * @default 'No records to show'
+   */
   noDataToShowMsg = 'No records to show';
+
+  /**
+   * Default label for button "Edit" inside the `cell-edit-toggle`-component
+   *
+   * @type string
+   * @default 'Edit'
+   */
   editRowButtonLabelMsg = 'Edit';
+
+  /**
+   * Default label for button "Save" inside the `cell-edit-toggle`-component
+   *
+   * @type string
+   * @default 'Save'
+   */
   saveRowButtonLabelMsg = 'Save';
+
+  /**
+   * Default label for button "Cancel" inside the `cell-edit-toggle`-component
+   *
+   * @type string
+   * @default 'Cancel'
+   */
   cancelRowButtonLabelMsg = 'Cancel';
+
+  /**
+   * Label for dropdown with page numbers. Used in both numeric and simple pagination
+   *
+   * @type string
+   * @default 'Page:'
+   */
   currentPageNumberMsg = 'Page:';
+
+  /**
+   * Label for dropdown with rows count shown in the page
+   *
+   * @type string
+   * @default 'Rows:'
+   */
   rowsCountMsg = 'Rows:';
+
+  /**
+   * Label for "First"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Go to first page'
+   */
   goToFirstPageButtonTextMsg = 'Go to first page';
+
+  /**
+   * Label for "Previous"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Go to previous page'
+   */
   goToPrevPageButtonTextMsg = 'Go to previous page';
+
+  /**
+   * Label for "Next"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Go to next page'
+   */
   goToNextPageButtonTextMsg = 'Go to next page';
+
+  /**
+   * Label for "Last"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Go to last page'
+   */
   goToLastPageButtonTextMsg = 'Go to last page';
+
+  /**
+   * Label for "Clear global filter"-button. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Clear global filter input'
+   */
   clearGlobalFilterMsg = 'Clear global filter input';
+
+  /**
+   * Label for "Clear filter"-buttons in the table header's cells. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Clear filter input'
+   */
   clearFilterMsg = 'Clear filter input';
+
+  /**
+   * Label for "Clear all filters"-button in the table summary section. It's used for screen-readers and not "visible" by default
+   *
+   * @type string
+   * @default 'Clear all filters'
+   */
   clearAllFiltersMsg = 'Clear all filters';
 
   /**
-   * Map with internal components
+   * CSS-classes for `table`-tag
    *
-   * You may override it if some custom component should be used instead the default one. You don't need to copy whole map because it's declared as a [mergedProperty](https://www.emberjs.com/api/ember/2.14/classes/Ember.CoreObject/properties/mergedProperties?anchor=mergedProperties)
-   *
-   * @property components
-   * @type object
-   */
-  components = {
-    'cell': 'models-table/cell',
-    'cell-content-display': 'models-table/cell-content-display',
-    'cell-content-edit': 'models-table/cell-content-edit',
-    'cell-column-summary': 'models-table/cell-column-summary',
-    'columns-dropdown': 'models-table/columns-dropdown',
-    'columns-hidden': 'models-table/columns-hidden',
-    'data-group-by-select': 'models-table/data-group-by-select',
-    'footer': 'models-table/footer',
-    'global-filter': 'models-table/global-filter',
-    'grouped-header': 'models-table/grouped-header',
-    'no-data': 'models-table/no-data',
-    'page-size-select': 'models-table/page-size-select',
-    'pagination-numeric': 'models-table/pagination-numeric',
-    'pagination-simple': 'models-table/pagination-simple',
-    'row': 'models-table/row',
-    'row-expand': 'models-table/row-expand',
-    'row-filtering': 'models-table/row-filtering',
-    'row-filtering-cell': 'models-table/row-filtering-cell',
-    'row-grouping': 'models-table/row-grouping',
-    'row-group-toggle': 'models-table/row-group-toggle',
-    'row-sorting': 'models-table/row-sorting',
-    'row-sorting-cell': 'models-table/row-sorting-cell',
-    'select': 'models-table/select',
-    'summary': 'models-table/summary',
-    'table': 'models-table/table',
-    'table-body': 'models-table/table-body',
-    'table-footer': 'models-table/table-footer',
-    'table-header': 'models-table/table-header'
-  };
-
-  tagNames = {
-    /* blank for backward compatibility */
-    'cell-content': ''
-  };
-
-  /**
-   *  Map with overrides for messages used in the component
-   *
-   * Available keys and values
-   *
-   *  * `searchLabel`: 'Search:',
-   *  * `groupByLabel`: 'Group by:',
-   *  * `searchPlaceholder`= '';
-   *  * `columns-title`: 'Columns',
-   *  * `columns-showAll`: 'Show All',
-   *  * `columns-hideAll`: 'Hide All',
-   *  * `columns-restoreDefaults`: 'Restore Defaults',
-   *  * `tableSummary`: 'Show %@ - %@ of %@',
-   *  * `allColumnsAreHidden`: 'All columns are hidden. Use <strong>columns</strong>-dropdown to show some of them',
-   *  * `noDataToShow`: 'No records to show',
-   *  * `editRowButtonLabel`: 'Edit',
-   *  * `saveRowButtonLabel`: 'Save',
-   *  * `cancelRowButtonLabel`: 'Cancel'
-   *  * `currentPageNumber`: 'Page:'
-   *  * `rowsCount`: 'Rows:'
-   *
-   * @property messages
-   * @type object
-   */
-  messages = {
-    searchLabel: 'Search:',
-    searchPlaceholder: '',
-    groupByLabel: 'Group by:',
-    'columns-title': 'Columns',
-    'columns-showAll': 'Show All',
-    'columns-hideAll': 'Hide All',
-    'columns-restoreDefaults': 'Restore Defaults',
-    tableSummary: 'Show %@ - %@ of %@',
-    allColumnsAreHidden: 'All columns are hidden. Use <strong>columns</strong>-dropdown to show some of them',
-    noDataToShow: 'No records to show',
-    editRowButtonLabel: 'Edit',
-    saveRowButtonLabel: 'Save',
-    cancelRowButtonLabel: 'Cancel',
-    currentPageNumber: 'Page:',
-    rowsCount: 'Rows:',
-    goToFirstPageButtonText: 'Go to first page',
-    goToPrevPageButtonText: 'Go to previous page',
-    goToNextPageButtonText: 'Go to next page',
-    goToLastPageButtonText: 'Go to last page',
-    clearGlobalFilter: 'Clear global filter input',
-    clearFilter: 'Clear filter input',
-    clearAllFilters: 'Clear all filters'
-  };
-
-  /**
-   * @property table
    * @type string
    * @default ''
    */
   table = '';
 
   /**
-   * @property buttonsGroup
    * @type string
    * @default ''
    */
   buttonsGroup = '';
 
   /**
-   * @property headerWrapper
+   * CSS-classes for `div`-wrapper over components `global-filter`, `data-group-by-select` and `columns-dropdown`
+   *
    * @type string
    * @default ''
    */
   headerWrapper = '';
 
   /**
+   * CSS-classes for wrapper used inside `global-filter` component
+   *
    * @type string
-   * @property globalFilterWrapper
    * @default ''
    */
   globalFilterWrapper = '';
 
   /**
+   * CSS-classes for wrapper used inside `columns-dropdown` component
+   *
    * @type string
-   * @property columnsDropdownWrapper
    * @default ''
    */
   columnsDropdownWrapper = '';
 
   /**
    * @type string
-   * @property columnsDropdownButtonWrapper
    * @default ''
    */
   columnsDropdownButtonWrapper = '';
 
   /**
+   * CSS-classes for wrapper over list inside `columns-dropdown` component
+   *
    * @type string
-   * @property columnsDropdown
    * @default ''
    */
   columnsDropdown = '';
 
   /**
+   * CSS-classes for divider for list inside `columns-dropdown` components. Divider is placed before single-column items by default
+   *
    * @type string
-   * @property columnsDropdownDivider
    * @default ''
    */
   columnsDropdownDivider = '';
 
   /**
+   * CSS-classes for wrapper inside `data-group-by-select` component
+   *
    * @type string
-   * @property dataGroupBySelectWrapper
    * @default ''
    */
   dataGroupBySelectWrapper = 'data-group-by-wrapper';
 
   /**
-   * CSS-class for thead cells
+   * CSS-classes for thead cells
    *
    * @type string
-   * @property theadCell
    * @default 'table-header'
    */
   theadCell = 'table-header';
 
   /**
-   * CSS-class used for thead-cells with columns titles. This class is used only if columns is not sortable
+   * CSS-classes used for thead-cells with columns titles. This class is used only if columns is not sortable
    *
    * @type string
-   * @property theadCellNoSorting
    * @default 'table-header-no-sorting'
    */
   theadCellNoSorting = 'table-header-no-sorting';
 
   /**
-   * CSS-class used for thead-cells with columns filters. This class is used only if columns is not filterable
+   * CSS-classes used for thead-cells with columns filters. This class is used only if columns is not filterable
    *
    * @type string
-   * @property theadCellNoFiltering
    * @default 'table-header-no-filtering'
    */
   theadCellNoFiltering = 'table-header-no-filtering';
 
   /**
+   * CSS-classes for selected rows. Used in the `row` component
+   *
    * @type string
-   * @property selectedRow
    * @default 'selected-row'
    */
   selectedRow = 'selected-row';
 
   /**
+   * CSS-classes for expanded rows. Used in the `row` component
+   *
    * @type string
-   * @property expandedRow
    * @default 'expanded-row'
    */
   expandedRow = 'expanded-row';
 
   /**
-   * CSS-class for table footer
+   * CSS-classes for table footer
    *
    * @type string
-   * @property tfooterWrapper
    * @default 'table-footer'
    */
   tfooterWrapper = 'table-footer';
 
   /**
+   * CSS-classes for wrapper inside `footer` component
+   *
    * @type string
-   * @property tfooterInternalWrapper
    * @default ''
    */
   tfooterInternalWrapper = '';
 
   /**
-   * CSS-class for table summary block
+   * CSS-classes for table summary block. Used in the `summary` component
    *
    * @type string
-   * @property footerSummary
    * @default 'table-summary'
    */
   footerSummary = 'table-summary';
 
   /**
+   * CSS-classes for table summary block. It's used when table has numeric pagination
+   *
    * @type string
-   * @property footerSummaryNumericPagination
    * @default ''
    */
   footerSummaryNumericPagination = '';
 
   /**
+   * CSS-classes for table summary block. It's used when table has simple pagination
+   *
    * @type string
-   * @property footerSummaryDefaultPagination
    * @default ''
    */
   footerSummaryDefaultPagination = '';
 
   /**
+   * CSS-classes for wrapper over "Page size"-block in the `footer` component
+   *
    * @type string
-   * @property pageSizeWrapper
    * @default ''
    */
   pageSizeWrapper = '';
 
   /**
    * @type string
-   * @property pageSizeSelectWrapper
    * @default ''
    */
   pageSizeSelectWrapper = '';
@@ -399,355 +583,359 @@ export default class DefaultTheme extends EmberObject {
    * Wrapper for select-tag in the current-page-number-select component
    *
    * @type string
-   * @property currentPageSizeSelectWrapper
    * @default ''
    */
   currentPageSizeSelectWrapper = '';
 
   /**
-   * Wrapper for pagination blocks
+   * CSS-classes for `pagination-simple` and `pagination-numeric` components
    *
    * @type string
-   * @property paginationWrapper
    * @default 'table-nav'
    */
   paginationWrapper = 'table-nav';
 
   /**
+   * CSS-classes for buttons-wrapper in the `pagination-simple` and `pagination-numeric` components
+   *
    * @type string
-   * @property paginationInternalWrapper
    * @default ''
    */
   paginationInternalWrapper = '';
 
   /**
+   * CSS-classes for `pagination-numeric` component
+   *
    * @type string
-   * @property paginationWrapperNumeric
    * @default ''
    */
   paginationWrapperNumeric = '';
 
   /**
+   * CSS-classes for `pagination-simple` component
+   *
    * @type string
-   * @property paginationWrapperDefault
    * @default ''
    */
   paginationWrapperDefault = '';
 
   /**
    * @type string
-   * @property paginationBlock
    * @default ''
    */
   paginationBlock = '';
 
   /**
+   * CSS-classes for items in the `pagination-numeric` component
+   *
    * @type string
-   * @property paginationNumericItem
    * @default ''
    */
   paginationNumericItem = '';
 
   /**
+   * CSS-classes for active item in the `pagination-numeric` component
+   *
    * @type string
-   * @property paginationNumericItemActive
    * @default ''
    */
   paginationNumericItemActive = '';
 
   /**
+   * CSS-classes for "default" buttons
+   *
    * @type string
-   * @property buttonDefault
    * @default ''
    */
   buttonDefault = '';
 
   /**
+   * CSS-classes for "link"-buttons
+   *
    * @type string
-   * @property buttonLink
    * @default ''
    */
   buttonLink = '';
 
   /**
+   * CSS-classes for `td` shown when all columns are hidden
+   *
    * @type string
-   * @property noDataCell
    * @default ''
    */
   noDataCell = '';
 
   /**
    * @type string
-   * @property collapseRow
-   * @default 'collapse-row'
+   * @default 'collapseRow'
    */
   collapseRow = 'collapse-row';
 
   /**
    * @type string
-   * @property collapseAllRows
    * @default 'collapse-all-rows'
    */
   collapseAllRows = 'collapse-all-rows';
 
   /**
    * @type string
-   * @property expandRow
    * @default 'expand-row'
    */
   expandRow = 'expand-row';
 
   /**
    * @type string
-   * @property expandAllRows
    * @default 'expand-all-rows'
    */
   expandAllRows = 'expand-all-rows';
 
   /**
    * @type string
-   * @property cellContentDisplay
    * @default ''
    */
   cellContentDisplay = '';
 
   /**
    * @type string
-   * @property cellContentEdit
    * @default ''
    */
   cellContentEdit = '';
 
   /**
-   * CSS-class for table header
+   * CSS-classes for `thead`
    *
    * @type string
-   * @property thead
    * @default ''
    */
   thead = '';
 
   /**
+   * CSS-classes for `form`
+   *
    * @type string
-   * @property form
    * @default ''
    */
   form = '';
 
   /**
-   * @property formElementWrapper
+   * CSS-classes for wrapper over the form elements
+   *
    * @type string
    * @default ''
    */
   formElementWrapper = '';
 
   /**
+   * CSS-classes for input elements
+   *
    * @type string
-   * @property input
    * @default ''
    */
   input = '';
 
   /**
+   * CSS-classes for `select`
+   *
    * @type string
-   * @property select
    * @default ''
    */
   select = '';
 
   /**
+   * CSS-classes for "Clear filter" button. Used for global filter and filters for each column
+   *
    * @type string
-   * @property clearFilterIcon
    * @default ''
    */
   clearFilterIcon = '';
 
   /**
+   * CSS-classes for "Clear all filters" button inside the `summary` component
+   *
    * @type string
-   * @property clearAllFiltersIcon
    * @default ''
    */
   clearAllFiltersIcon = '';
 
   /**
    * @type string
-   * @property globalFilterDropdownWrapper
    * @default ''
    */
   globalFilterDropdownWrapper = '';
 
   /**
+   * CSS-classes for `select` inside the `data-group-by-select` component
+   *
    * @type string
    * @default 'change-group-by-field'
-   * @property changeGroupByField
    */
   changeGroupByField = 'change-group-by-field';
 
   /**
+   * CSS-classes for "sort asc/desc" button inside the `data-group-by-select` component
+   *
    * @type string
    * @default ''
-   * @property sortGroupedPropertyBtn
    */
   sortGroupedPropertyBtn = 'sort-grouped-field';
 
   /**
+   * CSS-class for `row-grouping` component
+   *
    * @type string
-   * @property groupingRow
    * @default 'grouping-row'
    */
   groupingRow = 'grouping-row';
 
   /**
+   * CSS-classes for `td` inside `row-grouping` component
+   *
    * @type string
-   * @property groupingCell
    * @default 'grouping-cell'
    */
   groupingCell = 'grouping-cell';
 
   /**
+   * CSS-classes for icons used to show that some "list" is sorted "ASC". It's used for `data-group-by-select` and `row-sorting-cell`
+   *
    * @type string
-   * @property sort-asc
    * @default ''
    */
-  'sort-asc' = '';
+  sortAscIcon = '';
+
+  /**
+   * CSS-classes for icons used to show that some "list" is sorted "DESC". It's used for `data-group-by-select` and `row-sorting-cell`
+   *
+   * @type string
+   * @default ''
+   */
+  sortDescIcon = '';
+
+  /**
+   * CSS-classes for icons in the `columns-dropdown` related to the visible columns
+   *
+   * @type string
+   * @default ''
+   */
+  columnVisibleIcon = '';
+
+  /**
+   * CSS-classes for icons in the `columns-dropdown` related to the hidden columns
+   *
+   * @type string
+   * @default ''
+   */
+  columnHiddenIcon = '';
+
+  /**
+   * CSS-classes for icon used in the "First"-button (`pagination-simple`)
+   *
+   * @type string
+   * @default ''
+   */
+  navFirstIcon = '';
+
+  /**
+   * CSS-classes for icon used in the "Prev"-button (`pagination-simple`)
+   *
+   * @type string
+   * @default ''
+   */
+  navPrevIcon = '';
+
+  /**
+   * CSS-classes for icon used in the "Next"-button (`pagination-simple`)
+   *
+   * @type string
+   * @default ''
+   */
+  navNextIcon = '';
+
+  /**
+   * CSS-classes for icon used in the "Last"-button (`pagination-simple`)
+   *
+   * @type string
+   * @default ''
+   */
+  navLastIcon = '';
+
+  /**
+   * CSS-classes for "caret"-icon used in the `columns-dropdown`
+   *
+   * @type string
+   * @default ''
+   */
+  caretIcon = '';
 
   /**
    * @type string
-   * @property sort-desc
    * @default ''
    */
-  'sort-desc' = '';
+  selectAllRowsIcon = '';
 
   /**
    * @type string
-   * @property column-visible
    * @default ''
    */
-  'column-visible' = '';
+  deselectAllRowsIcon = '';
 
   /**
    * @type string
-   * @property column-hidden
    * @default ''
    */
-  'column-hidden' = '';
+  selectRowIcon = '';
 
   /**
    * @type string
-   * @property nav-first
    * @default ''
    */
-  'nav-first' = '';
+  deselectRowIcon = '';
 
   /**
    * @type string
-   * @property nav-prev
    * @default ''
    */
-  'nav-prev' = '';
+  editRowButton = '';
 
   /**
    * @type string
-   * @property nav-next
    * @default ''
    */
-  'nav-next' = '';
+  saveRowButton = '';
 
   /**
    * @type string
-   * @property nav-last
    * @default ''
    */
-  'nav-last' = '';
+  cancelRowButton = '';
 
   /**
    * @type string
-   * @property caret
    * @default ''
    */
-  'caret' = '';
+  filteringCellInternalWrapper = '';
 
   /**
    * @type string
-   * @property expand-row
    * @default ''
    */
-  'expand-row' = '';
+  expandRowIcon = '';
 
   /**
    * @type string
-   * @property expand-all-rows
    * @default ''
    */
-  'expand-all-rows' = '';
+  collapseRowIcon = '';
 
   /**
    * @type string
-   * @property collapse-row
    * @default ''
    */
-  'collapse-row' = '';
+  collapseAllRowsIcon = '';
 
   /**
    * @type string
-   * @property collapse-all-rows
    * @default ''
    */
-  'collapse-all-rows' = '';
-
-  /**
-   * @type string
-   * @property select-all-rows
-   * @default ''
-   */
-  'select-all-rows' = '';
-
-  /**
-   * @type string
-   * @property deselect-all-rows
-   * @default ''
-   */
-  'deselect-all-rows' = '';
-
-  /**
-   * @type string
-   * @property select-row
-   * @default ''
-   */
-  'select-row' = '';
-
-  /**
-   * @type string
-   * @property deselect-row
-   * @default ''
-   */
-  'deselect-row' = '';
-
-  /**
-   * @type string
-   * @property edit-row-button
-   * @default ''
-   */
-  'edit-row-button' = '';
-
-  /**
-   * @type string
-   * @property save-row-button
-   * @default ''
-   */
-  'save-row-button' = '';
-
-  /**
-   * @type string
-   * @property cancel-row-button
-   * @default ''
-   */
-  'cancel-row-button' = '';
-
-  /**
-   * @type string
-   * @property filtering-cell-internal-wrapper
-   * @default ''
-   */
-  'filtering-cell-internal-wrapper' = ''
+  expandAllRowsIcon = '';
 }

--- a/addon/themes/default.js
+++ b/addon/themes/default.js
@@ -10,11 +10,17 @@ export const componentPath = (componentName) =>
   });
 
 /**
- * Almost empty skeleton for themes. Extend it to provide custom css-classes for table items and icons.
+ * Almost empty skeleton for themes. Extend it to provide custom CSS-classes for table items and icons.
  *
- * Check [BootstrapTheme](Themes.Bootstrap3Theme.html) for implementation example.
+ * * Every property with suffix `Component` is a path to the component used in theme
+ * * Every property with suffix `Msg` is a message shown in the table
+ * * Every property with suffix `Icon` is a CSS-class for font-library used as an icons (used for buttons, carets etc)
  *
- * Check [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance) for usage example.
+ * **Difference from `v.2`:**
+ *
+ * * No `mergedProperties`
+ * * Properties `components`, `messages` and `icons` are removed. Every their key is placed directly in theme and named with suffix `Component`, `Msg` or `Icon`.
+ * * Every property name is converted to the `lowerCamelCase`
  *
  * @class DefaultTheme
  * @namespace Themes
@@ -24,6 +30,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Path to theme's components. It's used in the child-themes
    *
+   * @property componentsPath
    * @default 'models-table/'
    * @type string
    */
@@ -32,12 +39,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Default path to theme's components
    *
+   * @property defaultComponentsPath
    * @default 'models-table/'
    * @type string
    */
   defaultComponentsPath = 'models-table/';
 
   /**
+   * @property cellComponent
    * @type string
    * @default 'models-table/cell'
    */
@@ -45,6 +54,7 @@ export default class DefaultTheme extends EmberObject {
   cellComponent;
 
   /**
+   * @property cellContentDisplayComponent
    * @type string
    * @default 'models-table/cell-content-display'
    */
@@ -52,6 +62,7 @@ export default class DefaultTheme extends EmberObject {
   cellContentDisplayComponent;
 
   /**
+   * @property cellContentEditComponent
    * @type string
    * @default 'models-table/cell-content-edit'
    */
@@ -59,6 +70,7 @@ export default class DefaultTheme extends EmberObject {
   cellContentEditComponent;
 
   /**
+   * @property cellContentSummaryComponent
    * @type string
    * @default 'models-table/cell-column-summary'
    */
@@ -66,6 +78,7 @@ export default class DefaultTheme extends EmberObject {
   cellContentSummaryComponent;
 
   /**
+   * @property columnsDropdownComponent
    * @type string
    * @default 'models-table/columns-dropdown'
    */
@@ -73,6 +86,7 @@ export default class DefaultTheme extends EmberObject {
   columnsDropdownComponent;
 
   /**
+   * @property columnsHiddenComponent
    * @type string
    * @default 'models-table/columns-hidden'
    */
@@ -80,6 +94,7 @@ export default class DefaultTheme extends EmberObject {
   columnsHiddenComponent;
 
   /**
+   * @property dataGroupBySelectComponent
    * @type string
    * @default 'models-table/data-group-by-select'
    */
@@ -87,6 +102,7 @@ export default class DefaultTheme extends EmberObject {
   dataGroupBySelectComponent;
 
   /**
+   * @property footerComponent
    * @type string
    * @default 'models-table/footer'
    */
@@ -94,6 +110,7 @@ export default class DefaultTheme extends EmberObject {
   footerComponent;
 
   /**
+   * @property globalFilterComponent
    * @type string
    * @default 'models-table/global-filter'
    */
@@ -101,6 +118,7 @@ export default class DefaultTheme extends EmberObject {
   globalFilterComponent;
 
   /**
+   * @property groupedHeaderComponent
    * @type string
    * @default 'models-table/grouped-header'
    */
@@ -108,6 +126,7 @@ export default class DefaultTheme extends EmberObject {
   groupedHeaderComponent;
 
   /**
+   * @property noDataComponent
    * @type string
    * @default 'models-table/no-data'
    */
@@ -115,6 +134,7 @@ export default class DefaultTheme extends EmberObject {
   noDataComponent;
 
   /**
+   * @property pageSizeSelectComponent
    * @type string
    * @default 'models-table/page-size-select'
    */
@@ -122,6 +142,7 @@ export default class DefaultTheme extends EmberObject {
   pageSizeSelectComponent;
 
   /**
+   * @property paginationNumericComponent
    * @type string
    * @default 'models-table/pagination-numeric'
    */
@@ -129,6 +150,7 @@ export default class DefaultTheme extends EmberObject {
   paginationNumericComponent;
 
   /**
+   * @property paginationSimpleComponent
    * @type string
    * @default 'models-table/pagination-simple'
    */
@@ -136,6 +158,7 @@ export default class DefaultTheme extends EmberObject {
   paginationSimpleComponent;
 
   /**
+   * @property rowComponent
    * @type string
    * @default 'models-table/row'
    */
@@ -143,6 +166,7 @@ export default class DefaultTheme extends EmberObject {
   rowComponent;
 
   /**
+   * @property rowExpandComponent
    * @type string
    * @default 'models-table/row-expand'
    */
@@ -150,6 +174,7 @@ export default class DefaultTheme extends EmberObject {
   rowExpandComponent;
 
   /**
+   * @property rowFilteringComponent
    * @type string
    * @default 'models-table/row-filtering'
    */
@@ -157,6 +182,7 @@ export default class DefaultTheme extends EmberObject {
   rowFilteringComponent;
 
   /**
+   * @property rowFilteringCellComponent
    * @type string
    * @default 'models-table/row-filtering-cell'
    */
@@ -164,6 +190,7 @@ export default class DefaultTheme extends EmberObject {
   rowFilteringCellComponent;
 
   /**
+   * @property rowGroupingComponent
    * @type string
    * @default 'models-table/row-grouping'
    */
@@ -171,6 +198,7 @@ export default class DefaultTheme extends EmberObject {
   rowGroupingComponent;
 
   /**
+   * @property rowGroupToggleComponent
    * @type string
    * @default 'models-table/row-group-toggle'
    */
@@ -178,6 +206,7 @@ export default class DefaultTheme extends EmberObject {
   rowGroupToggleComponent;
 
   /**
+   * @property rowSortingComponent
    * @type string
    * @default 'models-table/row-sorting'
    */
@@ -185,6 +214,7 @@ export default class DefaultTheme extends EmberObject {
   rowSortingComponent;
 
   /**
+   * @property rowSortingCellComponent
    * @type string
    * @default 'models-table/row-sorting-cell'
    */
@@ -192,6 +222,7 @@ export default class DefaultTheme extends EmberObject {
   rowSortingCellComponent;
 
   /**
+   * @property selectComponent
    * @type string
    * @default 'models-table/select'
    */
@@ -199,6 +230,7 @@ export default class DefaultTheme extends EmberObject {
   selectComponent;
 
   /**
+   * @property summaryComponent
    * @type string
    * @default 'models-table/summary'
    */
@@ -206,6 +238,7 @@ export default class DefaultTheme extends EmberObject {
   summaryComponent;
 
   /**
+   * @property tableComponent
    * @type string
    * @default 'models-table/table'
    */
@@ -213,6 +246,7 @@ export default class DefaultTheme extends EmberObject {
   tableComponent;
 
   /**
+   * @property tableBodyComponent
    * @type string
    * @default 'models-table/table-body'
    */
@@ -220,6 +254,7 @@ export default class DefaultTheme extends EmberObject {
   tableBodyComponent;
 
   /**
+   * @property tableFooterComponent
    * @type string
    * @default 'models-table/table-footer'
    */
@@ -227,6 +262,7 @@ export default class DefaultTheme extends EmberObject {
   tableFooterComponent;
 
   /**
+   * @property tableHeaderComponent
    * @type string
    * @default 'models-table/table-header'
    */
@@ -234,12 +270,14 @@ export default class DefaultTheme extends EmberObject {
   tableHeaderComponent;
 
   /**
+   * @property cellContentTagName
    * @type string
    * @default ''
    */
   cellContentTagName = '';
 
   /**
+   * @property searchLabelMsg
    * Label for global filter
    *
    * @type string
@@ -250,6 +288,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Placeholder for global filter
    *
+   * @property searchPlaceholderMsg
    * @type string
    * @default ''
    */
@@ -258,6 +297,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for dropdown with columns for rows grouping
    *
+   * @property groupByLabelMsg
    * @type string
    * @default 'Group by:'
    */
@@ -266,6 +306,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Text on toggle for columns dropdown
    *
+   * @property columnsTitleMsg
    * @type string
    * @default 'Columns'
    */
@@ -274,6 +315,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for button to show all table columns (under columns dropdown)
    *
+   * @property columnsShowAllMsg
    * @type string
    * @default 'Show All'
    */
@@ -282,6 +324,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for button to hide all table columns (under columns dropdown)
    *
+   * @property columnsHideAllMsg
    * @type string
    * @default 'Hide All'
    */
@@ -290,6 +333,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for button to restore default visibility for table columns (under columns dropdown)
    *
+   * @property columnsRestoreDefaultsMsg
    * @type string
    * @default 'Restore Defaults'
    */
@@ -302,6 +346,7 @@ export default class DefaultTheme extends EmberObject {
    * 2. Last row's index
    * 3. Overall rows count
    *
+   * @property tableSummaryMsg
    * @type string
    * @default 'Show %@ - %@ of %@'
    */
@@ -309,12 +354,17 @@ export default class DefaultTheme extends EmberObject {
 
   /**
    * Message shown when all columns are hidden. It's shown inside table body
+   *
+   * @property allColumnsAreHiddenMsg
+   * @type string
+   * @default 'All columns are hidden. Use <strong>columns</strong>-dropdown to show some of them'
    */
   allColumnsAreHiddenMsg = 'All columns are hidden. Use <strong>columns</strong>-dropdown to show some of them';
 
   /**
    * Message shown when there are not data to display in the table. It's shown inside table body in cases when initial `data` is empty or when all records are filtered out
    *
+   * @property noDataToShowMsg
    * @type string
    * @default 'No records to show'
    */
@@ -323,6 +373,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Default label for button "Edit" inside the `cell-edit-toggle`-component
    *
+   * @property editRowButtonLabelMsg
    * @type string
    * @default 'Edit'
    */
@@ -331,6 +382,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Default label for button "Save" inside the `cell-edit-toggle`-component
    *
+   * @property saveRowButtonLabelMsg
    * @type string
    * @default 'Save'
    */
@@ -339,6 +391,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Default label for button "Cancel" inside the `cell-edit-toggle`-component
    *
+   * @property cancelRowButtonLabelMsg
    * @type string
    * @default 'Cancel'
    */
@@ -347,6 +400,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for dropdown with page numbers. Used in both numeric and simple pagination
    *
+   * @property currentPageNumberMsg
    * @type string
    * @default 'Page:'
    */
@@ -355,6 +409,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for dropdown with rows count shown in the page
    *
+   * @property rowsCountMsg
    * @type string
    * @default 'Rows:'
    */
@@ -363,6 +418,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "First"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
    *
+   * @property goToFirstPageButtonTextMsg
    * @type string
    * @default 'Go to first page'
    */
@@ -371,6 +427,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Previous"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
    *
+   * @property goToPrevPageButtonTextMsg
    * @type string
    * @default 'Go to previous page'
    */
@@ -379,6 +436,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Next"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
    *
+   * @property goToNextPageButtonTextMsg
    * @type string
    * @default 'Go to next page'
    */
@@ -387,6 +445,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Last"-page in the numeric pagination. It's used for screen-readers and not "visible" by default
    *
+   * @property goToLastPageButtonTextMsg
    * @type string
    * @default 'Go to last page'
    */
@@ -395,6 +454,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Clear global filter"-button. It's used for screen-readers and not "visible" by default
    *
+   * @property clearGlobalFilterMsg
    * @type string
    * @default 'Clear global filter input'
    */
@@ -403,6 +463,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Clear filter"-buttons in the table header's cells. It's used for screen-readers and not "visible" by default
    *
+   * @property clearFilterMsg
    * @type string
    * @default 'Clear filter input'
    */
@@ -411,6 +472,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Label for "Clear all filters"-button in the table summary section. It's used for screen-readers and not "visible" by default
    *
+   * @property clearAllFiltersMsg
    * @type string
    * @default 'Clear all filters'
    */
@@ -419,12 +481,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `table`-tag
    *
+   * @property table
    * @type string
    * @default ''
    */
   table = '';
 
   /**
+   * @property buttonsGroup
    * @type string
    * @default ''
    */
@@ -433,6 +497,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `div`-wrapper over components `global-filter`, `data-group-by-select` and `columns-dropdown`
    *
+   * @property headerWrapper
    * @type string
    * @default ''
    */
@@ -441,6 +506,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper used inside `global-filter` component
    *
+   * @property globalFilterWrapper
    * @type string
    * @default ''
    */
@@ -449,12 +515,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper used inside `columns-dropdown` component
    *
+   * @property columnsDropdownWrapper
    * @type string
    * @default ''
    */
   columnsDropdownWrapper = '';
 
   /**
+   * @property columnsDropdownButtonWrapper
    * @type string
    * @default ''
    */
@@ -463,6 +531,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper over list inside `columns-dropdown` component
    *
+   * @property columnsDropdown
    * @type string
    * @default ''
    */
@@ -471,6 +540,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for divider for list inside `columns-dropdown` components. Divider is placed before single-column items by default
    *
+   * @property columnsDropdownDivider
    * @type string
    * @default ''
    */
@@ -479,6 +549,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper inside `data-group-by-select` component
    *
+   * @property dataGroupBySelectWrapper
    * @type string
    * @default ''
    */
@@ -487,6 +558,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for thead cells
    *
+   * @property theadCell
    * @type string
    * @default 'table-header'
    */
@@ -495,6 +567,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes used for thead-cells with columns titles. This class is used only if columns is not sortable
    *
+   * @property theadCellNoSorting
    * @type string
    * @default 'table-header-no-sorting'
    */
@@ -503,6 +576,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes used for thead-cells with columns filters. This class is used only if columns is not filterable
    *
+   * @property theadCellNoFiltering
    * @type string
    * @default 'table-header-no-filtering'
    */
@@ -511,6 +585,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for selected rows. Used in the `row` component
    *
+   * @property selectedRow
    * @type string
    * @default 'selected-row'
    */
@@ -519,6 +594,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for expanded rows. Used in the `row` component
    *
+   * @property expandedRow
    * @type string
    * @default 'expanded-row'
    */
@@ -527,6 +603,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for table footer
    *
+   * @property tfooterWrapper
    * @type string
    * @default 'table-footer'
    */
@@ -535,6 +612,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper inside `footer` component
    *
+   * @property tfooterInternalWrapper
    * @type string
    * @default ''
    */
@@ -543,6 +621,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for table summary block. Used in the `summary` component
    *
+   * @property footerSummary
    * @type string
    * @default 'table-summary'
    */
@@ -551,6 +630,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for table summary block. It's used when table has numeric pagination
    *
+   * @property footerSummaryNumericPagination
    * @type string
    * @default ''
    */
@@ -559,6 +639,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for table summary block. It's used when table has simple pagination
    *
+   * @property footerSummaryDefaultPagination
    * @type string
    * @default ''
    */
@@ -567,12 +648,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper over "Page size"-block in the `footer` component
    *
+   * @property pageSizeWrapper
    * @type string
    * @default ''
    */
   pageSizeWrapper = '';
 
   /**
+   * @property pageSizeSelectWrapper
    * @type string
    * @default ''
    */
@@ -582,6 +665,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * Wrapper for select-tag in the current-page-number-select component
    *
+   * @property currentPageSizeSelectWrapper
    * @type string
    * @default ''
    */
@@ -590,6 +674,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `pagination-simple` and `pagination-numeric` components
    *
+   * @property paginationWrapper
    * @type string
    * @default 'table-nav'
    */
@@ -598,6 +683,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for buttons-wrapper in the `pagination-simple` and `pagination-numeric` components
    *
+   * @property paginationInternalWrapper
    * @type string
    * @default ''
    */
@@ -606,6 +692,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `pagination-numeric` component
    *
+   * @property paginationWrapperNumeric
    * @type string
    * @default ''
    */
@@ -614,12 +701,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `pagination-simple` component
    *
+   * @property paginationWrapperDefault
    * @type string
    * @default ''
    */
   paginationWrapperDefault = '';
 
   /**
+   * @property paginationBlock
    * @type string
    * @default ''
    */
@@ -628,6 +717,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for items in the `pagination-numeric` component
    *
+   * @property paginationNumericItem
    * @type string
    * @default ''
    */
@@ -636,6 +726,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for active item in the `pagination-numeric` component
    *
+   * @property paginationNumericItemActive
    * @type string
    * @default ''
    */
@@ -644,6 +735,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "default" buttons
    *
+   * @property buttonDefault
    * @type string
    * @default ''
    */
@@ -652,6 +744,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "link"-buttons
    *
+   * @property buttonLink
    * @type string
    * @default ''
    */
@@ -660,42 +753,49 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `td` shown when all columns are hidden
    *
+   * @property noDataCell
    * @type string
    * @default ''
    */
   noDataCell = '';
 
   /**
+   * @property collapseRow
    * @type string
    * @default 'collapseRow'
    */
   collapseRow = 'collapse-row';
 
   /**
+   * @property collapseAllRows
    * @type string
    * @default 'collapse-all-rows'
    */
   collapseAllRows = 'collapse-all-rows';
 
   /**
+   * @property expandRow
    * @type string
    * @default 'expand-row'
    */
   expandRow = 'expand-row';
 
   /**
+   * @property expandAllRows
    * @type string
    * @default 'expand-all-rows'
    */
   expandAllRows = 'expand-all-rows';
 
   /**
+   * @property cellContentDisplay
    * @type string
    * @default ''
    */
   cellContentDisplay = '';
 
   /**
+   * @property cellContentEdit
    * @type string
    * @default ''
    */
@@ -704,6 +804,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `thead`
    *
+   * @property thead
    * @type string
    * @default ''
    */
@@ -712,6 +813,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `form`
    *
+   * @property form
    * @type string
    * @default ''
    */
@@ -720,6 +822,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for wrapper over the form elements
    *
+   * @property formElementWrapper
    * @type string
    * @default ''
    */
@@ -728,6 +831,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for input elements
    *
+   * @property input
    * @type string
    * @default ''
    */
@@ -736,6 +840,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `select`
    *
+   * @property select
    * @type string
    * @default ''
    */
@@ -744,6 +849,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "Clear filter" button. Used for global filter and filters for each column
    *
+   * @property clearFilterIcon
    * @type string
    * @default ''
    */
@@ -752,12 +858,14 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "Clear all filters" button inside the `summary` component
    *
+   * @property clearAllFiltersIcon
    * @type string
    * @default ''
    */
   clearAllFiltersIcon = '';
 
   /**
+   * @property globalFilterDropdownWrapper
    * @type string
    * @default ''
    */
@@ -766,6 +874,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `select` inside the `data-group-by-select` component
    *
+   * @property changeGroupByField
    * @type string
    * @default 'change-group-by-field'
    */
@@ -774,6 +883,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "sort asc/desc" button inside the `data-group-by-select` component
    *
+   * @property sortGroupedPropertyBtn
    * @type string
    * @default ''
    */
@@ -782,6 +892,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-class for `row-grouping` component
    *
+   * @property groupingRow
    * @type string
    * @default 'grouping-row'
    */
@@ -790,6 +901,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for `td` inside `row-grouping` component
    *
+   * @property groupingCell
    * @type string
    * @default 'grouping-cell'
    */
@@ -798,6 +910,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icons used to show that some "list" is sorted "ASC". It's used for `data-group-by-select` and `row-sorting-cell`
    *
+   * @property sortAscIcon
    * @type string
    * @default ''
    */
@@ -806,6 +919,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icons used to show that some "list" is sorted "DESC". It's used for `data-group-by-select` and `row-sorting-cell`
    *
+   * @property sortDescIcon
    * @type string
    * @default ''
    */
@@ -814,6 +928,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icons in the `columns-dropdown` related to the visible columns
    *
+   * @property columnVisibleIcon
    * @type string
    * @default ''
    */
@@ -822,6 +937,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icons in the `columns-dropdown` related to the hidden columns
    *
+   * @property columnHiddenIcon
    * @type string
    * @default ''
    */
@@ -830,6 +946,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icon used in the "First"-button (`pagination-simple`)
    *
+   * @property navFirstIcon
    * @type string
    * @default ''
    */
@@ -838,6 +955,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icon used in the "Prev"-button (`pagination-simple`)
    *
+   * @property navPrevIcon
    * @type string
    * @default ''
    */
@@ -846,6 +964,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icon used in the "Next"-button (`pagination-simple`)
    *
+   * @property navNextIcon
    * @type string
    * @default ''
    */
@@ -854,6 +973,7 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for icon used in the "Last"-button (`pagination-simple`)
    *
+   * @property navLastIcon
    * @type string
    * @default ''
    */
@@ -862,78 +982,91 @@ export default class DefaultTheme extends EmberObject {
   /**
    * CSS-classes for "caret"-icon used in the `columns-dropdown`
    *
+   * @property caretIcon
    * @type string
    * @default ''
    */
   caretIcon = '';
 
   /**
+   * @property selectAllRowsIcon
    * @type string
    * @default ''
    */
   selectAllRowsIcon = '';
 
   /**
+   * @property deselectAllRowsIcon
    * @type string
    * @default ''
    */
   deselectAllRowsIcon = '';
 
   /**
+   * @property selectRowIcon
    * @type string
    * @default ''
    */
   selectRowIcon = '';
 
   /**
+   * @property deselectRowIcon
    * @type string
    * @default ''
    */
   deselectRowIcon = '';
 
   /**
+   * @property editRowButton
    * @type string
    * @default ''
    */
   editRowButton = '';
 
   /**
+   * @property saveRowButton
    * @type string
    * @default ''
    */
   saveRowButton = '';
 
   /**
+   * @property cancelRowButton
    * @type string
    * @default ''
    */
   cancelRowButton = '';
 
   /**
+   * @property filteringCellInternalWrapper
    * @type string
    * @default ''
    */
   filteringCellInternalWrapper = '';
 
   /**
+   * @property expandRowIcon
    * @type string
    * @default ''
    */
   expandRowIcon = '';
 
   /**
+   * @property collapseRowIcon
    * @type string
    * @default ''
    */
   collapseRowIcon = '';
 
   /**
+   * @property collapseAllRowsIcon
    * @type string
    * @default ''
    */
   collapseAllRowsIcon = '';
 
   /**
+   * @property expandAllRowsIcon
    * @type string
    * @default ''
    */

--- a/addon/themes/ember-bootstrap-v3.js
+++ b/addon/themes/ember-bootstrap-v3.js
@@ -1,10 +1,46 @@
 import Bootstrap3Theme from './bootstrap3';
 
 /**
- * @class EmberBootstrapTheme
+ * @class EmberBootstrap3Theme
  * @namespace Themes
  * @extends Themes.Bootstrap3Theme
  */
 export default class EmberBootstrap3Theme extends Bootstrap3Theme {
+
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/columns-dropdown'
+   */
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/data-group-by-select'
+   */
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/global-filter'
+   */
+
+  /**
+   * @property rowFilteringCellComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/row-filtering-cell'
+   */
+
+  /**
+   * @property summaryComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/row-filtering-summary'
+   */
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v3/'
+   */
   componentsPath = 'models-table/themes/ember-bootstrap-v3/';
 }

--- a/addon/themes/ember-bootstrap-v3.js
+++ b/addon/themes/ember-bootstrap-v3.js
@@ -1,9 +1,9 @@
 import Bootstrap3Theme from './bootstrap3';
 
 /**
- * @class EmberBootstrap
+ * @class EmberBootstrapTheme
  * @namespace Themes
- * @extends Themes.Bootstrap3
+ * @extends Themes.Bootstrap3Theme
  */
 export default class EmberBootstrap3Theme extends Bootstrap3Theme {
   componentsPath = 'models-table/themes/ember-bootstrap-v3/';

--- a/addon/themes/ember-bootstrap-v4.js
+++ b/addon/themes/ember-bootstrap-v4.js
@@ -1,9 +1,9 @@
 import Bootstrap4Theme from './bootstrap4';
 
 /**
- * @class EmberBootstrap
+ * @class EmberBootstrapTheme
  * @namespace Themes
- * @extends Themes.Bootstrap4
+ * @extends Themes.Bootstrap4Theme
  */
 export default class EmberBootstrap4Theme extends Bootstrap4Theme {
   componentsPath = 'models-table/themes/ember-bootstrap-v4/';

--- a/addon/themes/ember-bootstrap-v4.js
+++ b/addon/themes/ember-bootstrap-v4.js
@@ -1,11 +1,53 @@
 import Bootstrap4Theme from './bootstrap4';
 
 /**
- * @class EmberBootstrapTheme
+ * @class EmberBootstrap4Theme
  * @namespace Themes
  * @extends Themes.Bootstrap4Theme
  */
 export default class EmberBootstrap4Theme extends Bootstrap4Theme {
+
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/columns-dropdown'
+   */
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/data-group-by-select'
+   */
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/global-filter'
+   */
+
+  /**
+   * @property rowFilteringCellComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/row-filtering-cell'
+   */
+
+  /**
+   * @property summaryComponent
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/row-filtering-summary'
+   */
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/ember-bootstrap-v4/'
+   */
   componentsPath = 'models-table/themes/ember-bootstrap-v4/';
+
+  /**
+   * @property sortGroupedPropertyBtn
+   * @type string
+   * @default 'btn btn-link'
+   */
   sortGroupedPropertyBtn = 'btn btn-link';
 }

--- a/addon/themes/ember-paper.js
+++ b/addon/themes/ember-paper.js
@@ -6,20 +6,176 @@ import DefaultTheme from './default';
  * @extends Themes.DefaultTheme
  */
 export default class EmberPaperTheme extends DefaultTheme {
+
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default ''models-table/themes/ember-paper/columns-dropdown'
+   */
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/data-group-by-select'
+   */
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/global-filter'
+   */
+
+  /**
+   * @property pageSizeSelectComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/page-size-select'
+   */
+
+  /**
+   * @property paginationNumericComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/pagination-numeric'
+   */
+
+  /**
+   * @property paginationSimpleComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/pagination-simple'
+   */
+
+  /**
+   * @property rowFilteringCellComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/row-filtering-cell'
+   */
+
+  /**
+   * @property rowSortingCellComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/row-sorting-cell'
+   */
+
+  /**
+   * @property selectComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/select'
+   */
+
+  /**
+   * @property summaryComponent
+   * @type string
+   * @default 'models-table/themes/ember-paper/summary'
+   */
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/ember-paper/'
+   */
   componentsPath = 'models-table/themes/ember-paper/';
+
+  /**
+   * @property table
+   * @type string
+   * @default 'paper-table'
+   */
   table = 'paper-table';
+
+  /**
+   * @property headerWrapper
+   * @type string
+   * @default 'layout-row layout-align-space-between'
+   */
   headerWrapper = 'layout-row layout-align-space-between';
+
+  /**
+   * @property tfooterInternalWrapper
+   * @type string
+   * @default 'layout-row layout-align-space-between-center footer-internal-wrapper'
+   */
   tfooterInternalWrapper = 'layout-row layout-align-space-between-center footer-internal-wrapper';
+
+  /**
+   * @property paginationInternalWrapper
+   * @type string
+   * @default 'layout-row layout-align-space-between-center'
+   */
   paginationInternalWrapper = 'layout-row layout-align-space-between-center';
+
+  /**
+   * @property columnVisibleIcon
+   * @type string
+   * @default 'check_box'
+   */
   columnVisibleIcon = 'check_box';
+
+  /**
+   * @property columnHiddenIcon
+   * @type string
+   * @default 'check_box_outline_blank'
+   */
   columnHiddenIcon = 'check_box_outline_blank';
+
+  /**
+   * @property sortAscIcon
+   * @type string
+   * @default 'arrow_drop_up'
+   */
   sortAscIcon = 'arrow_drop_up';
+
+  /**
+   * @property sortDescIcon
+   * @type string
+   * @default 'arrow_drop_down'
+   */
   sortDescIcon = 'arrow_drop_down';
+
+  /**
+   * @property navFirstIcon
+   * @type string
+   * @default 'first_page'
+   */
   navFirstIcon = 'first_page';
+
+  /**
+   * @property navPrevIcon
+   * @type string
+   * @default 'chevron_left'
+   */
   navPrevIcon = 'chevron_left';
+
+  /**
+   * @property navNextIcon
+   * @type string
+   * @default 'chevron_right'
+   */
   navNextIcon = 'chevron_right';
+
+  /**
+   * @property navLastIcon
+   * @type string
+   * @default 'last_page'
+   */
   navLastIcon = 'last_page';
+
+  /**
+   * @property clearAllFiltersIcon
+   * @type string
+   * @default 'clear'
+   */
   clearAllFiltersIcon = 'clear';
+
+  /**
+   * @property filteringCellInternalWrapper
+   * @type string
+   * @default 'layout-row layout-align-space-between-center'
+   */
   filteringCellInternalWrapper = 'layout-row layout-align-space-between-center';
+
+  /**
+   * @property columnsDropdownWrapper
+   * @type string
+   * @default 'dropdown'
+   */
   columnsDropdownWrapper = 'columns-dropdown';
 }

--- a/addon/themes/ember-paper.js
+++ b/addon/themes/ember-paper.js
@@ -1,9 +1,9 @@
 import DefaultTheme from './default';
 
 /**
- * @class EmberPaper
+ * @class EmberPaperTheme
  * @namespace Themes
- * @extends Themes.Default
+ * @extends Themes.DefaultTheme
  */
 export default class EmberPaperTheme extends DefaultTheme {
   componentsPath = 'models-table/themes/ember-paper/';
@@ -11,15 +11,15 @@ export default class EmberPaperTheme extends DefaultTheme {
   headerWrapper = 'layout-row layout-align-space-between';
   tfooterInternalWrapper = 'layout-row layout-align-space-between-center footer-internal-wrapper';
   paginationInternalWrapper = 'layout-row layout-align-space-between-center';
-  'column-visible' = 'check_box';
-  'column-hidden' = 'check_box_outline_blank';
-  'sort-asc' = 'arrow_drop_up';
-  'sort-desc' = 'arrow_drop_down';
-  'nav-first' = 'first_page';
-  'nav-prev' = 'chevron_left';
-  'nav-next' = 'chevron_right';
-  'nav-last' = 'last_page';
+  columnVisibleIcon = 'check_box';
+  columnHiddenIcon = 'check_box_outline_blank';
+  sortAscIcon = 'arrow_drop_up';
+  sortDescIcon = 'arrow_drop_down';
+  navFirstIcon = 'first_page';
+  navPrevIcon = 'chevron_left';
+  navNextIcon = 'chevron_right';
+  navLastIcon = 'last_page';
   clearAllFiltersIcon = 'clear';
-  'filtering-cell-internal-wrapper' = 'layout-row layout-align-space-between-center';
+  filteringCellInternalWrapper = 'layout-row layout-align-space-between-center';
   columnsDropdownWrapper = 'columns-dropdown';
 }

--- a/addon/themes/ember-semanticui.js
+++ b/addon/themes/ember-semanticui.js
@@ -6,12 +6,53 @@ import SemanticUiTheme from './semanticui';
  * @extends Themes.SemanticUITheme
  */
 export default class EmberSemanticUiTheme extends SemanticUiTheme {
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/ember-semanticui/'
+   */
   componentsPath = 'models-table/themes/ember-semanticui/';
 
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/columns-dropdown'
+   */
   columnsDropdownComponent = 'models-table/themes/semanticui/columns-dropdown';
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/global-filter'
+   */
   globalFilterComponent = 'models-table/themes/semanticui/global-filter';
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/data-group-by-select'
+   */
   dataGroupBySelectComponent = 'models-table/themes/semanticui/data-group-by-select';
+
+  /**
+   * @property paginationSimpleComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/pagination-simple'
+   */
   paginationSimpleComponent = 'models-table/themes/semanticui/pagination-simple';
+
+  /**
+   * @property paginationNumericComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/pagination-numeric'
+   */
   paginationNumericComponent = 'models-table/themes/semanticui/pagination-numeric';
+
+  /**
+   * @property summaryComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/summary'
+   */
   summaryComponent = 'models-table/themes/semanticui/summary';
 }

--- a/addon/themes/ember-semanticui.js
+++ b/addon/themes/ember-semanticui.js
@@ -1,9 +1,9 @@
 import SemanticUiTheme from './semanticui';
 
 /**
- * @class EmberSemanticUI
+ * @class EmberSemanticUITheme
  * @namespace Themes
- * @extends Themes.SemanticUI
+ * @extends Themes.SemanticUITheme
  */
 export default class EmberSemanticUiTheme extends SemanticUiTheme {
   componentsPath = 'models-table/themes/ember-semanticui/';

--- a/addon/themes/semanticui.js
+++ b/addon/themes/semanticui.js
@@ -9,44 +9,319 @@ import {alias} from '@ember/object/computed';
  */
 export default class SemanticUiTheme extends DefaultTheme {
 
+  /**
+   * @property columnsDropdownComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/columns-dropdown'
+   */
+
+  /**
+   * @property dataGroupBySelectComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/data-group-by-select'
+   */
+
+  /**
+   * @property globalFilterComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/global-filter'
+   */
+
+  /**
+   * @property paginationNumericComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/pagination-numeric'
+   */
+
+  /**
+   * @property paginationSimpleComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/pagination-simple'
+   */
+
+  /**
+   * @property rowFilteringCellComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/row-filtering-cell'
+   */
+
+  /**
+   * @property selectComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/select'
+   */
+
+  /**
+   * @property summaryComponent
+   * @type string
+   * @default 'models-table/themes/semanticui/summary'
+   */
+
+  /**
+   * @property componentsPath
+   * @type string
+   * @default 'models-table/themes/semanticui/'
+   */
   componentsPath = 'models-table/themes/semanticui/';
+
+  /**
+   * @property buttonDefault
+   * @type string
+   * @default 'ui button'
+   */
   buttonDefault = 'ui button';
+
+  /**
+   * @property globalFilterWrapper
+   * @type string
+   * @default 'ui labeled icon input'
+   */
   globalFilterWrapper = 'ui labeled icon input';
+
+  /**
+   * @property columnsDropdownWrapper
+   * @type string
+   * @default 'ui compact menu right floated'
+   */
   columnsDropdownWrapper = 'ui compact menu right floated';
+
+  /**
+   * @property columnsDropdownDivider
+   * @type string
+   * @default 'divider'
+   */
   columnsDropdownDivider = 'divider';
+
+  /**
+   * @property buttonsGroup
+   * @type string
+   * @default 'ui compact menu right floated'
+   */
   buttonsGroup = 'ui compact menu right floated';
+
+  /**
+   * @property clearFilterIcon
+   * @type string
+   * @default 'remove circle link icon'
+   */
   clearFilterIcon = 'remove circle link icon';
+
+  /**
+   * @property dataGroupBySelectWrapper
+   * @type string
+   * @default 'ui labeled action input data-group-by-wrapper'
+   */
   dataGroupBySelectWrapper = 'ui labeled action input data-group-by-wrapper';
+
+  /**
+   * @property sortGroupedPropertyBtn
+   * @type string
+   * @default 'ui icon button'
+   */
   sortGroupedPropertyBtn = 'ui icon button';
+
+  /**
+   * @property caretIcon
+   * @type string
+   * @default 'dropdown icon'
+   */
   caretIcon = 'dropdown icon';
+
+  /**
+   * @property table
+   * @type string
+   * @default 'ui selectable striped celled sortable table'
+   */
   table = 'ui selectable striped celled sortable table';
+
+  /**
+   * @property columnVisibleIcon
+   * @type string
+   * @default 'toggle on icon'
+   */
   columnVisibleIcon = 'toggle on icon';
+
+  /**
+   * @property columnHiddenIcon
+   * @type string
+   * @default 'toggle off icon'
+   */
   columnHiddenIcon = 'toggle off icon';
+
+  /**
+   * @property sortAscIcon
+   * @type string
+   * @default 'sort ascending icon'
+   */
   sortAscIcon = 'sort ascending icon';
+
+  /**
+   * @property sortDescIcon
+   * @type string
+   * @default 'sort descending icon'
+   */
   sortDescIcon = 'sort descending icon';
+
+  /**
+   * @property clearAllFiltersIcon
+   * @type string
+   * @default 'remove circle icon'
+   */
   clearAllFiltersIcon = 'remove circle icon';
+
+  /**
+   * @property footerSummaryNumericPagination
+   * @type string
+   * @default 'four wide tablet wide column'
+   */
   footerSummaryNumericPagination = 'four wide tablet wide column';
+
+  /**
+   * @property footerSummaryDefaultPagination
+   * @type string
+   * @default 'four wide tablet wide column'
+   */
   @alias('footerSummaryNumericPagination')
   footerSummaryDefaultPagination;
+
+  /**
+   * @property pageSizeWrapper
+   * @type string
+   * @default 'three wide tablet wide column'
+   */
   pageSizeWrapper = 'three wide tablet wide column';
+
+  /**
+   * @property paginationWrapperNumeric
+   * @type string
+   * @default 'nine wide tablet wide column'
+   */
   paginationWrapperNumeric = 'nine wide tablet wide column';
+
+  /**
+   * @property paginationWrapperDefault
+   * @type string
+   * @default 'nine wide tablet wide column'
+   */
   @alias('paginationWrapperNumeric')
   paginationWrapperDefault;
+
+  /**
+   * @property tfooterInternalWrapper
+   * @type string
+   * @default 'ui stackable grid middle aligned'
+   */
   tfooterInternalWrapper = 'ui stackable grid middle aligned';
+
+  /**
+   * @property navFirstIcon
+   * @type string
+   * @default 'angle double left icon'
+   */
   navFirstIcon = 'angle double left icon';
+
+  /**
+   * @property navPrevIcon
+   * @type string
+   * @default 'angle left icon'
+   */
   navPrevIcon = 'angle left icon';
+
+  /**
+   * @property navNextIcon
+   * @type string
+   * @default 'angle right icon'
+   */
   navNextIcon = 'angle right icon';
+
+  /**
+   * @property navLastIcon
+   * @type string
+   * @default 'angle double right icon'
+   */
   navLastIcon = 'angle double right icon';
+
+  /**
+   * @property expandRowIcon
+   * @type string
+   * @default 'icon plus'
+   */
   expandRowIcon = 'icon plus';
+
+  /**
+   * @property collapseRowIcon
+   * @type string
+   * @default 'icon minus'
+   */
   collapseRowIcon = 'icon minus';
+
+  /**
+   * @property expandAllRowsIcon
+   * @type string
+   * @default 'icon plus'
+   */
   expandAllRowsIcon = 'icon plus';
+
+  /**
+   * @property collapseAllRowsIcon
+   * @type string
+   * @default 'icon minus'
+   */
   collapseAllRowsIcon = 'icon minus';
+
+  /**
+   * @property selectAllRowsIcon
+   * @type string
+   * @default 'toggle on icon'
+   */
   selectAllRowsIcon = 'toggle on icon';
+
+  /**
+   * @property deselectAllRowsIcon
+   * @type string
+   * @default 'toggle off icon'
+   */
   deselectAllRowsIcon = 'toggle off icon';
+
+  /**
+   * @property selectRowIcon
+   * @type string
+   * @default 'toggle on icon'
+   */
   selectRowIcon = 'toggle on icon';
+
+  /**
+   * @property deselectRowIcon
+   * @type string
+   * @default 'toggle off icon'
+   */
   deselectRowIcon = 'toggle off icon';
+
+  /**
+   * @property paginationBlock
+   * @type string
+   * @default 'ui icon buttons'
+   */
   paginationBlock = 'ui icon buttons';
+
+  /**
+   * @property currentPageSizeSelectWrapper
+   * @type string
+   * @default 'ui form right floated'
+   */
   currentPageSizeSelectWrapper = 'ui form right floated';
+
+  /**
+   * @property formElementWrapper
+   * @type string
+   * @default 'inline fields'
+   */
   formElementWrapper = 'inline fields';
+
+  /**
+   * @property form
+   * @type string
+   * @default 'ui form'
+   */
   form = 'ui form';
 }

--- a/addon/themes/semanticui.js
+++ b/addon/themes/semanticui.js
@@ -3,9 +3,9 @@ import DefaultTheme from './default';
 import {alias} from '@ember/object/computed';
 
 /**
- * @class SemanticUI
+ * @class SemanticUITheme
  * @namespace Themes
- * @extends Themes.Default
+ * @extends Themes.DefaultTheme
  */
 export default class SemanticUiTheme extends DefaultTheme {
 
@@ -18,12 +18,12 @@ export default class SemanticUiTheme extends DefaultTheme {
   clearFilterIcon = 'remove circle link icon';
   dataGroupBySelectWrapper = 'ui labeled action input data-group-by-wrapper';
   sortGroupedPropertyBtn = 'ui icon button';
-  caret = 'dropdown icon';
+  caretIcon = 'dropdown icon';
   table = 'ui selectable striped celled sortable table';
-  'column-visible' = 'toggle on icon';
-  'column-hidden' = 'toggle off icon';
-  'sort-asc' = 'sort ascending icon';
-  'sort-desc' = 'sort descending icon';
+  columnVisibleIcon = 'toggle on icon';
+  columnHiddenIcon = 'toggle off icon';
+  sortAscIcon = 'sort ascending icon';
+  sortDescIcon = 'sort descending icon';
   clearAllFiltersIcon = 'remove circle icon';
   footerSummaryNumericPagination = 'four wide tablet wide column';
   @alias('footerSummaryNumericPagination')
@@ -33,18 +33,18 @@ export default class SemanticUiTheme extends DefaultTheme {
   @alias('paginationWrapperNumeric')
   paginationWrapperDefault;
   tfooterInternalWrapper = 'ui stackable grid middle aligned';
-  'nav-first' = 'angle double left icon';
-  'nav-prev' = 'angle left icon';
-  'nav-next' = 'angle right icon';
-  'nav-last' = 'angle double right icon';
-  'expand-row' = 'icon plus';
-  'collapse-row' = 'icon minus';
-  'expand-all-rows' = 'icon plus';
-  'collapse-all-rows' = 'icon minus';
-  'select-all-rows' = 'toggle on icon';
-  'deselect-all-rows' = 'toggle off icon';
-  'select-row' = 'toggle on icon';
-  'deselect-row' = 'toggle off icon';
+  navFirstIcon = 'angle double left icon';
+  navPrevIcon = 'angle left icon';
+  navNextIcon = 'angle right icon';
+  navLastIcon = 'angle double right icon';
+  expandRowIcon = 'icon plus';
+  collapseRowIcon = 'icon minus';
+  expandAllRowsIcon = 'icon plus';
+  collapseAllRowsIcon = 'icon minus';
+  selectAllRowsIcon = 'toggle on icon';
+  deselectAllRowsIcon = 'toggle off icon';
+  selectRowIcon = 'toggle on icon';
+  deselectRowIcon = 'toggle off icon';
   paginationBlock = 'ui icon buttons';
   currentPageSizeSelectWrapper = 'ui form right floated';
   formElementWrapper = 'inline fields';

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -24,15 +24,16 @@ export function propertyNameToTitle(name) {
  * @class ModelsTableColumn
  * @extends Ember.Object
  * @namespace Utils
- * @private
  */
-export default class Column extends EmberObject {
+export default class ModelsTableColumn extends EmberObject {
 
   /**
-   * Value inverted to the {{#crossLink "Utils.ModelsTableColumn/isHidden:property"}}isHidden{{/crossLink}} initial value
+   * Value inverted to the [isHidden](Utils.ModelsTableColumn.html#property_isHidden) initial value
    *
    * It set on column init and not changed any more
    *
+   * @property defaultVisible
+   * @type boolean
    * @private
    * @readOnly
    */
@@ -40,6 +41,7 @@ export default class Column extends EmberObject {
   /**
    * Field-name of the data's object shown in the current column. If it isn't provided, sorting and filtering options for current column are ignored
    *
+   * @property propertyName
    * @default ''
    * @type string
    */
@@ -48,6 +50,7 @@ export default class Column extends EmberObject {
   /**
    * Header for column. If it isn't provided, capitalized `propertyName` is used
    *
+   * @property title
    * @default ''
    * @type string
    */
@@ -58,6 +61,9 @@ export default class Column extends EmberObject {
    *
    * If `false` column's cells will be processed as usual (components will be used to display data and for edit-mode)
    *
+   * @property simple
+   * @type boolean
+   * @default false
    */
   simple = false;
 
@@ -69,20 +75,21 @@ export default class Column extends EmberObject {
    *  * `data` - whole dataset passed to the `models-table`
    *  * `record` - current row
    *  * `index` - current row index
-   *  * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
-   *  * `expandRow` - closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
-   *  * `collapseRow` - closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
-   *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
-   *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
-   *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
-   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
-   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
-   *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   *  * `column` - current column (one of the [processedColumns](Components.ModelsTable.html#property_processedColumns))
+   *  * `expandRow` - closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
+   *  * `collapseRow` - closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
+   *  * `expandAllRows` - closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   *  * `collapseAllRows` - closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   *  * `clickOnRow` - closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
+   *  * `editRow` - closure action [ModelsTable.editRow](Components.ModelsTableRow.html#event_editRow)
+   *  * `cancelEditRow` - closure action [ModelsTable.cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow)
+   *  * `themeInstance` - bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *  * `isExpanded` - is current row expanded
    *  * `isSelected` - is current row selected
-   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isEditRow` - is the row editable (one of the [processedColumns](Components.ModelsTableRow.html#property_isEditRow))
    *  * `isColumnEditable` - is the column currently editable
    *
+   * @property component
    * @type string
    * @default ''
    */
@@ -96,20 +103,21 @@ export default class Column extends EmberObject {
    *  * `data` - whole dataset passed to the `models-table`
    *  * `record` - current row
    *  * `index` - current row index
-   *  * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
-   *  * `expandRow` - closure action {{#crossLink "Components.ModelsTable/actions.expandRow:method"}}ModelsTable.actions.expandRow{{/crossLink}}
-   *  * `collapseRow` - closure action {{#crossLink "Components.ModelsTable/actions.collapseRow:method"}}ModelsTable.actions.collapseRow{{/crossLink}}
-   *  * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
-   *  * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
-   *  * `clickOnRow` - closure action {{#crossLink "Components.ModelsTable/actions.clickOnRow:method"}}ModelsTable.actions.clickOnRow{{/crossLink}}
-   *  * `editRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.editRow:method"}}ModelsTable.actions.editRow{{/crossLink}}
-   *  * `cancelEditRow` - closure action {{#crossLink "Components.ModelsTableRow/actions.cancelEditRow:method"}}ModelsTable.actions.cancelEditRow{{/crossLink}}
-   *  * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
+   *  * `column` - current column (one of the [processedColumns](Components.ModelsTable.html#property_processedColumns))
+   *  * `expandRow` - closure action [ModelsTable.expandRow](Components.ModelsTable.html#event_expandRow)
+   *  * `collapseRow` - closure action [ModelsTable.collapseRow](Components.ModelsTable.html#event_collapseRow)
+   *  * `expandAllRows` - closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   *  * `collapseAllRows` - closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   *  * `clickOnRow` - closure action [ModelsTable.clickOnRow](Components.ModelsTable.html#event_clickOnRow)
+   *  * `editRow` - closure action [ModelsTableRow.editRow](Components.ModelsTableRow.html#event_editRow)
+   *  * `cancelEditRow` - closure action [ModelsTableRow.cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow)
+   *  * `themeInstance` - bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *  * `isExpanded` - is current row expanded
    *  * `isSelected` - is current row selected
-   *  * `isEditRow` - is the row editable (one of the {{#crossLink "Components.ModelsTableRow/isEditRow:property"}}processedColumns{{/crossLink}})
+   *  * `isEditRow` - is the row editable (one of the [processedColumns](Components.ModelsTableRow.html#property_isEditRow))
    *  * `isColumnEditable` - is the column currently editable
    *
+   * @property componentForEdit
    * @type string
    * @default ''
    */
@@ -118,6 +126,9 @@ export default class Column extends EmberObject {
   /**
    * Is this column allowed to be editable
    *
+   * @property editable
+   * @type boolean
+   * @default true
    */
   editable = true;
 
@@ -126,15 +137,16 @@ export default class Column extends EmberObject {
    *
    * It will receive several options:
    *
-   * * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
+   * * `column` - current column (one of the [processedColumns](Components.ModelsTable.html#property_processedColumns))
    * * `data` - whole dataset passed to the `models-table`
-   * * `selectedItems` - bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
-   * * `expandedItems` - bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
-   * * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
-   * * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
-   * * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
-   * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * * `selectedItems` - bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
+   * * `expandedItems` - bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
+   * * `themeInstance` - bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
+   * * `expandAllRows` - closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   * * `collapseAllRows` - closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   * * `toggleAllSelection` - closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
+   * @property componentForFilterCell
    * @type string
    * @default ''
    */
@@ -145,15 +157,16 @@ export default class Column extends EmberObject {
    *
    * It will receive several options:
    *
-   * * `column` - current column (one of the {{#crossLink "Components.ModelsTable/processedColumns:property"}}processedColumns{{/crossLink}})
+   * * `column` - current column (one of the [processedColumns](Components.ModelsTable.html#property_processedColumns))
    * * `data` - whole dataset passed to the `models-table`
-   * * `selectedItems` - bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
-   * * `expandedItems` - bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
-   * * `themeInstance` - bound from {{#crossLink "Components.ModelsTable/themeInstance:property"}}ModelsTable.themeInstance{{/crossLink}}
-   * * `expandAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.expandAllRows:method"}}ModelsTable.actions.expandAllRows{{/crossLink}}
-   * * `collapseAllRows` - closure action {{#crossLink "Components.ModelsTable/actions.collapseAllRows:method"}}ModelsTable.actions.collapseAllRows{{/crossLink}}
-   * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
+   * * `selectedItems` - bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
+   * * `expandedItems` - bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
+   * * `themeInstance` - bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
+   * * `expandAllRows` - closure action [ModelsTable.expandAllRows](Components.ModelsTable.html#event_expandAllRows)
+   * * `collapseAllRows` - closure action [ModelsTable.collapseAllRows](Components.ModelsTable.html#event_collapseAllRows)
+   * * `toggleAllSelection` - closure action [ModelsTable.toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection)
    *
+   * @property componentForSortCell
    * @type string
    * @default ''
    */
@@ -164,13 +177,14 @@ export default class Column extends EmberObject {
    *
    * It will receive several options:
    *
-   * * `selectedItems` - bound from {{#crossLink "Components.ModelsTable/selectedItems:property"}}ModelsTable.selectedItems{{/crossLink}}
-   * * `expandedItems` - bound from {{#crossLink "Components.ModelsTable/expandedItems:property"}}ModelsTable.expandedItems{{/crossLink}}
+   * * `selectedItems` - bound from [ModelsTable.selectedItems](Components.ModelsTable.html#property_selectedItems)
+   * * `expandedItems` - bound from [ModelsTable.expandedItems](Components.ModelsTable.html#property_expandedItems)
    * * `data` - whole dataset passed to the `models-table`
    * * `mappedSelectedItems` - `selectedItems` mapped by `propertyName`
    * * `mappedExpandedItems` - `expandedItems` mapped by `propertyName`
    * * `mappedData` - `data` mapped by `propertyName`
    *
+   * @property componentForFooterCell
    * @type string
    * @default ''
    */
@@ -179,36 +193,41 @@ export default class Column extends EmberObject {
   /**
    * Colspan for cell in the sorting-row
    *
+   * @property colspanForSortCell
    * @type number
    * @default 1
    */
   colspanForSortCell = 1;
 
   /**
+   * @property realColspanForSortCell
    * @type number
    * @default 1
-   * @private
+   * @protected
    */
   realColspanForSortCell = 1;
 
   /**
    * Colspan for cell in the filters-row
    *
+   * @property colspanForFilterCell
    * @type number
    * @default 1
    */
   colspanForFilterCell = 1;
 
   /**
+   * @property realColspanForFilterCell
    * @type number
    * @default 1
-   * @private
+   * @protected
    */
   realColspanForFilterCell = 1;
 
   /**
    * Field-name for sorting by current column. If it isn't provided, `propertyName` is used
    *
+   * @property sortedBy
    * @type string
    * @default null
    */
@@ -218,6 +237,7 @@ export default class Column extends EmberObject {
    * The default sorting for this column. Can be either `asc` or `desc`. Needs to be set in conjunction with `sortPrecedence`,
    otherwise it will not have any effect
    *
+   * @property sortDirection
    * @type string
    * @default ''
    */
@@ -226,26 +246,34 @@ export default class Column extends EmberObject {
   /**
    * Sort precedence for this column - needs to be larger than -1 for sortDirection to take effect
    *
+   * @property sortPrecedence
    * @type number
-   * @default ''
+   * @default null
    */
   sortPrecedence = null;
 
   /**
    * If sorting should be disabled for this column
    *
+   * @property disableSorting
+   * @type boolean
+   * @default false
    */
   disableSorting = false;
 
   /**
    * If filtering should be disabled for this column
    *
+   * @property disableFiltering
+   * @type boolean
+   * @default false
    */
   disableFiltering = false;
 
   /**
    * FilterString a default filtering for this column
    *
+   * @property filterString
    * @type string
    * @default ''
    */
@@ -254,6 +282,7 @@ export default class Column extends EmberObject {
   /**
    * Custom data's property that is used to filter column. If it isn't provided, `propertyName` is used
    *
+   * @property filteredBy
    * @type string
    * @default null
    */
@@ -262,36 +291,52 @@ export default class Column extends EmberObject {
   /**
    * Sorting is column sorted now
    *
+   * @property sorting
+   * @type string
+   * @default ''
    */
-  sorting = false;
+  sorting = '';
 
   /**
    * Is current column hidden by default
    *
+   * @property isHidden
+   * @type boolean
+   * @default false
    */
   isHidden = false;
 
   /**
    * Can current column be hidden. This field determines, if column appears in the columns-dropdown. If `mayBeHidden` is `true` and `isHidden` is also `true` for column, this column always be hidden
    *
+   * @property mayBeHidden
+   * @type boolean
+   * @default true
    */
   mayBeHidden = true;
 
   /**
-   * If `true` select-dropdown will be used for filtering by current column. Options are unique values for <code>data.@each.${propertyName}</code>
+   * If `true` select-dropdown will be used for filtering by current column. Options are unique values for `data.@each.${propertyName}`
    *
+   * @property filterWithSelect
+   * @type boolean
+   * @default false
    */
   filterWithSelect = false;
 
   /**
    * Should options in the select-box be sorted
    *
+   * @property sortFilterOptions
+   * @type boolean
+   * @default false
    */
   sortFilterOptions = false;
 
   /**
-   * List of option to the filter-box (used if {{#crossLink "Utils.ModelsTableColumn/filterWithSelect:property"}}filterWithSelect{{/crossLink}} is true)
+   * List of option to the filter-box (used if [filterWithSelect](Utils.ModelsTableColumn.html#property_filterWithSelect) is true)
    *
+   * @property predefinedFilterOptions
    * @type string[]|number[]|boolean[]
    * @default null
    */
@@ -300,71 +345,87 @@ export default class Column extends EmberObject {
   /**
    * Custom class-name for cells in the current column. This class-name will also be added to the header and filter of the column
    *
+   * @property className
    * @default ''
    * @type string
    */
   className = '';
 
   /**
-   * Custom function used to filter rows (used if {{#crossLink "Utils.ModelsTableColumn/filterWithSelect:property"}}filterWithSelect{{/crossLink}} is false)
+   * Custom function used to filter rows (used if [filterWithSelect](Utils.ModelsTableColumn.html#property_filterWithSelect) is false)
    *
+   * @property filterFunction
    * @type function
+   * @default null
    */
   filterFunction = null;
 
   /**
    * Optional custom function used to sort rows
    *
+   * @property sortFunction
    * @type function
+   * @default null
    */
   sortFunction = null;
 
   /**
    * Placeholder for filter-input
    *
+   * @property filterPlaceholder
    * @type string
    * @default ''
    */
   filterPlaceholder = '';
 
   /**
-   * If this property is defined, link to the route will be rendered in the cell. {{#crossLink "Utils.ModelsTableColumn/propertyName:property"}}propertyName{{/crossLink}} is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
+   * If this property is defined, link to the route will be rendered in the cell. [propertyName](Utils.ModelsTableColumn.html#property_propertyName) is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
    *
+   * @property routeName
    * @type string
    * @default ''
    */
   routeName = '';
+
   /**
-   * If this property is defined, link to the route will be rendered in the cell. {{#crossLink "Utils.ModelsTableColumn/routeProperty:property"}}routeProperty{{/crossLink}} is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
+   * If this property is defined, link to the route will be rendered in the cell. [routeProperty](Utils.ModelsTableColumn.html#property_routeProperty) is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
    *
+   * @property routeProperty
    * @type string
    * @default ''
    */
   routeProperty = 'id';
+
   /**
    * Object containing the definition of the column passed into the component
    *
+   * @property originalDefinition
    * @type object
    * @default null
-   * @readOnly
-   * @private
+   * @protected
    */
   originalDefinition = null;
 
+  /**
+   * @property __mt
+   * @type Components.ModelsTable
+   * @private
+   */
   __mt = null;
 
   /**
+   * @property data
    * @type object[]
-   * @readonly
-   * @private
+   * @default []
+   * @protected
    */
   @readOnly('__mt.data')
   data;
 
   /**
+   * @property cssPropertyName
    * @type string
-   * @private
-   * @readOnly
+   * @protected
    */
   @computed('propertyName')
   get cssPropertyName() {
@@ -372,29 +433,37 @@ export default class Column extends EmberObject {
   }
 
   /**
-   * @private
-   * @readOnly
+   * @property isVisible
+   * @protected
+   * @type boolean
+   * @default true
    */
   @not('isHidden')
   isVisible;
 
   /**
-   * @private
-   * @readOnly
+   * @property sortAsc
+   * @protected
+   * @type boolean
+   * @default true
    */
   @equal('sorting', 'asc')
   sortAsc;
 
   /**
-   * @private
-   * @readOnly
+   * @property sortDesc
+   * @protected
+   * @type boolean
+   * @default false
    */
   @equal('sorting', 'desc')
   sortDesc;
 
   /**
-   * @private
-   * @readOnly
+   * @property filterUsed
+   * @protected
+   * @type boolean
+   * @default false
    */
   @notEmpty('filterString')
   filterUsed;
@@ -402,8 +471,10 @@ export default class Column extends EmberObject {
   /**
    * Allow sorting for column or not
    *
-   * @private
-   * @readOnly
+   * @property useSorting
+   * @protected
+   * @type boolean
+   * @default true
    */
   @computed('sortField', 'disableSorting')
   get useSorting () {
@@ -411,8 +482,9 @@ export default class Column extends EmberObject {
   }
 
   /**
+   * @property sortField
+   * @protected
    * @type string
-   * @readonly
    */
   @computed('sortedBy', 'propertyName')
   get sortField() {
@@ -425,7 +497,10 @@ export default class Column extends EmberObject {
   /**
    * Allow filtering for column or not
    *
-   * @private
+   * @protected
+   * @property useFilter
+   * @type boolean
+   * @default true
    */
   @computed('filterField', 'disableFiltering')
   get useFilter() {
@@ -436,8 +511,9 @@ export default class Column extends EmberObject {
   }
 
   /**
+   * @protected
+   * @property filterField
    * @type string
-   * @readonly
    */
   @computed('filteredBy', 'propertyName')
   get filterField() {
@@ -445,11 +521,11 @@ export default class Column extends EmberObject {
   }
 
   /**
-   * If preselected option doesn't exist after <code>filterOptions</code> update,
-   * <code>filterString</code> is reverted to empty string (basically, filtering for this column is dropped)
+   * If preselected option doesn't exist after `filterOptions` update,
+   * `filterString` is reverted to empty string (basically, filtering for this column is dropped)
    *
    * @method cleanFilterString
-   * @private
+   * @protected
    */
   @observes('filterWithSelect', 'filterOptions.[]', 'filterString')
   cleanFilterString () {

--- a/addon/utils/column.js
+++ b/addon/utils/column.js
@@ -33,8 +33,6 @@ export default class Column extends EmberObject {
    *
    * It set on column init and not changed any more
    *
-   * @property defaultVisible
-   * @type boolean
    * @private
    * @readOnly
    */
@@ -43,7 +41,6 @@ export default class Column extends EmberObject {
    * Field-name of the data's object shown in the current column. If it isn't provided, sorting and filtering options for current column are ignored
    *
    * @default ''
-   * @property propertyName
    * @type string
    */
   propertyName = '';
@@ -52,7 +49,6 @@ export default class Column extends EmberObject {
    * Header for column. If it isn't provided, capitalized `propertyName` is used
    *
    * @default ''
-   * @property title
    * @type string
    */
   title = null;
@@ -62,9 +58,6 @@ export default class Column extends EmberObject {
    *
    * If `false` column's cells will be processed as usual (components will be used to display data and for edit-mode)
    *
-   * @property simple
-   * @type boolean
-   * @default false
    */
   simple = false;
 
@@ -91,7 +84,6 @@ export default class Column extends EmberObject {
    *  * `isColumnEditable` - is the column currently editable
    *
    * @type string
-   * @property component
    * @default ''
    */
   component = '';
@@ -119,7 +111,6 @@ export default class Column extends EmberObject {
    *  * `isColumnEditable` - is the column currently editable
    *
    * @type string
-   * @property componentForEdit
    * @default ''
    */
   componentForEdit = '';
@@ -127,9 +118,6 @@ export default class Column extends EmberObject {
   /**
    * Is this column allowed to be editable
    *
-   * @default true
-   * @property editable
-   * @type boolean
    */
   editable = true;
 
@@ -148,7 +136,6 @@ export default class Column extends EmberObject {
    * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
    *
    * @type string
-   * @property componentForFilterCell
    * @default ''
    */
   componentForFilterCell = '';
@@ -168,7 +155,6 @@ export default class Column extends EmberObject {
    * * `toggleAllSelection` - closure action {{#crossLink "Components.ModelsTable/actions.toggleAllSelection:method"}}ModelsTable.actions.toggleAllSelection{{/crossLink}}
    *
    * @type string
-   * @property componentForSortCell
    * @default ''
    */
   componentForSortCell = '';
@@ -186,7 +172,6 @@ export default class Column extends EmberObject {
    * * `mappedData` - `data` mapped by `propertyName`
    *
    * @type string
-   * @property componentForFooterCell
    * @default ''
    */
   componentForFooterCell = '';
@@ -194,14 +179,12 @@ export default class Column extends EmberObject {
   /**
    * Colspan for cell in the sorting-row
    *
-   * @property colspanForSortCell
    * @type number
    * @default 1
    */
   colspanForSortCell = 1;
 
   /**
-   * @property realColspanForSortCell
    * @type number
    * @default 1
    * @private
@@ -211,14 +194,12 @@ export default class Column extends EmberObject {
   /**
    * Colspan for cell in the filters-row
    *
-   * @property colspanForSortCell
    * @type number
    * @default 1
    */
   colspanForFilterCell = 1;
 
   /**
-   * @property realColspanForFilterCell
    * @type number
    * @default 1
    * @private
@@ -229,7 +210,6 @@ export default class Column extends EmberObject {
    * Field-name for sorting by current column. If it isn't provided, `propertyName` is used
    *
    * @type string
-   * @property sortedBy
    * @default null
    */
   sortedBy = null;
@@ -239,7 +219,6 @@ export default class Column extends EmberObject {
    otherwise it will not have any effect
    *
    * @type string
-   * @property sortDirection
    * @default ''
    */
   sortDirection = '';
@@ -248,7 +227,6 @@ export default class Column extends EmberObject {
    * Sort precedence for this column - needs to be larger than -1 for sortDirection to take effect
    *
    * @type number
-   * @property sortPrecedence
    * @default ''
    */
   sortPrecedence = null;
@@ -256,25 +234,18 @@ export default class Column extends EmberObject {
   /**
    * If sorting should be disabled for this column
    *
-   * @property disableSorting
-   * @type boolean
-   * @default false
    */
   disableSorting = false;
 
   /**
    * If filtering should be disabled for this column
    *
-   * @property disableFiltering
-   * @type boolean
-   * @default false
    */
   disableFiltering = false;
 
   /**
    * FilterString a default filtering for this column
    *
-   * @property filterString
    * @type string
    * @default ''
    */
@@ -284,7 +255,6 @@ export default class Column extends EmberObject {
    * Custom data's property that is used to filter column. If it isn't provided, `propertyName` is used
    *
    * @type string
-   * @property filteredBy
    * @default null
    */
   filteredBy = null;
@@ -292,45 +262,30 @@ export default class Column extends EmberObject {
   /**
    * Sorting is column sorted now
    *
-   * @property sorting
-   * @type boolean
-   * @default false
    */
   sorting = false;
 
   /**
    * Is current column hidden by default
    *
-   * @property isHidden
-   * @default false
-   * @type boolean
    */
   isHidden = false;
 
   /**
    * Can current column be hidden. This field determines, if column appears in the columns-dropdown. If `mayBeHidden` is `true` and `isHidden` is also `true` for column, this column always be hidden
    *
-   * @property mayBeHidden
-   * @default true
-   * @type boolean
    */
   mayBeHidden = true;
 
   /**
    * If `true` select-dropdown will be used for filtering by current column. Options are unique values for <code>data.@each.${propertyName}</code>
    *
-   * @property filterWithSelect
-   * @type boolean
-   * @default false
    */
   filterWithSelect = false;
 
   /**
    * Should options in the select-box be sorted
    *
-   * @property sortFilterOptions
-   * @default false
-   * @type boolean
    */
   sortFilterOptions = false;
 
@@ -338,7 +293,6 @@ export default class Column extends EmberObject {
    * List of option to the filter-box (used if {{#crossLink "Utils.ModelsTableColumn/filterWithSelect:property"}}filterWithSelect{{/crossLink}} is true)
    *
    * @type string[]|number[]|boolean[]
-   * @property predefinedFilterOptions
    * @default null
    */
   predefinedFilterOptions = null;
@@ -346,7 +300,6 @@ export default class Column extends EmberObject {
   /**
    * Custom class-name for cells in the current column. This class-name will also be added to the header and filter of the column
    *
-   * @property className
    * @default ''
    * @type string
    */
@@ -355,7 +308,6 @@ export default class Column extends EmberObject {
   /**
    * Custom function used to filter rows (used if {{#crossLink "Utils.ModelsTableColumn/filterWithSelect:property"}}filterWithSelect{{/crossLink}} is false)
    *
-   * @property filterFunction
    * @type function
    */
   filterFunction = null;
@@ -363,7 +315,6 @@ export default class Column extends EmberObject {
   /**
    * Optional custom function used to sort rows
    *
-   * @property sortFunction
    * @type function
    */
   sortFunction = null;
@@ -371,7 +322,6 @@ export default class Column extends EmberObject {
   /**
    * Placeholder for filter-input
    *
-   * @property filterPlaceholder
    * @type string
    * @default ''
    */
@@ -380,7 +330,6 @@ export default class Column extends EmberObject {
   /**
    * If this property is defined, link to the route will be rendered in the cell. {{#crossLink "Utils.ModelsTableColumn/propertyName:property"}}propertyName{{/crossLink}} is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
    *
-   * @property routeName
    * @type string
    * @default ''
    */
@@ -388,7 +337,6 @@ export default class Column extends EmberObject {
   /**
    * If this property is defined, link to the route will be rendered in the cell. {{#crossLink "Utils.ModelsTableColumn/routeProperty:property"}}routeProperty{{/crossLink}} is used as an anchor. If it's not declared, `id` will be used. <br /> Main idea for `routeName` is to provide a simple way to generate links for each model in the `data`. It should not be used for any other purposes
    *
-   * @property routeProperty
    * @type string
    * @default ''
    */
@@ -396,7 +344,6 @@ export default class Column extends EmberObject {
   /**
    * Object containing the definition of the column passed into the component
    *
-   * @property originalDefinition
    * @type object
    * @default null
    * @readOnly
@@ -407,7 +354,6 @@ export default class Column extends EmberObject {
   __mt = null;
 
   /**
-   * @property data
    * @type object[]
    * @readonly
    * @private
@@ -417,7 +363,6 @@ export default class Column extends EmberObject {
 
   /**
    * @type string
-   * @property cssPropertyName
    * @private
    * @readOnly
    */
@@ -427,8 +372,6 @@ export default class Column extends EmberObject {
   }
 
   /**
-   * @type boolean
-   * @property isVisible
    * @private
    * @readOnly
    */
@@ -436,8 +379,6 @@ export default class Column extends EmberObject {
   isVisible;
 
   /**
-   * @type boolean
-   * @property sortAsc
    * @private
    * @readOnly
    */
@@ -445,8 +386,6 @@ export default class Column extends EmberObject {
   sortAsc;
 
   /**
-   * @type boolean
-   * @property sortDesc
    * @private
    * @readOnly
    */
@@ -454,8 +393,6 @@ export default class Column extends EmberObject {
   sortDesc;
 
   /**
-   * @type boolean
-   * @property filterUsed
    * @private
    * @readOnly
    */
@@ -465,8 +402,6 @@ export default class Column extends EmberObject {
   /**
    * Allow sorting for column or not
    *
-   * @type boolean
-   * @property useSorting
    * @private
    * @readOnly
    */
@@ -476,7 +411,6 @@ export default class Column extends EmberObject {
   }
 
   /**
-   * @property sortField
    * @type string
    * @readonly
    */
@@ -491,8 +425,6 @@ export default class Column extends EmberObject {
   /**
    * Allow filtering for column or not
    *
-   * @type boolean
-   * @property useFilter
    * @private
    */
   @computed('filterField', 'disableFiltering')
@@ -505,7 +437,6 @@ export default class Column extends EmberObject {
 
   /**
    * @type string
-   * @property filterField
    * @readonly
    */
   @computed('filteredBy', 'propertyName')

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -123,8 +123,8 @@ module.exports = async function() {
         },
         npm: {
           devDependencies: {
-            'semantic-ui-ember': '^3.0.0',
-            '@ember/jquery': '^0.5.1'
+            'semantic-ui-ember': '^3.0.4',
+            '@ember/jquery': '^0.6.0'
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.3",
     "ember-cli-uglify": "^3.0.0",
-    "ember-cli-yuidoc": "^0.8.8",
+    "ember-cli-yuidoc": "^0.9.1",
     "ember-data": "^3.14.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-exam": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-cli-yuidoc": "^0.8.8",
     "ember-data": "^3.14.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-exam": "^1.0.0",
+    "ember-exam": "^4.0.9",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^6.5.1",
     "ember-load-initializers": "^2.1.0",

--- a/tests/dummy/app/templates/components/custom-sort-cell.hbs
+++ b/tests/dummy/app/templates/components/custom-sort-cell.hbs
@@ -1,6 +1,6 @@
 {{column.originalDefinition.CustomColumString}}|{{column.originalDefinition.CustomColumObject.name}}|{{column.originalDefinition.CustomColumBool}}|{{column.originalDefinition.CustomColumNumber}}
 
 <span
-  class="{{if column.sortAsc themeInstance.sort-asc}} {{if column.sortDesc themeInstance.sort-desc}}">
+  class="{{if column.sortAsc themeInstance.sortAscIcon}} {{if column.sortDesc themeInstance.sortDescIcon}}">
 </span>
 {{yield}}

--- a/tests/dummy/app/templates/components/expand-all-toggle.hbs
+++ b/tests/dummy/app/templates/components/expand-all-toggle.hbs
@@ -2,13 +2,13 @@
   href="#"
   class={{themeInstance.expandAllRows}}
   {{action "doExpandAllRows" bubbles=false}}>
-  <i class={{themeInstance.expand-all-rows}}></i>
+  <i class={{themeInstance.expandAllRowsIcon}}></i>
 </a>
 <br>
 <a
   href="#"
   class={{themeInstance.collapseAllRows}}
   {{action "doCollapseAllRows" bubbles=false}}>
-  <i class={{themeInstance.collapse-all-rows}}></i>
+  <i class={{themeInstance.collapseAllRowsIcon}}></i>
 </a>
 {{yield}}

--- a/tests/dummy/app/templates/components/expand-toggle.hbs
+++ b/tests/dummy/app/templates/components/expand-toggle.hbs
@@ -3,14 +3,14 @@
     href="#"
     class={{themeInstance.collapseRow}}
     {{action "doCollapseRow" index record bubbles=false}}>
-    <i class={{themeInstance.collapse-row}}></i>
+    <i class={{themeInstance.collapseRowIcon}}></i>
   </a>
 {{else}}
   <a
     href="#"
     class={{themeInstance.expandRow}}
     {{action "doExpandRow" index record bubbles=false}}>
-    <i class={{themeInstance.expand-row}}></i>
+    <i class={{themeInstance.expandRowIcon}}></i>
   </a>
 {{/if}}
 {{yield}}

--- a/tests/dummy/app/templates/components/select-all-rows-checkbox.hbs
+++ b/tests/dummy/app/templates/components/select-all-rows-checkbox.hbs
@@ -7,7 +7,7 @@
 <span {{action "doToggleAllSelection"}}
   class="toggle-all {{if
     (is-equal selectedItems.length data.length)
-    themeInstance.select-all-rows
-    themeInstance.deselect-all-rows}}">
+    themeInstance.selectAllRowsIcon
+    themeInstance.deselectAllRowsIcon}}">
 </span>
 {{yield}}

--- a/tests/dummy/app/templates/components/select-row-checkbox.hbs
+++ b/tests/dummy/app/templates/components/select-row-checkbox.hbs
@@ -4,7 +4,7 @@
     @onChange={{action "doClickOnRow" index record}} />
 {{else}}
   <span
-    class={{if isSelected themeInstance.select-row themeInstance.deselect-row}}
+    class={{if isSelected themeInstance.selectRowIcon themeInstance.deselectRowIcon}}
     onclick={{action "doClickOnRow" index record}}>
   </span>
 {{/if}}

--- a/tests/dummy/app/templates/components/sort-cell.hbs
+++ b/tests/dummy/app/templates/components/sort-cell.hbs
@@ -1,5 +1,5 @@
 {{column.title}}
 <span
-  class="{{if column.sortAsc table.icons.sort-asc}} {{if column.sortDesc table.icons.sort-desc}}">
+  class="{{if column.sortAsc table.icons.sortAscIcon}} {{if column.sortDesc table.icons.sortDescIcon}}">
 </span>
 {{yield}}

--- a/tests/dummy/app/templates/components/top-nav-bs3.hbs
+++ b/tests/dummy/app/templates/components/top-nav-bs3.hbs
@@ -24,6 +24,7 @@
           <ddm.item><a href="/ember-models-table/v.3/bs4/">Bootstrap 4 Demo</a></ddm.item>
           <ddm.item><a href="/ember-models-table/v.3/semantic/">SemanticUI Demo</a></ddm.item>
           <ddm.item><a href="/ember-models-table/v.3/paper/">Paper Demo</a></ddm.item>
+          <ddm.item><a href="/ember-models-table/v.3/docs/">API docs</a></ddm.item>
         {{/dd.menu}}
       {{/nav.dropdown}}
     {{/navbar.nav}}

--- a/tests/dummy/app/templates/components/top-nav-bs4.hbs
+++ b/tests/dummy/app/templates/components/top-nav-bs4.hbs
@@ -24,6 +24,7 @@
           <a href="/ember-models-table/v.3/bs4/" class="dropdown-item active">Bootstrap 4 Demo</a>
           <a href="/ember-models-table/v.3/semantic/" class="dropdown-item">SemanticUI Demo</a>
           <a href="/ember-models-table/v.3/paper/" class="dropdown-item">Paper Demo</a>
+          <a href="/ember-models-table/v.3/docs/" class="dropdown-item">API docs</a>
         {{/dd.menu}}
       {{/nav.dropdown}}
     {{/navbar.nav}}

--- a/tests/dummy/app/templates/components/top-nav-paper.hbs
+++ b/tests/dummy/app/templates/components/top-nav-paper.hbs
@@ -49,6 +49,9 @@
         {{#content.menu-item href="/ember-models-table/v.3/semantic/"}}
           SemanticUI Demo
         {{/content.menu-item}}
+        {{#content.menu-item href="/ember-models-table/v.3/docs/"}}
+          API docs
+        {{/content.menu-item}}
       {{/menu.content}}
     {{/paper-menu}}
     <span class="flex"></span>

--- a/tests/dummy/app/templates/components/top-nav-semantic.hbs
+++ b/tests/dummy/app/templates/components/top-nav-semantic.hbs
@@ -23,6 +23,7 @@
       <a href="/ember-models-table/v.3/bs4/" class="item">Bootstrap 4 Demo</a>
       <a href="/ember-models-table/v.3/semantic/" class="item active">SemanticUI Demo</a>
       <a href="/ember-models-table/v.3/paper/" class="item">Paper Demo</a>
+      <a href="/ember-models-table/v.3/docs/" class="item">API docs</a>
     </div>
   </div>
   <div class="ui item gh">

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -1214,14 +1214,14 @@ module('ModelsTable | Integration', function (hooks) {
   test('custom icons', async function (assert) {
 
     const customIcons = {
-      'sort-asc': 'sort-asc',
-      'sort-desc': 'sort-desc',
-      'column-visible': 'column-visible',
-      'column-hidden': 'column-hidden',
-      'nav-first': 'nav-first',
-      'nav-prev': 'nav-prev',
-      'nav-next': 'nav-next',
-      'nav-last': 'nav-last'
+      sortAscIcon: 'sort-asc',
+      sortDescIcon: 'sort-desc',
+      columnVisibleIcon: 'column-visible',
+      columnHiddenIcon: 'column-hidden',
+      navFirstIcon: 'nav-first',
+      navPrevIcon: 'nav-prev',
+      navNextIcon: 'nav-next',
+      navLastIcon: 'nav-last'
     };
 
     this.setProperties({

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,9 +1,8 @@
 {
   "name": "ember-models-table",
   "description": "Table with pagination, sorting and filtering",
-  "version": "2.0.0",
+  "version": "3.0.0-beta.3",
   "options": {
-    "enabledEnvironments": ["development", "production"],
     "paths": [
       "addon"
     ],


### PR DESCRIPTION
* Every property with suffix `Component` is a path to the component used in theme
* Every property with suffix `Msg` is a message shown in the table
* Every property with suffix `Icon` is a CSS-class for font-library used as an icons (used for buttons, carets etc)

**Difference from `v.2`:**

* No `mergedProperties`
* Properties `components`, `messages` and `icons` are removed. Every their key is placed directly in theme and named with suffix `Component`, `Msg` or `Icon`.
* Every property name is converted to the `lowerCamelCase`