### PR TITLE
[BREAKING] Yield more props and event handlers

### DIFF
--- a/addon/components/models-table-server-paginated.js
+++ b/addon/components/models-table-server-paginated.js
@@ -30,13 +30,7 @@ import layout from '../templates/components/models-table';
  * </ModelsTable>
  * ```
  *
- * ModelsTableServerPaginated yields references to the following contextual components:
- *
- * * [models-table/global-filter](Components.ModelsTableGlobalFilter.html) - global filter used for table data
- * * [models-table/data-group-by-select](Components.ModelsTableDataGroupBySelect.html) - dropdown to select property for table-rows grouping
- * * [models-table/columns-dropdown](Components.ModelsTableColumnsDropdown.html) - dropdown with list of options to toggle columns and column-sets visibility
- * * [models-table/table](Components.ModelsTableTable.html) - table with a data
- * * [models-table/footer](Components.ModelsTableFooter.html) - summary and pagination
+ * ModelsTableServerPaginated yields same components, actions and properties as a ModelsTable does. Check its docs for more info.
  *
  * Check own docs for each component to get detailed info.
  *

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -255,6 +255,21 @@ function objToArray(map) {
  * </ModelsTable>
  * ```
  *
+ * Usage with block content 2:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.GlobalFilter />
+ *   <MT.DataGroupBySelect />
+ *   <MT.ColumnsDropdown />
+ *   <MT.Table />
+ *   <MT.PaginationNumeric />
+ *   <MT.PaginationSimple />
+ *   <MT.Summary />
+ *   <MT.SizeSelect />
+ * </ModelsTable>
+ * ```
+ *
  * ModelsTable yields references to the following contextual components:
  *
  * * [models-table/global-filter](Components.ModelsTableGlobalFilter.html) - global filter used for table data
@@ -262,6 +277,10 @@ function objToArray(map) {
  * * [models-table/data-group-by-select](Components.ModelsTableDataGroupBySelect.html) - dropdown to select property for table-rows grouping
  * * [models-table/table](Components.ModelsTableTable.html) - table with a data
  * * [models-table/footer](Components.ModelsTableFooter.html) - summary and pagination
+ * * [models-table/summary](Components.ModelsTableSummary.html) - component with summary info about table data. It also contains button to clear all filters applied to the table
+ * * [models-table/size-select](Components.ModelsTableSizeSelect.html) - component with a page sizes dropdown. It allows to select number if records shown on page
+ * * [models-table/pagination-numeric](Components.ModelsTablePaginationNumeric.html) - component with a table navigation. It allows to move to the page by its number
+ * * [models-table/pagination-simple](Components.ModelsTablePaginationSimple.html) - component with a table navigation. It allows to move to the first, last, prev and next pages (this four buttons are shown always)
  *
  * Check own docs for each component to get detailed info.
  *
@@ -1073,7 +1092,6 @@ class ModelsTableComponent extends Component {
       });
     });
   }
-
   set filteredContent(v) {
     return v;
   }

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -294,6 +294,7 @@ function objToArray(map) {
  * * [groupedVisibleContentValuesOrder](Components.ModelsTable.html#property_groupedVisibleContentValuesOrder) - list of values for property used to group rows
  * * [groupedArrangedContent](Components.ModelsTable.html#property_groupedArrangedContent) - list of all filtered and sorted records in the table used when rows grouping is enabled
  * * [displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs) - determines how value for grouping is shown. Can "row" and "column"
+ * * [sortByGroupedFieldDirection](Components.ModelsTable.html#property_sortByGroupedFieldDirection) - sorting order for property used to group rows
  * * [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) - flag to turn on/off rows grouping
  * * [globalFilterUsed](Components.ModelsTable.html#property_globalFilterUsed) - `true` if global filter is used
  * * [anyFilterUsed](Components.ModelsTable.html#property_anyFilterUsed) - `true` when any filter (global or for column) is used. `false` when no filters are used

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -266,7 +266,7 @@ function objToArray(map) {
  *   <MT.PaginationNumeric />
  *   <MT.PaginationSimple />
  *   <MT.Summary />
- *   <MT.SizeSelect />
+ *   <MT.PageSizeSelect />
  * </ModelsTable>
  * ```
  *
@@ -283,6 +283,60 @@ function objToArray(map) {
  * * [models-table/pagination-simple](Components.ModelsTablePaginationSimple.html) - component with a table navigation. It allows to move to the first, last, prev and next pages (this four buttons are shown always)
  *
  * Check own docs for each component to get detailed info.
+ *
+ * References to the following properties are yielded:
+ *
+ * * [processedColumns](Components.ModelsTable.html#property_processedColumns) - list of columns in the table
+ * * [visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns) - list of currently visible columns in the table
+ * * [visibleContent](Components.ModelsTable.html#property_visibleContent) - list of records shown in the current table's page
+ * * [groupedHeaders](Components.ModelsTable.html#property_groupedHeaders) - extra headers for table's header. DOESN'T work properly with visibility toggle for columns
+ * * [groupedVisibleContent](Components.ModelsTable.html#property_groupedVisibleContent) - list of records shown in the current table's page when rows grouping is enabled
+ * * [groupedVisibleContentValuesOrder](Components.ModelsTable.html#property_groupedVisibleContentValuesOrder) - list of values for property used to group rows
+ * * [groupedArrangedContent](Components.ModelsTable.html#property_groupedArrangedContent) - list of all filtered and sorted records in the table used when rows grouping is enabled
+ * * [displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs) - determines how value for grouping is shown. Can "row" and "column"
+ * * [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) - flag to turn on/off rows grouping
+ * * [globalFilterUsed](Components.ModelsTable.html#property_globalFilterUsed) - `true` if global filter is used
+ * * [anyFilterUsed](Components.ModelsTable.html#property_anyFilterUsed) - `true` when any filter (global or for column) is used. `false` when no filters are used
+ * * [useFilteringByColumns](Components.ModelsTable.html#property_useFilteringByColumns) - determines if columns filtering should be used. By default if it's `false` header's row with filter input/select fields is not shown
+ * * [collapsedGroupValues](Components.ModelsTable.html#property_collapsedGroupValues) - list of values for property used to group rows. Row group with this value are collapsed
+ * * [pagesCount](Components.ModelsTable.html#property_pagesCount) - number of pages in the table
+ * * [firstIndex](Components.ModelsTable.html#property_firstIndex) - first row's index in the current page
+ * * [lastIndex](Components.ModelsTable.html#property_lastIndex) - last row's index in the current page
+ * * [currentPageNumberOptions](Components.ModelsTable.html#property_currentPageNumberOptions) - list of options for current page
+ * * [pageSizeOptions](Components.ModelsTable.html#property_pageSizeOptions) - list of options for page size select
+ * * [pageSize](Components.ModelsTable.html#property_pageSize) - number of rows shown in the table's page
+ * * [columnDropdownOptions](Components.ModelsTable.html#property_columnDropdownOptions) - list of options for columns dropdown
+ * * [allColumnsAreHidden](Components.ModelsTable.html#property_allColumnsAreHidden) - `true` if all columns are hidden. `false` if at least one column is visible
+ * * [dataGroupOptions](Components.ModelsTable.html#property_dataGroupOptions) - list of property names used for rows grouping
+ * * [themeInstance](Components.ModelsTable.html#property_themeInstance) - theme instance used in the table
+ * * [expandedItems](Components.ModelsTable.html#property_expandedItems) - list of expanded rows
+ * * [selectedItems](Components.ModelsTable.html#property_selectedItems) - list of selected rows
+ * * [isLoading](Components.ModelsTable.html#property_isLoading) - `true` when data for table is loading (used only for `models-table-server-paginated`)
+ * * [isError](Components.ModelsTable.html#property_isError) - `true` when request for data loading failed (used only for `models-table-server-paginated`)
+ * * [publicAPI](Components.ModelsTable.html#property_publicAPI) - public API that allows for programmatic interaction with the component
+ *
+ * References to the following actions are yielded:
+ *
+ * * [showAllColumns](Components.ModelsTable.html#event_showAllColumns) - show all columns in the table (by default used in the columns dropdown)
+ * * [hideAllColumns](Components.ModelsTable.html#event_hideAllColumns) - hide all column in the table (by default used in the columns dropdown)
+ * * [restoreDefaultVisibility](Components.ModelsTable.html#event_restoreDefaultVisibility) - show columns visible initially (by default used in the columns dropdown)
+ * * [toggleColumnSet](Components.ModelsTable.html#event_toggleColumnSet) - toggle visibility for columns in the custom columns set (by default used in the columns dropdown)
+ * * [toggleHidden](Components.ModelsTable.html#event_toggleHidden) - toggle visibility for column (by default used in the columns dropdown)
+ * * [expandRow](Components.ModelsTable.html#event_expandRow) - expand or collapse row to show details
+ * * [collapseRow](Components.ModelsTable.html#event_collapseRow) - select or deselect row
+ * * [expandAllRows](Components.ModelsTable.html#event_expandAllRows) - expand all rows
+ * * [collapseAllRows](Components.ModelsTable.html#event_collapseAllRows) - collapse all rows
+ * * [toggleAllSelection](Components.ModelsTable.html#event_toggleAllSelection) - select or deselect all rows
+ * * [goToPage](Components.ModelsTable.html#event_goToPage) - change table's page (by default used in the pagination)
+ * * [clearFilters](Components.ModelsTable.html#event_clearFilters) - clear all filters (by default used in the summary)
+ * * [sort](Components.ModelsTable.html#event_sort) - sort provided column
+ * * [toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection) - select or deselect all rows in the group (for cases when rows grouping is used)
+ * * [toggleGroupedRowsExpands](Components.ModelsTable.html#event_toggleGroupedRowsExpands) - expand or collapse all rows in the group (for cases when rows grouping is used)
+ * * [toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows) - toggle rows group (for cases when rows grouping is used)
+ * * [clickOnRow](Components.ModelsTable.html#event_clickOnRow)
+ * * [doubleClickOnRow](Components.ModelsTable.html#event_doubleClickOnRow)
+ * * [hoverOnRow](Components.ModelsTable.html#event_hoverOnRow)
+ * * [outRow](Components.ModelsTable.html#event_outRow)
  *
  * ModelsTable has a lot of options you may configure, but there are two required properties called `data` and `columns`. First one contains data (e.g. list of records from the store). Second one is a list of table's columns (check [models-table-column](Utils.ModelsTableColumn.html) for available options).
  *

--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -297,19 +297,22 @@ function objToArray(map) {
  * * [sortByGroupedFieldDirection](Components.ModelsTable.html#property_sortByGroupedFieldDirection) - sorting order for property used to group rows
  * * [useDataGrouping](Components.ModelsTable.html#property_useDataGrouping) - flag to turn on/off rows grouping
  * * [globalFilterUsed](Components.ModelsTable.html#property_globalFilterUsed) - `true` if global filter is used
+ * * [globalFilter](Components.ModelsTable.html#property_filterString) - value of global filter
  * * [anyFilterUsed](Components.ModelsTable.html#property_anyFilterUsed) - `true` when any filter (global or for column) is used. `false` when no filters are used
  * * [useFilteringByColumns](Components.ModelsTable.html#property_useFilteringByColumns) - determines if columns filtering should be used. By default if it's `false` header's row with filter input/select fields is not shown
  * * [collapsedGroupValues](Components.ModelsTable.html#property_collapsedGroupValues) - list of values for property used to group rows. Row group with this value are collapsed
  * * [pagesCount](Components.ModelsTable.html#property_pagesCount) - number of pages in the table
+ * * [recordsCount](Components.ModelsTable.html#property_arrangedContentLength) - number of records in the table
  * * [firstIndex](Components.ModelsTable.html#property_firstIndex) - first row's index in the current page
  * * [lastIndex](Components.ModelsTable.html#property_lastIndex) - last row's index in the current page
+ * * [currentPageNumber](Components.ModelsTable.html#property_currentPageNumber) - current page
  * * [currentPageNumberOptions](Components.ModelsTable.html#property_currentPageNumberOptions) - list of options for current page
  * * [pageSizeOptions](Components.ModelsTable.html#property_pageSizeOptions) - list of options for page size select
  * * [pageSize](Components.ModelsTable.html#property_pageSize) - number of rows shown in the table's page
  * * [columnDropdownOptions](Components.ModelsTable.html#property_columnDropdownOptions) - list of options for columns dropdown
  * * [allColumnsAreHidden](Components.ModelsTable.html#property_allColumnsAreHidden) - `true` if all columns are hidden. `false` if at least one column is visible
  * * [dataGroupOptions](Components.ModelsTable.html#property_dataGroupOptions) - list of property names used for rows grouping
- * * [themeInstance](Components.ModelsTable.html#property_themeInstance) - theme instance used in the table
+ * * [currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName) - property name used now for grouping rows * [themeInstance](Components.ModelsTable.html#property_themeInstance) - theme instance used in the table
  * * [expandedItems](Components.ModelsTable.html#property_expandedItems) - list of expanded rows
  * * [selectedItems](Components.ModelsTable.html#property_selectedItems) - list of selected rows
  * * [isLoading](Components.ModelsTable.html#property_isLoading) - `true` when data for table is loading (used only for `models-table-server-paginated`)
@@ -321,8 +324,8 @@ function objToArray(map) {
  * * [showAllColumns](Components.ModelsTable.html#event_showAllColumns) - show all columns in the table (by default used in the columns dropdown)
  * * [hideAllColumns](Components.ModelsTable.html#event_hideAllColumns) - hide all column in the table (by default used in the columns dropdown)
  * * [restoreDefaultVisibility](Components.ModelsTable.html#event_restoreDefaultVisibility) - show columns visible initially (by default used in the columns dropdown)
- * * [toggleColumnSet](Components.ModelsTable.html#event_toggleColumnSet) - toggle visibility for columns in the custom columns set (by default used in the columns dropdown)
- * * [toggleHidden](Components.ModelsTable.html#event_toggleHidden) - toggle visibility for column (by default used in the columns dropdown)
+ * * [toggleColumnSetVisibility](Components.ModelsTable.html#event_toggleColumnSet) - toggle visibility for columns in the custom columns set (by default used in the columns dropdown)
+ * * [toggleColumnVisibility](Components.ModelsTable.html#event_toggleHidden) - toggle visibility for column (by default used in the columns dropdown)
  * * [expandRow](Components.ModelsTable.html#event_expandRow) - expand or collapse row to show details
  * * [collapseRow](Components.ModelsTable.html#event_collapseRow) - select or deselect row
  * * [expandAllRows](Components.ModelsTable.html#event_expandAllRows) - expand all rows

--- a/addon/components/models-table/cell-column-summary.js
+++ b/addon/components/models-table/cell-column-summary.js
@@ -43,24 +43,26 @@ function medianBy(collection) {
 }
 
 /**
- * Component for table-footer cells. Used as column-summary. It provides several metrics like:
+ * Component for table-footer cells. Used as column-summary.
  *
- * * min of selected items
- * * max of selected items
- * * sum of selected items
- * * average of selected items
- * * median of selected items
- * * min of data
- * * max of data
- * * sum of data
- * * average of data
- * * median of data
+ * It yields several properties:
+ *
+ * * [minSelected](Components.ModelsTableCellColumnSummary.html#property_minSelected) - min of selected items
+ * * [maxSelected](Components.ModelsTableCellColumnSummary.html#property_maxSelected) - max of selected items
+ * * [sumSelected](Components.ModelsTableCellColumnSummary.html#property_sumSelected) - sum of selected items
+ * * [avgSelected](Components.ModelsTableCellColumnSummary.html#property_avgSelected) - average of selected items
+ * * [medianSelected](Components.ModelsTableCellColumnSummary.html#property_medianSelected) - median of selected items
+ * * [minData](Components.ModelsTableCellColumnSummary.html#property_minData) - min of data
+ * * [maxData](Components.ModelsTableCellColumnSummary.html#property_maxData) - max of data
+ * * [sumData](Components.ModelsTableCellColumnSummary.html#property_sumData) - sum of data
+ * * [avgData](Components.ModelsTableCellColumnSummary.html#property_avgData) - average of data
+ * * [medianData](Components.ModelsTableCellColumnSummary.html#property_medianData) - median of data
  *
  * Here `selectedItems` and `data` are bound from `models-table` and are mapped by `column.propertyName`.
  *
  * Component should be used only for column with set `propertyName`.
  *
- * Component should be extended or it's template should be overridden.
+ * Component should be extended or its template should be overridden.
  *
  * @namespace Components
  * @class ModelsTableCellColumnSummary
@@ -134,60 +136,70 @@ class CellColumnSummaryComponent extends Component {
   /**
    * @property minSelected
    * @type number
+   * @protected
    */
   @minBy('mappedSelectedItems') minSelected;
 
   /**
    * @property minData
    * @type number
+   * @protected
    */
   @minBy('mappedData') minData;
 
   /**
    * @property maxSelected
    * @type number
+   * @protected
    */
   @maxBy('mappedSelectedItems') maxSelected;
 
   /**
    * @property maxData
    * @type number
+   * @protected
    */
   @maxBy('mappedData') maxData;
 
   /**
    * @property sumSelected
    * @type number
+   * @protected
    */
   @sumBy('mappedSelectedItems') sumSelected;
 
   /**
    * @property sumData
    * @type number
+   * @protected
    */
   @sumBy('mappedData') sumData;
 
   /**
    * @property avgSelected
    * @type number
+   * @protected
    */
   @avgBy('mappedSelectedItems', 'sumSelected') avgSelected;
 
   /**
    * @property avgData
    * @type number
+   * @protected
    */
   @avgBy('mappedData', 'sumData') avgData;
 
   /**
    * @property medianSelected
    * @type number
+   * @protected
    */
   @medianBy('mappedSelectedItems') medianSelected;
 
   /**
    * @property medianData
    * @type number
+   * @protected
    */
   @medianBy('mappedData') medianData;
 

--- a/addon/components/models-table/cell-edit-toggle.js
+++ b/addon/components/models-table/cell-edit-toggle.js
@@ -229,6 +229,7 @@ class CellEditToggleComponent extends Component {
    * @property editButtonLabel
    * @type string
    * @default themeInstance.editRowButtonLabelMsg
+   * @protected
    */
   @alias('themeInstance.editRowButtonLabelMsg')
   editButtonLabel;
@@ -239,6 +240,7 @@ class CellEditToggleComponent extends Component {
    * @property cancelButtonLabel
    * @type string
    * @default themeInstance.cancelRowButtonLabelMsg
+   * @protected
    */
   @alias('themeInstance.cancelRowButtonLabelMsg')
   cancelButtonLabel;
@@ -249,6 +251,7 @@ class CellEditToggleComponent extends Component {
    * @property saveButtonLabel
    * @type string
    * @default themeInstance.saveRowButtonLabelMsg
+   * @protected
    */
   @alias('themeInstance.saveRowButtonLabelMsg')
   saveButtonLabel;

--- a/addon/components/models-table/cell.js
+++ b/addon/components/models-table/cell.js
@@ -23,9 +23,9 @@ import {isPresent, isNone} from '@ember/utils';
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Body as |Body|>
- *       {{#each Body.visibleContent as |record index|}}
+ *       {{#each MT.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} as |Row|>
- *           {{#each Row.visibleProcessedColumns as |column|}}
+ *           {{#each MT.visibleProcessedColumns as |column|}}
  *             <Row.Cell @column={{column}} @index={{index}} as |Cell|/>
  *               {{#if Cell.componentToRender}}
  *                 {{component Cell.componentToRender record=Cell.record column=column index=index}}

--- a/addon/components/models-table/cell.js
+++ b/addon/components/models-table/cell.js
@@ -28,7 +28,7 @@ import {isPresent, isNone} from '@ember/utils';
  *           {{#each Row.visibleProcessedColumns as |column|}}
  *             <Row.Cell @column={{column}} @index={{index}} as |Cell|/>
  *               {{#if Cell.componentToRender}}
- *                 {{component Cell.componentToRender}}
+ *                 {{component Cell.componentToRender record=Cell.record column=column index=index}}
  *               {{/if}}
  *               {{! ... }}
  *             </Row.Cell>

--- a/addon/components/models-table/columns-dropdown.js
+++ b/addon/components/models-table/columns-dropdown.js
@@ -8,13 +8,54 @@ import layout from '../../templates/components/models-table/columns-dropdown';
  *
  * It allows to toggle visibility for column sets or single column.
  *
- * Columns that should not be hidden must have property `canBeHidden` set to `false`.
+ * Columns that should not be hidden must have property [mayBeHidden](Utils.ModelsTableColumn.html#property_mayBeHidden) set to `false`.
  *
  * Usage example:
  *
  * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.ColumnsDropdown />
+ *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ *
+ * Component yields next properties and actions:
+ *
+ * * Action `showAllColumns`
+ * * Action `hideAllColumns`
+ * * Action `restoreDefaultVisibility`
+ * * Action `toggleColumnSet`
+ * * Action `toggleHidden`
+ * * Property `columnDropdownOptions`
+ * * Property `processedColumns`
+ * * Property `themeInstance`
+ *
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.ColumnsDropdown as |CD|>
+ *     {{#if CD.columnDropdownOptions.showAll}}
+ *       <button {{action CD.showAllColumns}}>Show all</button>
+ *     {{/if}}
+ *     {{#if CD.columnDropdownOptions.hideAll}}
+ *       <button {{action CD.hideAllColumns}}>Hide all</button>
+ *     {{/if}}
+ *     {{#if CD.columnDropdownOptions.restoreDefaults}}
+ *       <button {{action CD.restoreDefaultVisibility}}>Restore default visibility</button>
+ *     {{/if}}
+ *     {{#each CD.columnDropdownOptions.columnSets as |columnSet|}}
+ *       <button {{action CD.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
+ *     {{/each}}
+ *     {{#each CD.processedColumns as |column|}}
+ *       {{#if column.mayBeHidden}}
+ *         <button {{action CD.toggleHidden column}}>
+ *           <i class={{if column.isVisible CD.themeInstance.columnVisibleIcon CD.themeInstance.columnHiddenIcon}}></i>
+ *           {{column.title}}
+ *         </button>
+ *       {{/if}}
+ *     {{/each}}
+ *   </MT.ColumnsDropdown>
  *   {{! .... }}
  * </ModelsTable>
  * ```

--- a/addon/components/models-table/columns-dropdown.js
+++ b/addon/components/models-table/columns-dropdown.js
@@ -34,12 +34,12 @@ import layout from '../../templates/components/models-table/columns-dropdown';
  *       <button {{action MT.restoreDefaultVisibility}}>Restore default visibility</button>
  *     {{/if}}
  *     {{#each MT.columnDropdownOptions.columnSets as |columnSet|}}
- *       <button {{action MT.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
+ *       <button {{action MT.toggleColumnSetVisibility columnSet}}>{{columnSet.label}}</button>
  *     {{/each}}
  *     {{#each MT.processedColumns as |column|}}
  *       {{#if column.mayBeHidden}}
  *         <button {{action MT.toggleHidden column}}>
- *           <i class={{if column.isVisible MT.themeInstance.columnVisibleIcon MT.themeInstance.columnHiddenIcon}}></i>
+ *           <i class={{if column.toggleColumnVisibility MT.themeInstance.columnVisibleIcon MT.themeInstance.columnHiddenIcon}}></i>
  *           {{column.title}}
  *         </button>
  *       {{/if}}

--- a/addon/components/models-table/columns-dropdown.js
+++ b/addon/components/models-table/columns-dropdown.js
@@ -19,38 +19,27 @@ import layout from '../../templates/components/models-table/columns-dropdown';
  * </ModelsTable>
  * ```
  *
- * Component yields next properties and actions:
- *
- * * Action `showAllColumns`
- * * Action `hideAllColumns`
- * * Action `restoreDefaultVisibility`
- * * Action `toggleColumnSet`
- * * Action `toggleHidden`
- * * Property `columnDropdownOptions`
- * * Property `processedColumns`
- * * Property `themeInstance`
- *
  * Block usage example:
  *
  * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.ColumnsDropdown as |CD|>
- *     {{#if CD.columnDropdownOptions.showAll}}
- *       <button {{action CD.showAllColumns}}>Show all</button>
+ *     {{#if MT.columnDropdownOptions.showAll}}
+ *       <button {{action MT.showAllColumns}}>Show all</button>
  *     {{/if}}
- *     {{#if CD.columnDropdownOptions.hideAll}}
- *       <button {{action CD.hideAllColumns}}>Hide all</button>
+ *     {{#if MT.columnDropdownOptions.hideAll}}
+ *       <button {{action MT.hideAllColumns}}>Hide all</button>
  *     {{/if}}
- *     {{#if CD.columnDropdownOptions.restoreDefaults}}
- *       <button {{action CD.restoreDefaultVisibility}}>Restore default visibility</button>
+ *     {{#if MT.columnDropdownOptions.restoreDefaults}}
+ *       <button {{action MT.restoreDefaultVisibility}}>Restore default visibility</button>
  *     {{/if}}
- *     {{#each CD.columnDropdownOptions.columnSets as |columnSet|}}
- *       <button {{action CD.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
+ *     {{#each MT.columnDropdownOptions.columnSets as |columnSet|}}
+ *       <button {{action MT.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
  *     {{/each}}
- *     {{#each CD.processedColumns as |column|}}
+ *     {{#each MT.processedColumns as |column|}}
  *       {{#if column.mayBeHidden}}
- *         <button {{action CD.toggleHidden column}}>
- *           <i class={{if column.isVisible CD.themeInstance.columnVisibleIcon CD.themeInstance.columnHiddenIcon}}></i>
+ *         <button {{action MT.toggleHidden column}}>
+ *           <i class={{if column.isVisible MT.themeInstance.columnVisibleIcon MT.themeInstance.columnHiddenIcon}}></i>
  *           {{column.title}}
  *         </button>
  *       {{/if}}

--- a/addon/components/models-table/data-group-by-select.js
+++ b/addon/components/models-table/data-group-by-select.js
@@ -11,9 +11,41 @@ import layout from '../../templates/components/models-table/data-group-by-select
  * Usage example:
  *
  * ```hbs
- * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @useDataGrouping={{true}}
+ *   @currentGroupingPropertyName="firstName"
+ *   @displayGroupedValueAs="column"
+ *   @dataGroupProperties={{dataGroupProperties}} as |MT|>
  *   <MT.DataGroupBySelect />
  *   {{! ... }}
+ * </ModelsTable>
+ * ```
+ *
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @useDataGrouping={{true}}
+ *   @currentGroupingPropertyName="firstName"
+ *   @displayGroupedValueAs="column"
+ *   @dataGroupProperties={{dataGroupProperties}} as |MT|>
+ *   <MT.DataGroupBySelect as |DGBS|>
+ *     <label>{{DGBS.themeInstance.groupByLabelMsg}}</label>
+ *     <DGBS.Select />
+ *     <button
+ *       class={{DGBS.themeInstance.sortGroupedPropertyBtn}}
+ *       onclick={{action DGBS.sort}}>
+ *       <i class={{if
+ *        (is-equal DGBS.sortByGroupedFieldDirection "asc")
+ *        DGBS.themeInstance.sortAscIcon
+ *        DGBS.themeInstance.sortDescIcon}}>
+ *       </i>
+ *     </button>
+ *   </MT.DataGroupBySelect>
  * </ModelsTable>
  * ```
  *

--- a/addon/components/models-table/data-group-by-select.js
+++ b/addon/components/models-table/data-group-by-select.js
@@ -34,15 +34,15 @@ import layout from '../../templates/components/models-table/data-group-by-select
  *   @displayGroupedValueAs="column"
  *   @dataGroupProperties={{dataGroupProperties}} as |MT|>
  *   <MT.DataGroupBySelect as |DGBS|>
- *     <label>{{DGBS.themeInstance.groupByLabelMsg}}</label>
+ *     <label>{{MT.themeInstance.groupByLabelMsg}}</label>
  *     <DGBS.Select />
  *     <button
- *       class={{DGBS.themeInstance.sortGroupedPropertyBtn}}
- *       onclick={{action DGBS.sort}}>
+ *       class={{MT.themeInstance.sortGroupedPropertyBtn}}
+ *       onclick={{action MT.sort}}>
  *       <i class={{if
- *        (is-equal DGBS.sortByGroupedFieldDirection "asc")
- *        DGBS.themeInstance.sortAscIcon
- *        DGBS.themeInstance.sortDescIcon}}>
+ *        (is-equal MT.sortByGroupedFieldDirection "asc")
+ *        MT.themeInstance.sortAscIcon
+ *        MT.themeInstance.sortDescIcon}}>
  *       </i>
  *     </button>
  *   </MT.DataGroupBySelect>

--- a/addon/components/models-table/data-group-by-select.js
+++ b/addon/components/models-table/data-group-by-select.js
@@ -1,6 +1,7 @@
-import {layout as templateLayout} from '@ember-decorators/component';
+import {className, layout as templateLayout} from '@ember-decorators/component';
 import Component from '@ember/component';
 import {action} from '@ember/object';
+import {alias} from '@ember/object/computed';
 import layout from '../../templates/components/models-table/data-group-by-select';
 
 /**
@@ -38,7 +39,7 @@ import layout from '../../templates/components/models-table/data-group-by-select
  *     <DGBS.Select />
  *     <button
  *       class={{MT.themeInstance.sortGroupedPropertyBtn}}
- *       onclick={{action MT.sort}}>
+ *       onclick={{action DGBS.sort}}>
  *       <i class={{if
  *        (is-equal MT.sortByGroupedFieldDirection "asc")
  *        MT.themeInstance.sortAscIcon
@@ -49,6 +50,10 @@ import layout from '../../templates/components/models-table/data-group-by-select
  * </ModelsTable>
  * ```
  *
+ * References to the following actions are yielded:
+ *
+ * * [sort](Components.ModelsTableDataGroupBySelect.html#event_doSort) - do sort by property name used to group rows
+ *
  * @class ModelsTableDataGroupBySelect
  * @namespace Components
  * @extends Ember.Component
@@ -56,6 +61,14 @@ import layout from '../../templates/components/models-table/data-group-by-select
 export default
 @templateLayout(layout)
 class DataGroupBySelectComponent extends Component {
+
+  /**
+   * @property dataGroupBySelectWrapper
+   * @type string
+   * @protected
+   */
+  @className
+  @alias('themeInstance.dataGroupBySelectWrapper') dataGroupBySelectWrapper;
 
   /**
    * Bound from [ModelsTable.currentGroupingPropertyName](Components.ModelsTable.html#property_currentGroupingPropertyName)

--- a/addon/components/models-table/expand-all-toggle.js
+++ b/addon/components/models-table/expand-all-toggle.js
@@ -4,6 +4,33 @@ import {action} from '@ember/object';
 import layout from '../../templates/components/models-table/expand-all-toggle';
 
 /**
+ * Component to expand or collapse all rows
+ *
+ * Usage example:
+ *
+ * ```js
+ * const columns = [
+ *   {
+ *     component: 'models-table/expand-toggle',
+ *     componentForFilterCell: 'models-table/expand-all-toggle',
+ *     mayBeHidden: false
+ *   },
+ *   {propertyName: 'firstName'},
+ *   {propertyName: 'lastName'}
+ * ];
+ *
+ * const data = [ ... ];
+ * ```
+ *
+ * ```hbs
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @multipleExpand={{true}}
+ *   @expandedRowComponent={{component "path/to/your-component"}}
+ * />
+ * ```
+ *
  * @class ModelsTableExpandAllToggle
  * @extends Ember.Component
  * @namespace Components

--- a/addon/components/models-table/expand-toggle.js
+++ b/addon/components/models-table/expand-toggle.js
@@ -4,6 +4,31 @@ import {action} from '@ember/object';
 import layout from '../../templates/components/models-table/expand-toggle';
 
 /**
+ * Component to expand or collapse any single row
+ *
+ * Usage example:
+ *
+ * ```js
+ * const columns = [
+ *   {
+ *     component: 'models-table/expand-toggle',
+ *     mayBeHidden: false
+ *   },
+ *   {propertyName: 'firstName'},
+ *   {propertyName: 'lastName'}
+ * ];
+ *
+ * const data = [ ... ];
+ * ```
+ *
+ * ```hbs
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @expandedRowComponent={{component "path/to/your-component"}}
+ * />
+ * ```
+ *
  * @class ModelsTableExpandToggle
  * @extends Ember.Component
  * @namespace Components

--- a/addon/components/models-table/footer.js
+++ b/addon/components/models-table/footer.js
@@ -1,5 +1,6 @@
-import {layout as templateLayout} from '@ember-decorators/component';
+import {className, layout as templateLayout} from '@ember-decorators/component';
 import Component from '@ember/component';
+import {alias} from '@ember/object/computed';
 import layout from '../../templates/components/models-table/footer';
 
 /**
@@ -20,7 +21,7 @@ import layout from '../../templates/components/models-table/footer';
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Footer as |Footer|>
  *     <Footer.Summary />
- *     <Footer.SizeSelect />
+ *     <Footer.PageSizeSelect />
  *     {{#if useNumericPagination}}
  *       <Footer.PaginationNumeric />
  *     {{else}}
@@ -46,6 +47,15 @@ import layout from '../../templates/components/models-table/footer';
 export default
 @templateLayout(layout)
 class FooterComponent extends Component {
+
+  /**
+   * @property tfooterInternalWrapper
+   * @type string
+   * @protected
+   */
+  @className
+  @alias('themeInstance.tfooterInternalWrapper')
+  tfooterInternalWrapper;
 
   /**
    * Bound from [ModelsTable.collapseNumPaginationForPagesCount](Components.ModelsTable.html#property_collapseNumPaginationForPagesCount)

--- a/addon/components/models-table/global-filter.js
+++ b/addon/components/models-table/global-filter.js
@@ -1,7 +1,8 @@
-import {layout as templateLayout} from '@ember-decorators/component';
+import {className, layout as templateLayout} from '@ember-decorators/component';
 import Component from '@ember/component';
 import layout from '../../templates/components/models-table/global-filter';
 import {action, computed} from '@ember/object';
+import {alias} from '@ember/object/computed';
 
 /**
  * Global filter element used within [models-table](Components.ModelsTable.html).
@@ -17,6 +18,20 @@ import {action, computed} from '@ember/object';
  * </ModelsTable>
  * ```
  *
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.GlobalFilter>
+ *     {{input value=MT.globalFilter}}
+ *     <button disabled={{if MT.globalFilterUsed "disabled"}} {{action (mut MT.globalFilter) ""}}>
+ *       Clear Global Filter
+ *     </button>
+ *   </MT.GlobalFilter>
+ *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ *
  * @namespace Components
  * @class ModelsTableGlobalFilter
  * @extends Ember.Component
@@ -24,6 +39,14 @@ import {action, computed} from '@ember/object';
 export default
 @templateLayout(layout)
 class GlobalFilterComponent extends Component {
+
+  /**
+   * @property globalFilterWrapper
+   * @type string
+   * @protected
+   */
+  @className
+  @alias('themeInstance.globalFilterWrapper') globalFilterWrapper;
 
   /**
    * Bound from [ModelsTable.filterString](Components.ModelsTable.html#property_filterString)

--- a/addon/components/models-table/grouped-header.js
+++ b/addon/components/models-table/grouped-header.js
@@ -5,22 +5,32 @@ import layout from '../../templates/components/models-table/grouped-header';
 /**
  * Table header item used within [models-table/table-header](Components.ModelsTableTableHeader.html).
  *
- * Each `grouped-header` should represents one item from [ModelsTable.groupedHeaders](Components.ModelsTable.html#property_groupedHeaders).
+ * Each `grouped-header` should represent one item from [ModelsTable.groupedHeaders](Components.ModelsTable.html#property_groupedHeaders).
  *
  * Usage example:
  *
+ * ```js
+ * const groupedHeaders = [
+ *   [{title: 'BigTitle', colspan: 5}],
+ *   [{title: 'SubTitle1', colspan: 2}, {title: 'SubTitle2', colspan: 3}]
+ * ];
+ * ```
+ *
  * ```hbs
- * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ * <ModelsTable
+ *   @columns={{columns}}
+ *   @data={{data}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
- *       {{#each Header.GroupedHeaders as |GroupedHeader|}}
- *         <GroupedHeader @groupedHeader={{groupedHeader}} />
+ *       {{#each groupedHeaders as |groupedHeader|}}
+ *         <Header.GroupedHeader @groupedHeader={{groupedHeader}} as |GroupedHeader|>
+ *           {{#each GroupedHeader.groupedHeader as |cell|}}
+ *             <th colspan={{cell.colspan}} rowspan={{cell.rowspan}}>{{cell.title}}</th>
+ *           {{/each}}
+ *         </Header.GroupedHeader>
  *       {{/each}}
- *       {{! ... }}
  *     </Table.Header>
- *     {{! ... }}
  *   </MT.Table>
- *   {{! .... }}
  * </ModelsTable>
  * ```
  *

--- a/addon/components/models-table/grouped-header.js
+++ b/addon/components/models-table/grouped-header.js
@@ -1,5 +1,6 @@
 import {layout as templateLayout, tagName} from '@ember-decorators/component';
 import Component from '@ember/component';
+import {computed} from '@ember/object';
 import layout from '../../templates/components/models-table/grouped-header';
 
 /**
@@ -84,4 +85,24 @@ class GroupedHeaderComponent extends Component {
    * @type string
    */
   displayGroupedValueAs = null;
+
+  /**
+   * Bound from [ModelsTable.visibleProcessedColumns](Components.ModelsTable.html#property_visibleProcessedColumns)
+   *
+   * @property visibleProcessedColumns
+   * @default null
+   * @type {Utils.ModelsTableColumn[]}
+   */
+  visibleProcessedColumns = null;
+
+  /**
+   * @property shouldAddExtraColumn
+   * @type boolean
+   * @default false
+   * @protected
+   */
+  @computed('displayGroupedValueAs', 'useDataGrouping', 'visibleProcessedColumns.[]')
+  get shouldAddExtraColumn () {
+    return this.displayGroupedValueAs === 'column' && this.useDataGrouping && !!this.visibleProcessedColumns.length;
+  }
 }

--- a/addon/components/models-table/page-size-select.js
+++ b/addon/components/models-table/page-size-select.js
@@ -1,6 +1,7 @@
-import {layout as templateLayout} from '@ember-decorators/component';
+import {className, layout as templateLayout} from '@ember-decorators/component';
 import Component from '@ember/component';
 import {computed} from '@ember/object';
+import {alias} from '@ember/object/computed';
 import layout from '../../templates/components/models-table/page-size-select';
 
 /**
@@ -13,7 +14,7 @@ import layout from '../../templates/components/models-table/page-size-select';
  * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Footer as |Footer|>
- *     <Footer.SizeSelect />
+ *     <Footer.PageSizeSelect />
  *     {{! ... }}
  *   </MT.Footer>
  *   {{! .... }}
@@ -24,12 +25,15 @@ import layout from '../../templates/components/models-table/page-size-select';
  * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Footer as |Footer|>
- *     <Footer.SizeSelect as |SizeSelectBlock|>
+ *     <Footer.PageSizeSelect as |SizeSelectBlock|>
  *       <SizeSelectBlock.Select />
- *     </Footer.SizeSelect>
+ *     </Footer.PageSizeSelect>
  *   </MT.Footer>
  * </ModelsTable>
  * ```
+ * ModelsTablePageSizeSelect yields references to the following contextual components:
+ *
+ * * Select - selectbox with list of available page size options
  *
  * @class ModelsTablePageSizeSelect
  * @namespace Components
@@ -38,6 +42,16 @@ import layout from '../../templates/components/models-table/page-size-select';
 export default
 @templateLayout(layout)
 class PageSizeSelectComponent extends Component {
+
+  /**
+   * @property pageSizeWrapper
+   * @type string
+   * @protected
+   */
+  @className
+  @alias('themeInstance.pageSizeWrapper')
+  pageSizeWrapper;
+
   /**
    * Bound from [ModelsTable.pageSizeOptions](Components.ModelsTable.html#property_pageSizeOptions)
    *

--- a/addon/components/models-table/page-size-select.js
+++ b/addon/components/models-table/page-size-select.js
@@ -19,6 +19,17 @@ import layout from '../../templates/components/models-table/page-size-select';
  *   {{! .... }}
  * </ModelsTable>
  * ```
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Footer as |Footer|>
+ *     <Footer.SizeSelect as |SizeSelectBlock|>
+ *       <SizeSelectBlock.Select />
+ *     </Footer.SizeSelect>
+ *   </MT.Footer>
+ * </ModelsTable>
+ * ```
  *
  * @class ModelsTablePageSizeSelect
  * @namespace Components

--- a/addon/components/models-table/pagination-numeric.js
+++ b/addon/components/models-table/pagination-numeric.js
@@ -29,14 +29,14 @@ import layout from '../../templates/components/models-table/pagination-numeric';
  *       {{#each PN.visiblePageNumbers as |page|}}
  *         {{#if page.isLink}}
  *           <button
- *             class="{{themeInstance.paginationNumericItem}} {{if page.isActive themeInstance.paginationNumericItemActive}} {{themeInstance.buttonDefault}}"
- *             {{action PN.goToPage page.label}}>
+ *             class="{{MT.themeInstance.paginationNumericItem}} {{if page.isActive MT.themeInstance.paginationNumericItemActive}} {{MT.themeInstance.buttonDefault}}"
+ *             {{action MT.goToPage page.label}}>
  *             {{page.label}}
  *           </button>
  *         {{else}}
  *           <button
  *             type="button"
- *             class="{{themeInstance.buttonDefault}} {{themeInstance.paginationNumericItem}}"
+ *             class="{{MT.themeInstance.buttonDefault}} {{MT.themeInstance.paginationNumericItem}}"
  *             disabled="disabled">
  *             {{page.label}}
  *           </button>
@@ -54,10 +54,6 @@ import layout from '../../templates/components/models-table/pagination-numeric';
  * References to the following properties are yielded:
  *
  * * [visiblePageNumbers](Components.ModelsTablePaginationNumeric.html#property_visiblePageNumbers)
- *
- * References to the following actions are yielded:
- *
- * * [goToPage](Components.ModelsTablePaginationSimple.html#event_goToPage) - action to navigate user to the custom page
  *
  * @class ModelsTablePaginationNumeric
  * @namespace Components

--- a/addon/components/models-table/pagination-numeric.js
+++ b/addon/components/models-table/pagination-numeric.js
@@ -12,11 +12,40 @@ import layout from '../../templates/components/models-table/pagination-numeric';
  *
  * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
- *   <MT.Footer as |footer|>
+ *   <MT.Footer as |Footer|>
  *     <Footer.PaginationNumeric />
  *     {{! ... }}
  *   </MT.Footer>
  *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ *
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Footer as |Footer|>
+ *     <Footer.PaginationNumeric as |PN|>
+ *       {{#each PN.visiblePageNumbers as |page|}}
+ *         {{#if page.isLink}}
+ *           <button
+ *             class="{{themeInstance.paginationNumericItem}} {{if page.isActive themeInstance.paginationNumericItemActive}} {{themeInstance.buttonDefault}}"
+ *             {{action "gotoCustomPage" page.label}}>
+ *             {{page.label}}
+ *           </button>
+ *         {{else}}
+ *           <button
+ *             type="button"
+ *             class="{{themeInstance.buttonDefault}} {{themeInstance.paginationNumericItem}}"
+ *             disabled="disabled"
+ *             {{action "gotoCustomPage" page.label}}>
+ *             {{page.label}}
+ *           </button>
+ *         {{/if}}
+ *       {{/each}}
+ *       <PN.PageNumberSelect />
+ *     </Footer.PaginationNumeric>
+ *   </MT.Footer>
  * </ModelsTable>
  * ```
  *

--- a/addon/components/models-table/pagination-numeric.js
+++ b/addon/components/models-table/pagination-numeric.js
@@ -30,15 +30,14 @@ import layout from '../../templates/components/models-table/pagination-numeric';
  *         {{#if page.isLink}}
  *           <button
  *             class="{{themeInstance.paginationNumericItem}} {{if page.isActive themeInstance.paginationNumericItemActive}} {{themeInstance.buttonDefault}}"
- *             {{action "gotoCustomPage" page.label}}>
+ *             {{action PN.goToPage page.label}}>
  *             {{page.label}}
  *           </button>
  *         {{else}}
  *           <button
  *             type="button"
  *             class="{{themeInstance.buttonDefault}} {{themeInstance.paginationNumericItem}}"
- *             disabled="disabled"
- *             {{action "gotoCustomPage" page.label}}>
+ *             disabled="disabled">
  *             {{page.label}}
  *           </button>
  *         {{/if}}
@@ -48,6 +47,17 @@ import layout from '../../templates/components/models-table/pagination-numeric';
  *   </MT.Footer>
  * </ModelsTable>
  * ```
+ * ModelsTablePaginationNumeric yields references to the following contextual components:
+ *
+ * * PageNumberSelect - selectbox with list of available pages
+ *
+ * References to the following properties are yielded:
+ *
+ * * [visiblePageNumbers](Components.ModelsTablePaginationNumeric.html#property_visiblePageNumbers)
+ *
+ * References to the following actions are yielded:
+ *
+ * * [goToPage](Components.ModelsTablePaginationSimple.html#event_goToPage) - action to navigate user to the custom page
  *
  * @class ModelsTablePaginationNumeric
  * @namespace Components

--- a/addon/components/models-table/pagination-simple.js
+++ b/addon/components/models-table/pagination-simple.js
@@ -19,6 +19,38 @@ import layout from '../../templates/components/models-table/pagination-simple';
  * </ModelsTable>
  * ```
  *
+ * Block usage example:
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Footer as |Footer|>
+ *     <Footer.PaginationSimple as |PS|>
+ *       <button
+ *         class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.gotoFirst}}>
+ *         <i class={{themeInstance.navFirstIcon}}></i>
+ *       </button>
+ *       <button
+ *         class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.gotoPrev}}>
+ *         <i class={{themeInstance.navPrevIcon}}></i>
+ *       </button>
+ *       <button
+ *         class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.gotoNext}}>
+ *         <i class={{themeInstance.navNextIcon}}></i>
+ *       </button>
+ *       <button
+ *         class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.gotoLast}}>
+ *         <i class={{themeInstance.navLastIcon}}></i>
+ *       </button>
+ *       <PS.PageNumberSelect/>
+ *     </Footer.PaginationSimple>
+ *   </MT.Footer>
+ * </ModelsTable>
+ * ```
+ *
  * @class ModelsTablePaginationSimple
  * @namespace Components
  * @extends Ember.Component

--- a/addon/components/models-table/pagination-simple.js
+++ b/addon/components/models-table/pagination-simple.js
@@ -26,23 +26,23 @@ import layout from '../../templates/components/models-table/pagination-simple';
  *   <MT.Footer as |Footer|>
  *     <Footer.PaginationSimple as |PS|>
  *       <button
- *         class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
- *         {{action PS.gotoFirst}}>
+ *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.goToFirst}}>
  *         <i class={{themeInstance.navFirstIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
- *         {{action PS.gotoPrev}}>
+ *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.goToPrev}}>
  *         <i class={{themeInstance.navPrevIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
- *         {{action PS.gotoNext}}>
+ *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.goToNext}}>
  *         <i class={{themeInstance.navNextIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
- *         {{action PS.gotoLast}}>
+ *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         {{action PS.goToLast}}>
  *         <i class={{themeInstance.navLastIcon}}></i>
  *       </button>
  *       <PS.PageNumberSelect/>
@@ -50,6 +50,22 @@ import layout from '../../templates/components/models-table/pagination-simple';
  *   </MT.Footer>
  * </ModelsTable>
  * ```
+ * ModelsTablePaginationSimple yields references to the following contextual components:
+ *
+ * * PageNumberSelect - selectbox with list of available pages
+ *
+ * References to the following properties are yielded:
+ *
+ * * [goToBackEnabled](Components.ModelsTablePaginationSimple.html#property_goToBackEnabled) - `true` is user is not in the first page
+ * * [goToForwardEnabled](Components.ModelsTablePaginationSimple.html#property_goToForwardEnabled) - `true` if user is not in the last page
+ *
+ * References to the following actions are yielded:
+ *
+ * * [goToPage](Components.ModelsTablePaginationSimple.html#event_goToPage) - action to navigate user to the custom page
+ * * [goToFirst](Components.ModelsTablePaginationSimple.html#event_goToFirst) - action to navigate user to the first page
+ * * [goToPrev](Components.ModelsTablePaginationSimple.html#event_goToPrev) - action to navigate user to the previous page
+ * * [goToNext](Components.ModelsTablePaginationSimple.html#event_goToNext) - action to navigate user to the next page
+ * * [goToLast](Components.ModelsTablePaginationSimple.html#event_goToLast) - action to navigate user to the last page
  *
  * @class ModelsTablePaginationSimple
  * @namespace Components
@@ -148,23 +164,23 @@ class PaginationSimpleComponent extends Component {
   /**
    * Are buttons "Back" and "First" enabled
    *
-   * @property gotoBackEnabled
+   * @property goToBackEnabled
    * @type boolean
    * @default false
    * @protected
    */
-  @gt('currentPageNumber', 1) gotoBackEnabled;
+  @gt('currentPageNumber', 1) goToBackEnabled;
 
   /**
    * Are buttons "Next" and "Last" enabled
    *
-   * @property gotoForwardEnabled
+   * @property goToForwardEnabled
    * @type boolean
    * @default false
    * @protected
    */
   @computed('currentPageNumber', 'pagesCount')
-  get gotoForwardEnabled() {
+  get goToForwardEnabled() {
     return this.currentPageNumber < this.pagesCount;
   }
   /**
@@ -183,7 +199,7 @@ class PaginationSimpleComponent extends Component {
    */
   @action
   gotoFirst() {
-    if (!this.gotoBackEnabled) {
+    if (!this.goToBackEnabled) {
       return;
     }
     this.goToPage(1);
@@ -195,7 +211,7 @@ class PaginationSimpleComponent extends Component {
    */
   @action
   gotoPrev() {
-    if (!this.gotoBackEnabled) {
+    if (!this.goToBackEnabled) {
       return;
     }
     if (this.currentPageNumber > 1) {
@@ -209,7 +225,7 @@ class PaginationSimpleComponent extends Component {
    */
   @action
   gotoNext() {
-    if (!this.gotoForwardEnabled) {
+    if (!this.goToForwardEnabled) {
       return;
     }
     const pageSize = parseInt(this.pageSize, 10);
@@ -224,7 +240,7 @@ class PaginationSimpleComponent extends Component {
    */
   @action
   gotoLast() {
-    if (!this.gotoForwardEnabled) {
+    if (!this.goToForwardEnabled) {
       return;
     }
     const pageSize = parseInt(this.pageSize, 10);

--- a/addon/components/models-table/pagination-simple.js
+++ b/addon/components/models-table/pagination-simple.js
@@ -26,24 +26,24 @@ import layout from '../../templates/components/models-table/pagination-simple';
  *   <MT.Footer as |Footer|>
  *     <Footer.PaginationSimple as |PS|>
  *       <button
- *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
  *         {{action PS.goToFirst}}>
- *         <i class={{themeInstance.navFirstIcon}}></i>
+ *         <i class={{MT.themeInstance.navFirstIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
  *         {{action PS.goToPrev}}>
- *         <i class={{themeInstance.navPrevIcon}}></i>
+ *         <i class={{MT.themeInstance.navPrevIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
  *         {{action PS.goToNext}}>
- *         <i class={{themeInstance.navNextIcon}}></i>
+ *         <i class={{MT.themeInstance.navNextIcon}}></i>
  *       </button>
  *       <button
- *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+ *         class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
  *         {{action PS.goToLast}}>
- *         <i class={{themeInstance.navLastIcon}}></i>
+ *         <i class={{MT.themeInstance.navLastIcon}}></i>
  *       </button>
  *       <PS.PageNumberSelect/>
  *     </Footer.PaginationSimple>

--- a/addon/components/models-table/row-expand.js
+++ b/addon/components/models-table/row-expand.js
@@ -15,9 +15,9 @@ import layout from '../../templates/components/models-table/row-expand';
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Body as |Body|>
- *       {{#each Body.visibleContent as |record index|}}
+ *       {{#each MT.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} />
- *         {{#if (exists-in Body.expandedItems record)}}
+ *         {{#if (exists-in MT.expandedItems record)}}
  *           <Body.RowExpand @record={{record}} @index={{index}} />
  *         {{/if}}
  *       {{/each}}

--- a/addon/components/models-table/row-filtering-cell.js
+++ b/addon/components/models-table/row-filtering-cell.js
@@ -12,8 +12,38 @@ import layout from '../../templates/components/models-table/row-filtering-cell';
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
  *       <Header.RowFiltering as |RF|>
- *         {{#each RF.visibleProcessedColumns as |column|}}
- *           {{RF.RowFilteringCell @column={{column}} />
+ *         {{#each MT.visibleProcessedColumns as |column|}}
+ *           <RF.RowFilteringCell @column={{column}} />
+ *         {{/each}}
+ *       </Header.RowFiltering>
+ *       {{! ... }}
+ *     </Table.Header>
+ *     {{! ... }}
+ *   </MT.Table>
+ *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ *
+ * If `column.componentForFilterCell` is provided it is yielded with next properties and actions:
+ *
+ * * [column](Component.ModelsTableCellContentDisplay.html#property_column)
+ * * [selectedItems](Component.ModelsTableCellContentDisplay.html#property_selectedItems)
+ * * [expandedItems](Component.ModelsTableCellContentDisplay.html#property_expandedItems)
+ * * [data](Component.ModelsTableCellContentDisplay.html#property_data)
+ * * [themeInstance](Component.ModelsTableCellContentDisplay.html#property_themeInstance)
+ * * [expandAllRows](Component.ModelsTableCellContentDisplay.html#event_expandAllRows)
+ * * [collapseAllRows](Component.ModelsTableCellContentDisplay.html#event_collapseAllRows)
+ * * [toggleAllSelection](Component.ModelsTableCellContentDisplay.html#event_toggleAllSelection)
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Table as |Table|>
+ *     <Table.Header as |Header|>
+ *       <Header.RowFiltering as |RF|>
+ *         {{#each MT.visibleProcessedColumns as |column|}}
+ *           <RF.RowFilteringCell @column={{column}} as |RowFilteringCellContent|>
+ *             <RowFilteringCellContent/>
+ *           </RF.RowFilteringCell>
  *         {{/each}}
  *       </Header.RowFiltering>
  *       {{! ... }}

--- a/addon/components/models-table/row-filtering.js
+++ b/addon/components/models-table/row-filtering.js
@@ -1,5 +1,6 @@
 import {layout as templateLayout, tagName} from '@ember-decorators/component';
 import Component from '@ember/component';
+import {computed} from '@ember/object';
 import layout from '../../templates/components/models-table/row-filtering';
 import {shownColumns} from '../../utils/macros';
 
@@ -160,4 +161,15 @@ class RowFilteringComponent extends Component {
    * @protected
    */
   @shownColumns('colspanForFilterCell') shownColumns;
+
+  /**
+   * @property shouldAddExtraColumn
+   * @type boolean
+   * @default false
+   * @protected
+   */
+  @computed('displayGroupedValueAs', 'useDataGrouping', 'visibleProcessedColumns.[]')
+  get shouldAddExtraColumn () {
+    return this.displayGroupedValueAs === 'column' && this.useDataGrouping && !!this.visibleProcessedColumns.length;
+  }
 }

--- a/addon/components/models-table/row-filtering.js
+++ b/addon/components/models-table/row-filtering.js
@@ -31,8 +31,10 @@ import {shownColumns} from '../../utils/macros';
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
  *       <Header.RowFiltering as |RF|>
- *         {{#each RF.visibleProcessedColumns as |column|}}
- *           <RF.RowFilteringCell @column={{column}} />
+ *         {{#each MT.visibleProcessedColumns as |column|}}
+ *           <RF.RowFilteringCell @column={{column}} as |RowFilteringCellContent|>
+ *             <RowFilteringCellContent/>
+ *           </RF.RowFilteringCell>
  *         {{/each}}
  *       </Header.RowFiltering>
  *       {{! ... }}
@@ -48,6 +50,10 @@ import {shownColumns} from '../../utils/macros';
  * * [models-table/row-filtering-cell](Components.ModelsTableRowFilteringCell.html) - component used as filter row cell. It shows input or select or custom component. Check filter-options for columns
  *
  * Check own docs for each component to get detailed info.
+ *
+ * References to the following properties are yielded:
+ *
+ * * [shouldAddExtraColumn](Components.ModelsTableRowFiltering.html#property_shouldAddExtraColumn) - determines if extra column should be added to the row in the `thead`. It happens when rows grouping is used and extra column with group values exists
  *
  * @class ModelsTableRowFiltering
  * @namespace Components

--- a/addon/components/models-table/row-select-all-checkbox.js
+++ b/addon/components/models-table/row-select-all-checkbox.js
@@ -4,6 +4,32 @@ import {action} from '@ember/object';
 import layout from '../../templates/components/models-table/row-select-all-checkbox';
 
 /**
+ * Component with checkbox to select or deselect all rows
+ *
+ * Usage example:
+ *
+ * ```js
+ * const columns = [
+ *   {
+ *     component: 'models-table/row-select-checkbox',
+ *     useFilter: false,
+ *     mayBeHidden: false,
+ *     componentForSortCell: 'models-table/row-select-all-checkbox'
+ *   },
+ *   {propertyName: 'firstName'},
+ *   {propertyName: 'lastName'}
+ * ];
+ * const data = [ ... ];
+ * ```
+ *
+ * ```hbs
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @multipleSelect={{true}}
+ * />
+ * ```
+ *
  * @class ModelsTableRowSelectAllCheckbox
  * @extends Ember.Component
  * @namespace Components

--- a/addon/components/models-table/row-select-checkbox.js
+++ b/addon/components/models-table/row-select-checkbox.js
@@ -4,6 +4,32 @@ import {action} from '@ember/object';
 import layout from '../../templates/components/models-table/row-select-checkbox';
 
 /**
+ * Component with checkbox to select or deselect any single row
+ *
+ * Usage example:
+ *
+ * ```js
+ * const columns = [
+ *   {
+ *     component: 'models-table/row-select-checkbox',
+ *     useFilter: false,
+ *     mayBeHidden: false,
+ *     componentForSortCell: 'models-table/row-select-all-checkbox'
+ *   },
+ *   {propertyName: 'firstName'},
+ *   {propertyName: 'lastName'}
+ * ];
+ * const data = [ ... ];
+ * ```
+ *
+ * ```hbs
+ * <ModelsTable
+ *   @data={{data}}
+ *   @columns={{columns}}
+ *   @multipleSelect={{true}}
+ * />
+ * ```
+ *
  * @class ModelsTableRowSelectCheckbox
  * @extends Ember.Component
  * @namespace Components

--- a/addon/components/models-table/row-sorting-cell.js
+++ b/addon/components/models-table/row-sorting-cell.js
@@ -12,8 +12,36 @@ import layout from '../../templates/components/models-table/row-sorting-cell';
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
  *       <Header.RowSorting as |RS|>
- *         {{#each RS.visibleProcessedColumns as |column|}}
+ *         {{#each MT.visibleProcessedColumns as |column|}}
  *           <RS.RowSortingCell @column={{column}} />
+ *         {{/each}}
+ *       </Header.RowSorting>
+ *       {{! ... }}
+ *     </Table.Header>
+ *     {{! ... }}
+ *   </MT.Table>
+ *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ * If `column.componentForSortCell` is provided it is yielded with next properties and actions:
+ *
+ * * [column](Component.ModelsTableCellContentDisplay.html#property_column)
+ * * [selectedItems](Component.ModelsTableCellContentDisplay.html#property_selectedItems)
+ * * [expandedItems](Component.ModelsTableCellContentDisplay.html#property_expandedItems)
+ * * [data](Component.ModelsTableCellContentDisplay.html#property_data)
+ * * [themeInstance](Component.ModelsTableCellContentDisplay.html#property_themeInstance)
+ * * [expandAllRows](Component.ModelsTableCellContentDisplay.html#event_expandAllRows)
+ * * [collapseAllRows](Component.ModelsTableCellContentDisplay.html#event_collapseAllRows)
+ *
+ * ```hbs
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Table as |Table|>
+ *     <Table.Header as |Header|>
+ *       <Header.RowSorting as |RS|>
+ *         {{#each MT.visibleProcessedColumns as |column|}}
+ *           <RS.RowSortingCell @column={{column}} as |RowSortingCellContent|>
+ *             <RowSortingCellContent/>
+ *           </RS.RowSortingCell>
  *         {{/each}}
  *       </Header.RowSorting>
  *       {{! ... }}

--- a/addon/components/models-table/row-sorting.js
+++ b/addon/components/models-table/row-sorting.js
@@ -191,6 +191,17 @@ class RowSortingComponent extends Component {
   @shownColumns('colspanForSortCell') shownColumns;
 
   /**
+   * @property shouldAddExtraColumn
+   * @type boolean
+   * @default false
+   * @protected
+   */
+  @computed('displayGroupedValueAs', 'useDataGrouping', 'visibleProcessedColumns.[]')
+  get shouldAddExtraColumn () {
+    return this.displayGroupedValueAs === 'column' && this.useDataGrouping && !!this.visibleProcessedColumns.length;
+  }
+
+  /**
    * @property currentGroupingPropertyNameTitlelized
    * @type string
    * @protected

--- a/addon/components/models-table/row-sorting.js
+++ b/addon/components/models-table/row-sorting.js
@@ -32,7 +32,7 @@ import {propertyNameToTitle} from '../../utils/column';
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
  *       <Header.RowSorting as |RS|>
- *         {{#each RS.visibleProcessedColumns as |column|}}
+ *         {{#each MT.visibleProcessedColumns as |column|}}
  *           <td>{{column.title}}</td>
  *         {{/each}}
  *       </Header.RowSorting>
@@ -47,6 +47,10 @@ import {propertyNameToTitle} from '../../utils/column';
  * ModelsTableRowSorting yields references to the following contextual components:
  *
  * * [models-table/row-sorting-cell](Components.ModelsTableRowSortingCell.html) - component used as sorting row cell. Clicking on it causes column sorting
+ *
+ * References to the following properties are yielded:
+ *
+ * * [shouldAddExtraColumn](Components.ModelsTableRowSorting.html#property_shouldAddExtraColumn) - determines if extra column should be added to the row in the `thead`. It happens when rows grouping is used and extra column with group values exists
  *
  * Check own docs for each component to get detailed info.
  *

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -166,6 +166,15 @@ class RowComponent extends Component {
   visibleGroupedItems = null;
 
   /**
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
+   *
+   * @property useDataGrouping
+   * @type boolean
+   * @default null
+   */
+  useDataGrouping = null;
+
+  /**
    * @protected
    * @property selectedGroupedItems
    * @type object[]
@@ -294,6 +303,13 @@ class RowComponent extends Component {
    * @event collapseAllRows
    */
   collapseAllRows = null;
+
+  /**
+   * Closure action [ModelsTable.toggleGroupedRows](Components.ModelsTable.html#event_toggleGroupedRows)
+   *
+   * @event toggleGroupedRows
+   */
+  toggleGroupedRows = null;
 
   /**
    * Closure action [ModelsTable.toggleGroupedRowsSelection](Components.ModelsTable.html#event_toggleGroupedRowsSelection)

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -51,8 +51,20 @@ import layout from '../../templates/components/models-table/row';
  * ModelsTableTableRow yields references to the following contextual components:
  *
  * * [models-table/cell](Components.ModelsTableCell.html) - component represents each row's cell
+ * * [models-table/row-group-toggle](Components.ModelsTableRowGroupToggle.html) - component is used to toggle rows group visibility
  *
  * Check own docs for each component to get detailed info.
+ *
+ * References to the following properties are yielded:
+ *
+ * * [isEditRow](Components.ModelsTableRow.html#property_isEditRow) - `true` if row in the Edit-mode
+ * * [isFirstGroupedRow](Components.ModelsTableRow.html#property_isFirstGroupedRow) - `true` if row is first in the rows group (flag used when rows grouping is used)
+ *
+ * References to the following actions are yielded:
+ *
+ * * [editRow](Components.ModelsTableRow.html#event_editRow) - action to set row to the Edit-mode
+ * * [saveRow](Components.ModelsTableRow.html#event_saveRow) - action to save row and turn off Edit-mode
+ * * [cancelEditRow](Components.ModelsTableRow.html#event_cancelEditRow) - action to cancel changes done to the row and turn off Edit-mode
  *
  * @class ModelsTableRow
  * @namespace Components

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -33,7 +33,7 @@ import layout from '../../templates/components/models-table/row';
  *     <Table.Body as |Body|>
  *       {{#each Body.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} as |Row|>
- *           {{#each Row.visibleProcessedColumns as |column|}}
+ *           {{#each MT.visibleProcessedColumns as |column|}}
  *             <Row.Cell @column={{column}} @index={{index}} />
  *           {{/each}}
  *         </Body.Row>

--- a/addon/components/models-table/row.js
+++ b/addon/components/models-table/row.js
@@ -34,7 +34,7 @@ import layout from '../../templates/components/models-table/row';
  *       {{#each Body.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} as |Row|>
  *           {{#each Row.visibleProcessedColumns as |column|}}
- *             <Row.Cell @column={{column}} />
+ *             <Row.Cell @column={{column}} @index={{index}} />
  *           {{/each}}
  *         </Body.Row>
  *       {{/each}}

--- a/addon/components/models-table/summary.js
+++ b/addon/components/models-table/summary.js
@@ -20,6 +20,10 @@ import fmt from '../../utils/fmt';
  * </ModelsTable>
  * ```
  *
+ * References to the following properties are yielded:
+ *
+ * * [summary](Components.ModelsTableSummary.html#property_summary) - message like "Show xx - yy from zzz"
+ *
  * @class ModelsTableSummary
  * @namespace Components
  * @extends Ember.Component

--- a/addon/components/models-table/table-body.js
+++ b/addon/components/models-table/table-body.js
@@ -26,13 +26,13 @@ import layout from '../../templates/components/models-table/table-body';
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Body as |Body|>
- *       {{#if Body.allColumnsAreHidden}}
+ *       {{#if MT.allColumnsAreHidden}}
  *         <Body.ColumnsHidden />
  *       {{else}}
- *         {{#if Body.visibleContent.length}}
- *           {{#each Body.visibleContent as |record index|}}
+ *         {{#if MT.visibleContent.length}}
+ *           {{#each MT.visibleContent as |record index|}}
  *             <Body.Row @record={{record}} @index={{index}} />
- *             {{#if (exists-in Body.expandedItems record)}}
+ *             {{#if (exists-in MT.expandedItems record)}}
  *               <Body.RowExpand @record={{record}} @index={{index}} />
  *             {{/if}}
  *           {{/each}}

--- a/addon/components/models-table/table-footer.js
+++ b/addon/components/models-table/table-footer.js
@@ -1,5 +1,6 @@
 import {layout as templateLayout, tagName} from '@ember-decorators/component';
 import Component from '@ember/component';
+import {computed} from '@ember/object';
 import layout from '../../templates/components/models-table/table-footer';
 
 /**
@@ -53,6 +54,15 @@ class TableFooterComponent extends Component {
   visibleProcessedColumns = null;
 
   /**
+   * Bound from [ModelsTable.displayGroupedValueAs](Components.ModelsTable.html#property_displayGroupedValueAs)
+   *
+   * @property displayGroupedValueAs
+   * @type string
+   * @default null
+   */
+  displayGroupedValueAs = null;
+
+  /**
    * Bound from [ModelsTable.themeInstance](Components.ModelsTable.html#property_themeInstance)
    *
    * @property themeInstance
@@ -78,6 +88,15 @@ class TableFooterComponent extends Component {
    * @default null
    */
   expandedItems = null;
+
+  /**
+   * Bound from [ModelsTable.useDataGrouping](Components.ModelsTable.html#property_useDataGrouping)
+   *
+   * @property useDataGrouping
+   * @type boolean
+   * @default null
+   */
+  useDataGrouping = null;
 
   /**
    * Closure action [ModelsTable.goToPage](Components.ModelsTable.html#event_goToPage)
@@ -120,4 +139,15 @@ class TableFooterComponent extends Component {
    * @event collapseAllRows
    */
   collapseAllRows = null;
+
+  /**
+   * @property shouldAddExtraColumn
+   * @type boolean
+   * @default false
+   * @protected
+   */
+  @computed('displayGroupedValueAs', 'useDataGrouping', 'visibleProcessedColumns.[]')
+  get shouldAddExtraColumn () {
+    return this.displayGroupedValueAs === 'column' && this.useDataGrouping && !!this.visibleProcessedColumns.length;
+  }
 }

--- a/addon/components/models-table/table-footer.js
+++ b/addon/components/models-table/table-footer.js
@@ -22,6 +22,7 @@ import layout from '../../templates/components/models-table/table-footer';
  *
  * Block usage example 2:
  *
+ * ```hbs
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Footer as |Footer|>

--- a/addon/components/models-table/table-footer.js
+++ b/addon/components/models-table/table-footer.js
@@ -20,6 +20,28 @@ import layout from '../../templates/components/models-table/table-footer';
  * </ModelsTable>
  * ```
  *
+ * Block usage example 2:
+ *
+ * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+ *   <MT.Table as |Table|>
+ *     <Table.Footer as |Footer|>
+ *        <tr>
+ *          <td colspan={{if Footer.shouldAddExtraColumn  (inc MT.visibleProcessedColumns.length) MT.visibleProcessedColumns.length}}>
+ *            {{! "inc" is a helper from `ember-composable-helpers` }}
+ *            Some custom summary for table can be shown in the <code>tfoot</code>
+ *          </td>
+ *        </tr>
+ *      </Table.Footer>
+ *     {{! ... }}
+ *   </MT.Table>
+ *   {{! .... }}
+ * </ModelsTable>
+ * ```
+ *
+ * References to the following properties are yielded:
+ *
+ * * [shouldAddExtraColumn](Components.ModelsTableTableFooter.html#property_shouldAddExtraColumn) - determines if extra column should be added to the row in the `tfoot`. It happens when rows grouping is used and extra column with group values exists
+ *
  * @class ModelsTableTableFooter
  * @extends Ember.Component
  * @namespace Components

--- a/addon/components/models-table/table-header.js
+++ b/addon/components/models-table/table-header.js
@@ -27,8 +27,12 @@ import layout from '../../templates/components/models-table/table-header';
  * <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
  *   <MT.Table as |Table|>
  *     <Table.Header as |Header|>
- *       {{#each Header.GroupedHeaders as |GroupedHeader|}}
- *         <GroupedHeader @groupedHeader={{groupedHeader}} />
+ *       {{#each groupedHeaders as |groupedHeader|}}
+ *         <Header.GroupedHeader @groupedHeader={{groupedHeader}} as |GroupedHeader|>
+ *           {{#each GroupedHeader.groupedHeader as |cell|}}
+ *             <th colspan={{cell.colspan}} rowspan={{cell.rowspan}}>{{cell.title}}</th>
+ *           {{/each}}
+ *         </Header.GroupedHeader>
  *       {{/each}}
  *       <Header.RowSorting />
  *       <Header.RowFiltering />

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -138,13 +138,17 @@
     displayGroupedValueAs=displayGroupedValueAs
     useDataGrouping=useDataGrouping
     anyFilterUsed=anyFilterUsed
+    currentGroupingPropertyName=currentGroupingPropertyName
     collapsedGroupValues=collapsedGroupValues
+    globalFilter=filterString
     globalFilterUsed=globalFilterUsed
     useFilteringByColumns=useFilteringByColumns
     pagesCount=pagesCount
+    recordsCount=arrangedContentLength
     firstIndex=firstIndex
     lastIndex=lastIndex
     pageSize=pageSize
+    currentPageNumber=currentPageNumber
     pageSizeOptions=pageSizeOptions
     currentPageNumberOptions=currentPageNumberOptions
     columnDropdownOptions=columnDropdownOptions
@@ -157,8 +161,8 @@
     showAllColumns=(action "showAllColumns")
     hideAllColumns=(action "hideAllColumns")
     restoreDefaultVisibility=(action "restoreDefaultVisibility")
-    toggleColumnSet=(action "toggleColumnSet")
-    toggleHidden=(action "toggleHidden")
+    toggleColumnSetVisilibity=(action "toggleColumnSet")
+    toggleColumnVisibility=(action "toggleHidden")
 
     expandRow=(action "expandRow")
     collapseRow=(action "collapseRow")

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -111,7 +111,7 @@
       pagesCount=pagesCount
       themeInstance=themeInstance
       showCurrentPageNumberSelect=showCurrentPageNumberSelect
-      goToPage=goToPage
+      goToPage=(action "gotoCustomPage")
     )
     PaginationSimple=(
       component themeInstance.paginationSimpleComponent
@@ -122,7 +122,7 @@
       pageSize=pageSize
       themeInstance=themeInstance
       showCurrentPageNumberSelect=showCurrentPageNumberSelect
-      goToPage=goToPage
+      goToPage=(action "gotoCustomPage")
     )
     isLoading=isLoading
     isError=isError
@@ -132,7 +132,11 @@
     visibleContent=visibleContent
     groupedVisibleContent=groupedVisibleContent
     groupedVisibleContentValuesOrder=groupedVisibleContentValuesOrder
+    groupedArrangedContent=groupedArrangedContent
+    displayGroupedValueAs=displayGroupedValueAs
+    useDataGrouping=useDataGrouping
     anyFilterUsed=anyFilterUsed
+    collapsedGroupValues=collapsedGroupValues
     globalFilterUsed=globalFilterUsed
     pagesCount=pagesCount
     firstIndex=firstIndex
@@ -141,6 +145,9 @@
     columnDropdownOptions=columnDropdownOptions
     allColumnsAreHidden=allColumnsAreHidden
     dataGroupOptions=dataGroupOptions
+    themeInstance=themeInstance
+    expandedItems=expandedItems
+    selectedItems=selectedItems
 
     showAllColumns=(action "showAllColumns")
     hideAllColumns=(action "hideAllColumns")

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -94,7 +94,7 @@
       clearFilters=clearFilters
       useNumericPagination=useNumericPagination
     )
-    SizeSelect=(
+    PageSizeSelect=(
       component themeInstance.pageSizeSelectComponent
       type="number"
       pageSizeOptions=pageSizeOptions
@@ -127,6 +127,7 @@
     isLoading=isLoading
     isError=isError
     publicAPI=publicAPI
+    groupedHeaders=groupedHeaders
     processedColumns=processedColumns
     visibleProcessedColumns=visibleProcessedColumns
     visibleContent=visibleContent
@@ -138,9 +139,12 @@
     anyFilterUsed=anyFilterUsed
     collapsedGroupValues=collapsedGroupValues
     globalFilterUsed=globalFilterUsed
+    useFilteringByColumns=useFilteringByColumns
     pagesCount=pagesCount
     firstIndex=firstIndex
     lastIndex=lastIndex
+    pageSize=pageSize
+    pageSizeOptions=pageSizeOptions
     currentPageNumberOptions=currentPageNumberOptions
     columnDropdownOptions=columnDropdownOptions
     allColumnsAreHidden=allColumnsAreHidden

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -131,6 +131,7 @@
     processedColumns=processedColumns
     visibleProcessedColumns=visibleProcessedColumns
     visibleContent=visibleContent
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     groupedVisibleContent=groupedVisibleContent
     groupedVisibleContentValuesOrder=groupedVisibleContentValuesOrder
     groupedArrangedContent=groupedArrangedContent

--- a/addon/templates/components/models-table.hbs
+++ b/addon/templates/components/models-table.hbs
@@ -84,9 +84,88 @@
       clearFilters=(action "clearFilters")
       themeInstance=themeInstance
     )
+    Summary=(
+      component themeInstance.summaryComponent
+      firstIndex=firstIndex
+      lastIndex=lastIndex
+      recordsCount=arrangedContentLength
+      anyFilterUsed=anyFilterUsed
+      themeInstance=themeInstance
+      clearFilters=clearFilters
+      useNumericPagination=useNumericPagination
+    )
+    SizeSelect=(
+      component themeInstance.pageSizeSelectComponent
+      type="number"
+      pageSizeOptions=pageSizeOptions
+      pageSize=pageSize
+      themeInstance=themeInstance
+    )
+    PaginationNumeric=(
+      component themeInstance.paginationNumericComponent
+      currentPageNumber=currentPageNumber
+      collapseNumPaginationForPagesCount=collapseNumPaginationForPagesCount
+      recordsCount=arrangedContentLength
+      pageSize=pageSize
+      currentPageNumberOptions=currentPageNumberOptions
+      pagesCount=pagesCount
+      themeInstance=themeInstance
+      showCurrentPageNumberSelect=showCurrentPageNumberSelect
+      goToPage=goToPage
+    )
+    PaginationSimple=(
+      component themeInstance.paginationSimpleComponent
+      currentPageNumber=currentPageNumber
+      recordsCount=arrangedContentLength
+      pagesCount=pagesCount
+      currentPageNumberOptions=currentPageNumberOptions
+      pageSize=pageSize
+      themeInstance=themeInstance
+      showCurrentPageNumberSelect=showCurrentPageNumberSelect
+      goToPage=goToPage
+    )
     isLoading=isLoading
     isError=isError
     publicAPI=publicAPI
+    processedColumns=processedColumns
+    visibleProcessedColumns=visibleProcessedColumns
+    visibleContent=visibleContent
+    groupedVisibleContent=groupedVisibleContent
+    groupedVisibleContentValuesOrder=groupedVisibleContentValuesOrder
+    anyFilterUsed=anyFilterUsed
+    globalFilterUsed=globalFilterUsed
+    pagesCount=pagesCount
+    firstIndex=firstIndex
+    lastIndex=lastIndex
+    currentPageNumberOptions=currentPageNumberOptions
+    columnDropdownOptions=columnDropdownOptions
+    allColumnsAreHidden=allColumnsAreHidden
+    dataGroupOptions=dataGroupOptions
+
+    showAllColumns=(action "showAllColumns")
+    hideAllColumns=(action "hideAllColumns")
+    restoreDefaultVisibility=(action "restoreDefaultVisibility")
+    toggleColumnSet=(action "toggleColumnSet")
+    toggleHidden=(action "toggleHidden")
+
+    expandRow=(action "expandRow")
+    collapseRow=(action "collapseRow")
+    expandAllRows=(action "expandAllRows")
+    collapseAllRows=(action "collapseAllRows")
+    toggleAllSelection=(action "toggleAllSelection")
+    clickOnRow=(action "clickOnRow")
+
+    goToPage=(action "gotoCustomPage")
+    clearFilters=(action "clearFilters")
+
+    sort=(action "sort")
+
+    toggleGroupedRowsSelection=(action "toggleGroupedRowsSelection")
+    toggleGroupedRowsExpands=(action "toggleGroupedRowsExpands")
+    toggleGroupedRows=(action "toggleGroupedRows")
+    doubleClickOnRow=(action "doubleClickOnRow")
+    hoverOnRow=(action "hoverOnRow")
+    outRow=(action "outRow")
   )
 as |ModelsTable|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/cell-column-summary.hbs
+++ b/addon/templates/components/models-table/cell-column-summary.hbs
@@ -1,1 +1,12 @@
-{{yield}}
+{{yield (hash
+  minSelected=minSelected
+  maxSelected=maxSelected
+  sumSelected=sumSelected
+  avgSelected=avgSelected
+  medianSelected=medianSelected
+  minData=minData
+  maxData=maxData
+  sumData=sumData
+  avgData=avgData
+  medianData=medianData
+)}}

--- a/addon/templates/components/models-table/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.columnsDropdownWrapper}}>
     <div class={{themeInstance.buttonsGroup}}>

--- a/addon/templates/components/models-table/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/data-group-by-select.hbs
@@ -8,9 +8,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    themeInstance=themeInstance
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/data-group-by-select.hbs
@@ -8,27 +8,26 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}
     {{yield DataGroupBySelect}}
   {{else}}
-    <div class={{themeInstance.dataGroupBySelectWrapper}}>
-      <div class={{themeInstance.form}}>
-        <div class={{themeInstance.formElementWrapper}}>
-          <label>{{themeInstance.groupByLabelMsg}}</label>
-          <DataGroupBySelect.Select/>
-          <button
-            class={{themeInstance.sortGroupedPropertyBtn}}
-            onclick={{action "doSort"}}>
-            <i
-              class={{if
-                (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sortAscIcon
-                themeInstance.sortDescIcon}}>
-            </i>
-          </button>
-        </div>
+    <div class={{themeInstance.form}}>
+      <div class={{themeInstance.formElementWrapper}}>
+        <label>{{themeInstance.groupByLabelMsg}}</label>
+        <DataGroupBySelect.Select/>
+        <button
+          class={{themeInstance.sortGroupedPropertyBtn}}
+          onclick={{action "doSort"}}>
+          <i
+            class={{if
+              (is-equal sortByGroupedFieldDirection "asc")
+              themeInstance.sortAscIcon
+              themeInstance.sortDescIcon}}>
+          </i>
+        </button>
       </div>
     </div>
   {{/if}}

--- a/addon/templates/components/models-table/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/data-group-by-select.hbs
@@ -9,8 +9,7 @@
       class=themeInstance.changeGroupByField
     )
     themeInstance=themeInstance
-    pageSizeOptions=pageSizeOptions
-    pageSize=pageSize
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     sort=doSort
   )
 as |DataGroupBySelect|}}
@@ -28,7 +27,7 @@ as |DataGroupBySelect|}}
             <i
               class={{if
                 (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sortAsc
+                themeInstance.sortAscIcon
                 themeInstance.sortDescIcon}}>
             </i>
           </button>

--- a/addon/templates/components/models-table/footer.hbs
+++ b/addon/templates/components/models-table/footer.hbs
@@ -10,7 +10,7 @@
       clearFilters=clearFilters
       useNumericPagination=useNumericPagination
     )
-    SizeSelect=(
+    PageSizeSelect=(
       component themeInstance.pageSizeSelectComponent
       type="number"
       pageSizeOptions=pageSizeOptions
@@ -43,21 +43,17 @@
     themeInstance=themeInstance
   )
 as |Footer|}}
-  <div class={{themeInstance.tfooterInternalWrapper}}>
-    {{#if (has-block)}}
-      {{yield Footer}}
-    {{else}}
-      <Footer.Summary/>
-      <div class={{themeInstance.pageSizeWrapper}}>
-        {{#if showPageSize}}
-          <Footer.SizeSelect/>
-        {{/if}}
-      </div>
-      {{#if useNumericPagination}}
-        <Footer.PaginationNumeric/>
-      {{else}}
-        <Footer.PaginationSimple/>
-      {{/if}}
+  {{#if (has-block)}}
+    {{yield Footer}}
+  {{else}}
+    <Footer.Summary/>
+    {{#if showPageSize}}
+      <Footer.PageSizeSelect/>
     {{/if}}
-  </div>
+    {{#if useNumericPagination}}
+      <Footer.PaginationNumeric/>
+    {{else}}
+      <Footer.PaginationSimple/>
+    {{/if}}
+  {{/if}}
 {{/let}}

--- a/addon/templates/components/models-table/global-filter.hbs
+++ b/addon/templates/components/models-table/global-filter.hbs
@@ -1,25 +1,23 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <div class={{themeInstance.globalFilterWrapper}}>
-    <div class={{concat themeInstance.form " globalSearch"}}>
-      <div class={{themeInstance.formElementWrapper}}>
-        <label for={{inputId}}>{{themeInstance.searchLabelMsg}}</label> {{input
-          id=inputId
-          type="text"
-          value=value
-          class=(concat themeInstance.input " filterString")
-          enter=(action "noop")
-          placeholder=themeInstance.searchPlaceholderMsg}}
-        {{#if globalFilterUsed}}
-          <i
-            class="clearFilterIcon {{themeInstance.clearFilterIcon}}"
-            role="button"
-            aria-label={{themeInstance.clearGlobalFilterMsg}}
-            onclick={{action (mut value) ""}}>
-          </i>
-        {{/if}}
-      </div>
+  <div class={{concat themeInstance.form " globalSearch"}}>
+    <div class={{themeInstance.formElementWrapper}}>
+      <label for={{inputId}}>{{themeInstance.searchLabelMsg}}</label> {{input
+        id=inputId
+        type="text"
+        value=value
+        class=(concat themeInstance.input " filterString")
+        enter=(action "noop")
+        placeholder=themeInstance.searchPlaceholderMsg}}
+      {{#if globalFilterUsed}}
+        <i
+          class="clearFilterIcon {{themeInstance.clearFilterIcon}}"
+          role="button"
+          aria-label={{themeInstance.clearGlobalFilterMsg}}
+          onclick={{action (mut value) ""}}>
+        </i>
+      {{/if}}
     </div>
   </div>
 {{/if}}

--- a/addon/templates/components/models-table/grouped-header.hbs
+++ b/addon/templates/components/models-table/grouped-header.hbs
@@ -1,7 +1,7 @@
 {{#if (has-block)}}
-  {{yield (hash groupedHeader=@groupedHeader)}}
+  {{yield (hash groupedHeader=@groupedHeader shouldAddExtraColumn=shouldAddExtraColumn)}}
 {{else}}
-  {{#if (and (is-equal @displayGroupedValueAs "column") @useDataGrouping)}}
+  {{#if shouldAddExtraColumn}}
     <th></th>
   {{/if}}
   {{#each @groupedHeader as |cell|}}

--- a/addon/templates/components/models-table/no-data.hbs
+++ b/addon/templates/components/models-table/no-data.hbs
@@ -1,6 +1,6 @@
 <td colspan={{realColumnsCount}}>
   {{#if (has-block)}}
-    {{yield}}
+    {{yield (hash realColumnsCount=realColumnsCount)}}
   {{else}}
     {{html-safe themeInstance.noDataToShowMsg}}
   {{/if}}

--- a/addon/templates/components/models-table/no-data.hbs
+++ b/addon/templates/components/models-table/no-data.hbs
@@ -1,6 +1,6 @@
 <td colspan={{realColumnsCount}}>
   {{#if (has-block)}}
-    {{yield (hash realColumnsCount=realColumnsCount)}}
+    {{yield}}
   {{else}}
     {{html-safe themeInstance.noDataToShowMsg}}
   {{/if}}

--- a/addon/templates/components/models-table/page-size-select.hbs
+++ b/addon/templates/components/models-table/page-size-select.hbs
@@ -9,9 +9,6 @@
       themeInstance=themeInstance
       class="changePageSize"
     )
-    themeInstance=themeInstance
-    pageSizeOptions=pageSizeOptions
-    pageSize=pageSize
   )
 as |PageSizeSelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/pagination-numeric.hbs
@@ -11,7 +11,6 @@
     )
     visiblePageNumbers=visiblePageNumbers
     goToPage=goToPage
-    gotoCustomPage=(action "gotoCustomPage")
     themeInstance=themeInstance
   )
 as |Pagination|}}

--- a/addon/templates/components/models-table/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/pagination-numeric.hbs
@@ -11,7 +11,6 @@
     )
     visiblePageNumbers=visiblePageNumbers
     goToPage=goToPage
-    themeInstance=themeInstance
   )
 as |Pagination|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/pagination-numeric.hbs
@@ -7,12 +7,8 @@
       type="number"
       visiblePageNumbers=visiblePageNumbers
       themeInstance=themeInstance
-      gotoCustomPage=(action "gotoCustomPage")
-    )
-    visiblePageNumbers=visiblePageNumbers
-    goToPage=goToPage
-  )
-as |Pagination|}}
+      gotoCustomPage=(action "gotoCustomPage"))
+    visiblePageNumbers=visiblePageNumbers) as |Pagination|}}
   {{#if (has-block)}}
     {{yield Pagination}}
   {{else}}

--- a/addon/templates/components/models-table/pagination-simple.hbs
+++ b/addon/templates/components/models-table/pagination-simple.hbs
@@ -10,13 +10,12 @@
       themeInstance=themeInstance
     )
     goToPage=goToPage
-    gotoFirst=(action "gotoFirst")
-    gotoPrev=(action "gotoPrev")
-    gotoNext=(action "gotoNext")
-    gotoLast=(action "gotoLast")
-    gotoBackEnabled=gotoBackEnabled
-    gotoForwardEnabled=gotoForwardEnabled
-    themeInstance=themeInstance
+    goToFirst=(action "gotoFirst")
+    goToPrev=(action "gotoPrev")
+    goToNext=(action "gotoNext")
+    goToLast=(action "gotoLast")
+    goToBackEnabled=goToBackEnabled
+    goToForwardEnabled=goToForwardEnabled
   )
 as |Pagination|}}
   {{#if (has-block)}}
@@ -25,25 +24,25 @@ as |Pagination|}}
     <div class={{themeInstance.paginationInternalWrapper}}>
       <div class={{themeInstance.paginationBlock}}>
         <button
-          class="{{if gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
           {{action "gotoFirst"}}>
           <i class={{themeInstance.navFirstIcon}}></i>
         </button>
         <button
-          class="{{if gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
           {{action "gotoPrev"}}>
           <i class={{themeInstance.navPrevIcon}}></i>
         </button>
         <button
-          class="{{if gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToNextPageButtonTextMsg}}
           {{action "gotoNext"}}>
           <i class={{themeInstance.navNextIcon}}></i>
         </button>
         <button
-          class="{{if gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
           aria-label={{themeInstance.goToLastPageButtonTextMsg}}
           {{action "gotoLast"}}>
           <i class={{themeInstance.navLastIcon}}></i>

--- a/addon/templates/components/models-table/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/row-filtering-cell.hbs
@@ -1,30 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
-{{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        data=data
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection)
-      as |CellContent|}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
       <CellContent/>
-    {{/let}}
+    {{/if}}
+  {{/let}}
+{{else}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       <div

--- a/addon/templates/components/models-table/row-filtering.hbs
+++ b/addon/templates/components/models-table/row-filtering.hbs
@@ -1,7 +1,5 @@
 {{#let
   (hash
-    themeInstance=themeInstance
-    visibleProcessedColumns=visibleProcessedColumns
     shouldAddExtraColumn=shouldAddExtraColumn
     RowFilteringCell=(component
       themeInstance.rowFilteringCellComponent

--- a/addon/templates/components/models-table/row-filtering.hbs
+++ b/addon/templates/components/models-table/row-filtering.hbs
@@ -2,6 +2,7 @@
   (hash
     themeInstance=themeInstance
     visibleProcessedColumns=visibleProcessedColumns
+    shouldAddExtraColumn=shouldAddExtraColumn
     RowFilteringCell=(component
       themeInstance.rowFilteringCellComponent
       themeInstance=themeInstance
@@ -16,8 +17,7 @@ as |RowFiltering|}}
   {{#if (has-block)}}
     {{yield RowFiltering}}
   {{else}}
-    {{#if
-      (and (is-equal displayGroupedValueAs "column") useDataGrouping visibleProcessedColumns.length)}}
+    {{#if shouldAddExtraColumn}}
       <th></th>
     {{/if}}
     {{#each shownColumns as |column|}}

--- a/addon/templates/components/models-table/row-group-toggle.hbs
+++ b/addon/templates/components/models-table/row-group-toggle.hbs
@@ -1,5 +1,5 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <a href="#" {{action "doToggleGroupedRows"}}>{{groupedValue}}</a>
+  <a href="#" {{action "doToggleGroupedRows" bubbles=false}}>{{groupedValue}}</a>
 {{/if}}

--- a/addon/templates/components/models-table/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/row-sorting-cell.hbs
@@ -18,18 +18,7 @@
   {{/let}}
 {{else}}
   {{#if (has-block)}}
-    {{yield
-      (hash
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        data=data
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        toggleAllSelection=toggleAllSelection
-        collapseAllRows=collapseAllRows
-      )
-    }}
+    {{yield}}
   {{else}}
     {{column.title}}
     {{#if column.useSorting}}

--- a/addon/templates/components/models-table/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/row-sorting-cell.hbs
@@ -9,7 +9,7 @@
       expandAllRows=expandAllRows
       toggleAllSelection=toggleAllSelection
       collapseAllRows=collapseAllRows)
-    as |CellContent|}}
+  as |CellContent|}}
     {{#if (has-block)}}
       {{yield CellContent}}
     {{else}}

--- a/addon/templates/components/models-table/row-sorting.hbs
+++ b/addon/templates/components/models-table/row-sorting.hbs
@@ -1,8 +1,5 @@
 {{#let
   (hash
-    themeInstance=themeInstance
-    groupHeaderCellComponent=groupHeaderCellComponent
-    visibleProcessedColumns=visibleProcessedColumns
     shouldAddExtraColumn=shouldAddExtraColumn
     RowSortingCell=(component
       themeInstance.rowSortingCellComponent

--- a/addon/templates/components/models-table/row-sorting.hbs
+++ b/addon/templates/components/models-table/row-sorting.hbs
@@ -3,6 +3,7 @@
     themeInstance=themeInstance
     groupHeaderCellComponent=groupHeaderCellComponent
     visibleProcessedColumns=visibleProcessedColumns
+    shouldAddExtraColumn=shouldAddExtraColumn
     RowSortingCell=(component
       themeInstance.rowSortingCellComponent
       themeInstance=themeInstance
@@ -19,8 +20,7 @@ as |RowSorting|}}
   {{#if (has-block)}}
     {{yield RowSorting}}
   {{else}}
-    {{#if
-      (and (is-equal displayGroupedValueAs "column") useDataGrouping visibleProcessedColumns.length)}}
+    {{#if shouldAddExtraColumn}}
       <th>
         {{#if groupHeaderCellComponent}}
           {{#let

--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -39,13 +39,14 @@
     saveRow=(action "saveRow")
     cancelEditRow=(action "cancelEditRow")
     visibleProcessedColumns=visibleProcessedColumns
+    isFirstGroupedRow=isFirstGroupedRow
     themeInstance=themeInstance
   )
 as |Row|}}
   {{#if (has-block)}}
     {{yield Row}}
   {{else}}
-    {{#if (and (is-equal displayGroupedValueAs "column") isFirstGroupedRow)}}
+    {{#if (and (is-equal displayGroupedValueAs "column") isFirstGroupedRow useDataGrouping)}}
       <td
         rowspan={{rowspanForFirstCell}}
         class={{themeInstance.groupingCell}}>

--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -38,9 +38,7 @@
     editRow=(action "editRow")
     saveRow=(action "saveRow")
     cancelEditRow=(action "cancelEditRow")
-    visibleProcessedColumns=visibleProcessedColumns
     isFirstGroupedRow=isFirstGroupedRow
-    themeInstance=themeInstance
   )
 as |Row|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/summary.hbs
+++ b/addon/templates/components/models-table/summary.hbs
@@ -1,12 +1,7 @@
 {{#if (has-block)}}
   {{yield
     (hash
-      anyFilterUsed=anyFilterUsed
       summary=summary
-      clearFilters=doClearFilters
-      firstIndex=firstIndex
-      lastIndex=lastIndex
-      recordsCount=recordsCount
     )}}
 {{else}}
   <form class={{themeInstance.form}}>

--- a/addon/templates/components/models-table/table-body.hbs
+++ b/addon/templates/components/models-table/table-body.hbs
@@ -26,6 +26,7 @@
       toggleGroupedRows=toggleGroupedRows
       toggleGroupedRowsSelection=toggleGroupedRowsSelection
       toggleGroupedRowsExpands=toggleGroupedRowsExpands
+      useDataGrouping=useDataGrouping
     )
     RowExpand=(
       component themeInstance.rowExpandComponent
@@ -82,30 +83,28 @@ as |TableBody|}}
               groupedArrangedContent)
               as |groupedItems|}}
             {{#let
-              (hash
-                visibleGroupedItems=(object-at groupedIndex groupedVisibleContent)
-              ) as |gi|}}
+              (object-at groupedIndex groupedVisibleContent)as |visibleGroupedItems|}}
               {{#let
                 (component TableBody.RowGrouping
                   groupedValue=groupedValue
                   groupedLength=groupedItems.length
                   groupedItems=groupedItems
-                  visibleGroupedItems=gi.visibleGroupedItems
+                  visibleGroupedItems=visibleGroupedItems
                 )
                 as |RowGrouping|}}
                 {{#if (is-equal displayGroupedValueAs "row")}}
                   <RowGrouping
                     @groupIsCollapsed={{exists-in collapsedGroupValues groupedValue}}
-                    @visibleGroupedLength={{gi.visibleGroupedItems.length}} />
+                    @visibleGroupedLength={{visibleGroupedItems.length}} />
                 {{/if}}
                 {{#if (exists-in collapsedGroupValues groupedValue)}}
                   {{#if (is-equal displayGroupedValueAs "column")}}
                     <RowGrouping
                       @groupIsCollapsed={{true}}
-                      @visibleGroupedLength={{gi.visibleGroupedItems.length}}/>
+                      @visibleGroupedLength={{visibleGroupedItems.length}}/>
                   {{/if}}
                 {{else}}
-                  {{#each gi.visibleGroupedItems as |record index|}}
+                  {{#each visibleGroupedItems as |record index|}}
                     <TableBody.Row
                       @record={{record}}
                       @index={{index}}
@@ -113,7 +112,7 @@ as |TableBody|}}
                       @groupedLength={{groupedItems.length}}
                       @groupedItems={{groupedItems}}
                       @groupSummaryRowComponent={{groupSummaryRowComponent}}
-                      @visibleGroupedItems={{gi.visibleGroupedItems}}/>
+                      @visibleGroupedItems={{visibleGroupedItems}}/>
                     {{#if (exists-in expandedItems record)}}
                       <TableBody.RowExpand
                         @record={{record}}
@@ -129,7 +128,7 @@ as |TableBody|}}
                         groupedItems=groupedItems
                         selectedItems=selectedItems
                         expandedItems=expandedItems
-                        visibleGroupedItems=gi.visibleGroupedItems)
+                        visibleGroupedItems=visibleGroupedItems)
                       as |GroupSummaryRow|}}
                       <GroupSummaryRow/>
                     {{/let}}

--- a/addon/templates/components/models-table/table-body.hbs
+++ b/addon/templates/components/models-table/table-body.hbs
@@ -56,16 +56,6 @@
       toggleGroupedRowsExpands=toggleGroupedRowsExpands
       themeInstance=themeInstance
     )
-    allColumnsAreHidden=allColumnsAreHidden
-    visibleContent=visibleContent
-    visibleProcessedColumns=visibleProcessedColumns
-    expandedItems=expandedItems
-    groupedVisibleContentValuesOrder=groupedVisibleContentValuesOrder
-    toggleGroupedRowsSelection=toggleGroupedRowsSelection
-    toggleGroupedRowsExpands=toggleGroupedRowsExpands
-    groupedVisibleContent=groupedVisibleContent
-    useDataGrouping=useDataGrouping
-    themeInstance=themeInstance
   )
 as |TableBody|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/table-footer.hbs
+++ b/addon/templates/components/models-table/table-footer.hbs
@@ -10,12 +10,16 @@
     selectedItems=selectedItems
     expandedItems=expandedItems
     visibleProcessedColumns=visibleProcessedColumns
+    shouldAddExtraColumn=shouldAddExtraColumn
     data=data)
 as |TableFooter|}}
   {{#if (has-block)}}
     {{yield TableFooter}}
   {{else}}
     <tr>
+      {{#if shouldAddExtraColumn}}
+        <td></td>
+      {{/if}}
       {{#each visibleProcessedColumns as |column|}}
         {{#if column.componentForFooterCell}}
           {{#let

--- a/addon/templates/components/models-table/table-footer.hbs
+++ b/addon/templates/components/models-table/table-footer.hbs
@@ -1,17 +1,7 @@
 {{#let
   (hash
-    goToPage=goToPage
-    clearFilters=clearFilters
-    expandRow=expandRow
-    collapseRow=collapseRow
-    expandAllRows=expandAllRows
-    collapseAllRows=collapseAllRows
-    themeInstance=themeInstance
-    selectedItems=selectedItems
-    expandedItems=expandedItems
-    visibleProcessedColumns=visibleProcessedColumns
     shouldAddExtraColumn=shouldAddExtraColumn
-    data=data)
+  )
 as |TableFooter|}}
   {{#if (has-block)}}
     {{yield TableFooter}}

--- a/addon/templates/components/models-table/table-footer.hbs
+++ b/addon/templates/components/models-table/table-footer.hbs
@@ -12,19 +12,15 @@ as |TableFooter|}}
       {{/if}}
       {{#each visibleProcessedColumns as |column|}}
         {{#if column.componentForFooterCell}}
-          {{#let
-            (component
-              column.componentForFooterCell
-              selectedItems=selectedItems
-              expandedItems=expandedItems
-              data=data
-              mappedSelectedItems=(if column.propertyName (map-by column.propertyName selectedItems))
-              mappedExpandedItems=(if column.propertyName (map-by column.propertyName expandedItems))
-              mappedData=(if column.propertyName (map-by column.propertyName data))
-            )
-          as |CellContent|}}
-            <CellContent/>
-          {{/let}}
+          {{component
+            column.componentForFooterCell
+            selectedItems=selectedItems
+            expandedItems=expandedItems
+            data=data
+            mappedSelectedItems=(if column.propertyName (map-by column.propertyName selectedItems))
+            mappedExpandedItems=(if column.propertyName (map-by column.propertyName expandedItems))
+            mappedData=(if column.propertyName (map-by column.propertyName data))
+          }}
         {{else}}
           <td></td>
         {{/if}}

--- a/addon/templates/components/models-table/table-header.hbs
+++ b/addon/templates/components/models-table/table-header.hbs
@@ -34,6 +34,7 @@
       component themeInstance.groupedHeaderComponent
       useDataGrouping=useDataGrouping
       displayGroupedValueAs=displayGroupedValueAs
+      visibleProcessedColumns=visibleProcessedColumns
       themeInstance=themeInstance
     )
     groupedHeaders=groupedHeaders

--- a/addon/templates/components/models-table/table-header.hbs
+++ b/addon/templates/components/models-table/table-header.hbs
@@ -37,9 +37,6 @@
       visibleProcessedColumns=visibleProcessedColumns
       themeInstance=themeInstance
     )
-    groupedHeaders=groupedHeaders
-    useFilteringByColumns=useFilteringByColumns
-    themeInstance=themeInstance
   )
 as |TableHeader|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/table.hbs
+++ b/addon/templates/components/models-table/table.hbs
@@ -71,8 +71,6 @@
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
     )
-    showTableFooter=showTableFooter
-    themeInstance=themeInstance
   )
 as |Table|}}
   {{#if (has-block)}}
@@ -80,7 +78,7 @@ as |Table|}}
   {{else}}
     <Table.Header/>
     <Table.Body/>
-    {{#if Table.showTableFooter}}
+    {{#if showTableFooter}}
       <Table.Footer/>
     {{/if}}
   {{/if}}

--- a/addon/templates/components/models-table/table.hbs
+++ b/addon/templates/components/models-table/table.hbs
@@ -58,6 +58,8 @@
     Footer=(
       component themeInstance.tableFooterComponent
       visibleProcessedColumns=visibleProcessedColumns
+      displayGroupedValueAs=displayGroupedValueAs
+      useDataGrouping=useDataGrouping
       themeInstance=themeInstance
       data=data
       goToPage=goToPage

--- a/addon/templates/components/models-table/themes/bootstrap4/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.columnsDropdownWrapper}}>
     <button

--- a/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
@@ -8,9 +8,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    themeInstance=themeInstance
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
@@ -9,8 +9,7 @@
       class=themeInstance.changeGroupByField
     )
     themeInstance=themeInstance
-    pageSizeOptions=pageSizeOptions
-    pageSize=pageSize
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     sort=doSort
   )
 as |DataGroupBySelect|}}

--- a/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/data-group-by-select.hbs
@@ -8,29 +8,28 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}
     {{yield DataGroupBySelect}}
   {{else}}
-    <div class={{themeInstance.dataGroupBySelectWrapper}}>
-      <div class={{themeInstance.inputGroup}}>
-        <span class="input-group-addon">{{themeInstance.groupByLabelMsg}}</span>
-        <DataGroupBySelect.Select/>
-        <span class="input-group-btn">
-          <button
-            class={{themeInstance.sortGroupedPropertyBtn}}
-            onclick={{action "doSort"}}
-            type="button">
-            <i
-              class={{if
-                (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sortAscIcon
-                themeInstance.sortDescIcon}}>
-            </i>
-          </button>
-        </span>
-      </div>
+    <div class={{themeInstance.inputGroup}}>
+      <span class="input-group-addon">{{themeInstance.groupByLabelMsg}}</span>
+      <DataGroupBySelect.Select/>
+      <span class="input-group-btn">
+        <button
+          class={{themeInstance.sortGroupedPropertyBtn}}
+          onclick={{action "doSort"}}
+          type="button">
+          <i
+            class={{if
+              (is-equal sortByGroupedFieldDirection "asc")
+              themeInstance.sortAscIcon
+              themeInstance.sortDescIcon}}>
+          </i>
+        </button>
+      </span>
     </div>
   {{/if}}
 {{/let}}

--- a/addon/templates/components/models-table/themes/bootstrap4/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/global-filter.hbs
@@ -1,28 +1,26 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <div class={{themeInstance.globalFilterWrapper}}>
-    <div class={{concat themeInstance.form " globalSearch"}}>
-      <div class={{themeInstance.inputGroup}}>
-        <label for={{inputId}} class="input-group-addon">{{themeInstance.searchLabelMsg}}</label>
-        {{input
-          id=inputId
-          type="text"
-          value=value
-          class=(concat themeInstance.input " filterString")
-          enter=(action "noop")
-          placeholder=themeInstance.searchPlaceholderMsg}}
-        <span class="input-group-btn">
-          <button
-            class="clearFilterIcon {{themeInstance.buttonDefaultSmall}}"
-            disabled={{unless globalFilterUsed "disabled"}}
-            onclick={{action (mut value) ""}}
-            type="button">
-            <i class={{themeInstance.clearFilterIcon}}></i>
-            <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
-          </button>
-        </span>
-      </div>
+  <div class={{concat themeInstance.form " globalSearch"}}>
+    <div class={{themeInstance.inputGroup}}>
+      <label for={{inputId}} class="input-group-addon">{{themeInstance.searchLabelMsg}}</label>
+      {{input
+        id=inputId
+        type="text"
+        value=value
+        class=(concat themeInstance.input " filterString")
+        enter=(action "noop")
+        placeholder=themeInstance.searchPlaceholderMsg}}
+      <span class="input-group-btn">
+        <button
+          class="clearFilterIcon {{themeInstance.buttonDefaultSmall}}"
+          disabled={{unless globalFilterUsed "disabled"}}
+          onclick={{action (mut value) ""}}
+          type="button">
+          <i class={{themeInstance.clearFilterIcon}}></i>
+          <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
+        </button>
+      </span>
     </div>
   </div>
 {{/if}}

--- a/addon/templates/components/models-table/themes/bootstrap4/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/global-filter.hbs
@@ -1,8 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.globalFilterWrapper}}>
     <div class={{concat themeInstance.form " globalSearch"}}>

--- a/addon/templates/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
@@ -1,29 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
-{{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection)
-    as |CellContent|}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
       <CellContent/>
-    {{/let}}
+    {{/if}}
+  {{/let}}
+{{else}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       <label for={{inputId}} class="emt-sr-only">{{column.title}}</label>

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <BsDropdown
     @closeOnMenuClick={{false}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
@@ -8,9 +8,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    themeInstance=themeInstance
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
@@ -9,6 +9,7 @@
       class=themeInstance.changeGroupByField
     )
     themeInstance=themeInstance
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     sort=doSort
   )
 as |DataGroupBySelect|}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/data-group-by-select.hbs
@@ -8,43 +8,42 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}
     {{yield DataGroupBySelect}}
   {{else}}
-    <div class={{themeInstance.dataGroupBySelectWrapper}}>
-      <BsForm
-        class="globalSearch"
-        @formLayout="inline"
-        @model={{this}}
-        @onSubmit={{action "noop"}}
-      as |Form|>
-        <Form.element
-          @property="value"
-          class="input-group"
-        as |GroupByField|>
-          {{#if themeInstance.groupByLabelMsg}}
-            <span class="input-group-addon">{{themeInstance.groupByLabelMsg}}</span>
-          {{/if}}
-          <DataGroupBySelect.Select
-            @id={{GroupByField.id}}
-            @value={{GroupByField.value}}/>
-          <span class="input-group-btn">
-            <BsButton
-              class={{themeInstance.sortGroupedPropertyBtn}}
-              @type="secondary"
-              @onClick={{action "doSort"}}>
-              <i
-                class={{if
-                (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sortAscIcon
-                themeInstance.sortDescIcon}}>
-              </i>
-            </BsButton>
-          </span>
-        </Form.element>
-      </BsForm>
-    </div>
+    <BsForm
+      class="globalSearch"
+      @formLayout="inline"
+      @model={{this}}
+      @onSubmit={{action "noop"}}
+    as |Form|>
+      <Form.element
+        @property="value"
+        class="input-group"
+      as |GroupByField|>
+        {{#if themeInstance.groupByLabelMsg}}
+          <span class="input-group-addon">{{themeInstance.groupByLabelMsg}}</span>
+        {{/if}}
+        <DataGroupBySelect.Select
+          @id={{GroupByField.id}}
+          @value={{GroupByField.value}}/>
+        <span class="input-group-btn">
+          <BsButton
+            class={{themeInstance.sortGroupedPropertyBtn}}
+            @type="secondary"
+            @onClick={{action "doSort"}}>
+            <i
+              class={{if
+              (is-equal sortByGroupedFieldDirection "asc")
+              themeInstance.sortAscIcon
+              themeInstance.sortDescIcon}}>
+            </i>
+          </BsButton>
+        </span>
+      </Form.element>
+    </BsForm>
   {{/if}}
 {{/let}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/global-filter.hbs
@@ -1,8 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.globalFilterWrapper}}>
     <BsForm

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/global-filter.hbs
@@ -1,41 +1,39 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <div class={{themeInstance.globalFilterWrapper}}>
-    <BsForm
-      @formLayout="inline"
-      class="globalSearch"
-      @model={{this}}
-      @onSubmit={{action "noop"}}
-    as |Form|>
-      <Form.element
-        class="input-group"
-        @placeholder={{themeInstance.searchPlaceholderMsg}}
-        @property="value"
-        @type="text"
-      as |GlobalFilter|>
-        {{#if themeInstance.searchLabelMsg}}
-          <label for={{GlobalFilter.id}} class="input-group-addon">{{themeInstance.searchLabelMsg}}</label>
-        {{/if}}
-        <input
-          class="filterString form-control"
-          value={{GlobalFilter.value}}
-          placeholder={{GlobalFilter.placeholder}}
-          oninput={{action (mut GlobalFilter.value) value="target.value"}}
-          onchange={{action (mut GlobalFilter.value) value="target.value"}}
-          id={{GlobalFilter.id}}>
-        <span class="input-group-btn">
-          <BsButton
-            class="clearFilterIcon"
-            @disabled={{unless globalFilterUsed "disabled"}}
-            @type="secondary"
-            @onClick={{action (mut value) ""}}>
-            &nbsp;&nbsp;
-            <i class={{themeInstance.clearFilterIcon}}></i>
-            <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
-          </BsButton>
-        </span>
-      </Form.element>
-    </BsForm>
-  </div>
+  <BsForm
+    @formLayout="inline"
+    class="globalSearch"
+    @model={{this}}
+    @onSubmit={{action "noop"}}
+  as |Form|>
+    <Form.element
+      class="input-group"
+      @placeholder={{themeInstance.searchPlaceholderMsg}}
+      @property="value"
+      @type="text"
+    as |GlobalFilter|>
+      {{#if themeInstance.searchLabelMsg}}
+        <label for={{GlobalFilter.id}} class="input-group-addon">{{themeInstance.searchLabelMsg}}</label>
+      {{/if}}
+      <input
+        class="filterString form-control"
+        value={{GlobalFilter.value}}
+        placeholder={{GlobalFilter.placeholder}}
+        oninput={{action (mut GlobalFilter.value) value="target.value"}}
+        onchange={{action (mut GlobalFilter.value) value="target.value"}}
+        id={{GlobalFilter.id}}>
+      <span class="input-group-btn">
+        <BsButton
+          class="clearFilterIcon"
+          @disabled={{unless globalFilterUsed "disabled"}}
+          @type="secondary"
+          @onClick={{action (mut value) ""}}>
+          &nbsp;&nbsp;
+          <i class={{themeInstance.clearFilterIcon}}></i>
+          <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
+        </BsButton>
+      </span>
+    </Form.element>
+  </BsForm>
 {{/if}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/row-filtering-cell.hbs
@@ -1,29 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
+      <CellContent/>
+    {{/if}}
+  {{/let}}
 {{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection
-      ) as |FilterCellContent|}}
-      <FilterCellContent/>
-    {{/let}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       <BsForm

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v3/summary.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v3/summary.hbs
@@ -1,12 +1,7 @@
 {{#if (has-block)}}
   {{yield
     (hash
-      anyFilterUsed=anyFilterUsed
       summary=summary
-      clearFilters=doClearFilters
-      firstIndex=firstIndex
-      lastIndex=lastIndex
-      recordsCount=recordsCount
     )}}
 {{else}}
   <BsForm

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <BsDropdown
     class={{themeInstance.columnsDropdownWrapper}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
@@ -5,7 +5,7 @@
       columnDropdownOptions=columnDropdownOptions
       processedColumns=processedColumns
       showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "foHideAllColumns")
+      hideAllColumns=(action "doHideAllColumns")
       restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
       toggleColumnSet=(action "doToggleColumnSet")
       toggleHidden=(action "doToggleHidden")

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
@@ -8,9 +8,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    themeInstance=themeInstance
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
@@ -9,6 +9,7 @@
       class=themeInstance.changeGroupByField
     )
     themeInstance=themeInstance
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     sort=doSort
   )
 as |DataGroupBySelect|}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
@@ -8,46 +8,45 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}
     {{yield DataGroupBySelect}}
   {{else}}
-    <div class={{themeInstance.dataGroupBySelectWrapper}}>
-      <BsForm
-        class="globalSearch"
-        @formLayout="inline"
-        @model={{this}}
-        @onSubmit={{action "noop"}}
-      as |Form|>
-        <Form.element
-          @property="value"
-          class="input-group"
-        as |GroupByField|>
-          {{#if themeInstance.groupByLabelMsg}}
-            <div class="input-group-prepend">
-              <span class="input-group-text">{{themeInstance.groupByLabelMsg}}</span>
-            </div>
-          {{/if}}
-          <DataGroupBySelect.Select
-            @id={{GroupByField.id}}
-            @value={{GroupByField.value}}/>
-          <div class="input-group-append">
-            <BsButton
-              class={{themeInstance.sortGroupedPropertyBtn}}
-              @type="secondary"
-              @onClick={{action "doSort"}}
-              @buttonType="link">
-              <i
-                class={{if
-                (is-equal sortByGroupedFieldDirection "asc")
-                themeInstance.sortAscIcon
-                themeInstance.sortDescIcon}}>
-              </i>
-            </BsButton>
+    <BsForm
+      class="globalSearch"
+      @formLayout="inline"
+      @model={{this}}
+      @onSubmit={{action "noop"}}
+    as |Form|>
+      <Form.element
+        @property="value"
+        class="input-group"
+      as |GroupByField|>
+        {{#if themeInstance.groupByLabelMsg}}
+          <div class="input-group-prepend">
+            <span class="input-group-text">{{themeInstance.groupByLabelMsg}}</span>
           </div>
-        </Form.element>
-      </BsForm>
-    </div>
+        {{/if}}
+        <DataGroupBySelect.Select
+          @id={{GroupByField.id}}
+          @value={{GroupByField.value}}/>
+        <div class="input-group-append">
+          <BsButton
+            class={{themeInstance.sortGroupedPropertyBtn}}
+            @type="secondary"
+            @onClick={{action "doSort"}}
+            @buttonType="link">
+            <i
+              class={{if
+              (is-equal sortByGroupedFieldDirection "asc")
+              themeInstance.sortAscIcon
+              themeInstance.sortDescIcon}}>
+            </i>
+          </BsButton>
+        </div>
+      </Form.element>
+    </BsForm>
   {{/if}}
 {{/let}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
@@ -1,8 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.globalFilterWrapper}}>
     <BsForm

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
@@ -1,42 +1,40 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <div class={{themeInstance.globalFilterWrapper}}>
-    <BsForm
-      class="globalSearch"
-      @formLayout="inline"
-      @model={{this}}
-      @onSubmit={{action "noop"}}
-    as |Form|>
-      <Form.element
-        class="input-group"
-        @placeholder={{themeInstance.searchPlaceholderMsg}}
-        @property="value"
-        @type="text"
-      as |GlobalFilter|>
-        {{#if themeInstance.searchLabelMsg}}
-          <div class="input-group-prepend">
-            <label for={{GlobalFilter.id}} class="input-group-text">{{themeInstance.searchLabelMsg}}</label>
-          </div>
-        {{/if}}
-        <input
-          class="filterString form-control"
-          value={{GlobalFilter.value}}
-          placeholder={{GlobalFilter.placeholder}}
-          oninput={{action (mut GlobalFilter.value) value="target.value"}}
-          onchange={{action (mut GlobalFilter.value) value="target.value"}}
-          id={{GlobalFilter.id}}>
-        <div class="input-group-append">
-          <BsButton
-            class={{concat "clearFilterIcon btn-outline-secondary " themeInstance.buttonLink}}
-            @disabled={{unless globalFilterUsed "disabled"}}
-            @type="secondary"
-            @onClick={{action (mut value) ""}}>
-            <i class={{themeInstance.clearFilterIcon}}></i>
-            <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
-          </BsButton>
+  <BsForm
+    class="globalSearch"
+    @formLayout="inline"
+    @model={{this}}
+    @onSubmit={{action "noop"}}
+  as |Form|>
+    <Form.element
+      class="input-group"
+      @placeholder={{themeInstance.searchPlaceholderMsg}}
+      @property="value"
+      @type="text"
+    as |GlobalFilter|>
+      {{#if themeInstance.searchLabelMsg}}
+        <div class="input-group-prepend">
+          <label for={{GlobalFilter.id}} class="input-group-text">{{themeInstance.searchLabelMsg}}</label>
         </div>
-      </Form.element>
-    </BsForm>
-  </div>
+      {{/if}}
+      <input
+        class="filterString form-control"
+        value={{GlobalFilter.value}}
+        placeholder={{GlobalFilter.placeholder}}
+        oninput={{action (mut GlobalFilter.value) value="target.value"}}
+        onchange={{action (mut GlobalFilter.value) value="target.value"}}
+        id={{GlobalFilter.id}}>
+      <div class="input-group-append">
+        <BsButton
+          class={{concat "clearFilterIcon btn-outline-secondary " themeInstance.buttonLink}}
+          @disabled={{unless globalFilterUsed "disabled"}}
+          @type="secondary"
+          @onClick={{action (mut value) ""}}>
+          <i class={{themeInstance.clearFilterIcon}}></i>
+          <span class="emt-sr-only">{{themeInstance.clearGlobalFilterMsg}}</span>
+        </BsButton>
+      </div>
+    </Form.element>
+  </BsForm>
 {{/if}}

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.hbs
@@ -1,29 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
+      <CellContent/>
+    {{/if}}
+  {{/let}}
 {{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection
-      ) as |FilterCellContent|}}
-      <FilterCellContent/>
-    {{/let}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       <BsForm

--- a/addon/templates/components/models-table/themes/ember-bootstrap-v4/summary.hbs
+++ b/addon/templates/components/models-table/themes/ember-bootstrap-v4/summary.hbs
@@ -1,12 +1,7 @@
 {{#if (has-block)}}
   {{yield
     (hash
-      anyFilterUsed=anyFilterUsed
       summary=summary
-      clearFilters=doClearFilters
-      firstIndex=firstIndex
-      lastIndex=lastIndex
-      recordsCount=recordsCount
     )}}
 {{else}}
   <BsForm

--- a/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
@@ -5,7 +5,7 @@
       columnDropdownOptions=columnDropdownOptions
       processedColumns=processedColumns
       showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "foHideAllColumns")
+      hideAllColumns=(action "doHideAllColumns")
       restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
       toggleColumnSet=(action "doToggleColumnSet")
       toggleHidden=(action "doToggleHidden")

--- a/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <PaperMenu @renderInPlace={{true}} as |menu|>
     <menu.trigger>

--- a/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
@@ -8,6 +8,7 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     themeInstance=themeInstance
     sort=doSort
   )

--- a/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
@@ -8,9 +8,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    themeInstance=themeInstance
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/data-group-by-select.hbs
@@ -8,6 +8,7 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-paper/expand-all-toggle.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/expand-all-toggle.hbs
@@ -4,6 +4,7 @@
     class=@themeInstance.expandAllRowsIcon
   }}
 </PaperButton>
+<br>
 <PaperButton @onClick={{action "doCollapseAllRows"}} @iconButton={{true}}>
   {{paper-icon
     @themeInstance.collapseAllRowsIcon

--- a/addon/templates/components/models-table/themes/ember-paper/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/global-filter.hbs
@@ -1,18 +1,20 @@
-{{#if (has-block)}}
-  {{yield}}
-{{else}}
-  <PaperInput
-    class={{concat @themeInstance.input " filterString"}}
-    @label={{@themeInstance.searchLabelMsg}}
-    @placeholder={{@themeInstance.searchPlaceholderMsg}}
-    @value={{@value}}
-    @onChange={{action (mut @value)}}/>
-  {{#if globalFilterUsed}}
-    <PaperButton
-      class={{concat "clearFilterIcon " @themeInstance.clearFilterIcon}}
-      @onClick={{action (mut @value) ""}}
-      @iconButton={{true}}>
-      {{paper-icon "close"}}
-    </PaperButton>
+<div class="globalSearch">
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    <PaperInput
+      class={{concat @themeInstance.input " filterString"}}
+      @label={{@themeInstance.searchLabelMsg}}
+      @placeholder={{@themeInstance.searchPlaceholderMsg}}
+      @value={{@value}}
+      @onChange={{action (mut @value)}}/>
+    {{#if globalFilterUsed}}
+      <PaperButton
+        class={{concat "clearFilterIcon " @themeInstance.clearFilterIcon}}
+        @onClick={{action (mut @value) ""}}
+        @iconButton={{true}}>
+        {{paper-icon "close"}}
+      </PaperButton>
+    {{/if}}
   {{/if}}
-{{/if}}
+</div>

--- a/addon/templates/components/models-table/themes/ember-paper/page-size-select.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/page-size-select.hbs
@@ -10,9 +10,6 @@
       themeInstance=themeInstance
       class="changePageSize"
     )
-    themeInstance=themeInstance
-    pageSizeOptions=pageSizeOptions
-    pageSize=pageSize
   )
 as |PageSizeSelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
@@ -8,7 +8,7 @@
       value=currentPageNumber
       type="number"
       themeInstance=themeInstance)
-    gotoCustomPage=(action "gotoCustomPage")
+    goToPage=goToPage
     visiblePageNumbers=visiblePageNumbers
     themeInstance=themeInstance) as |Pagination|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
@@ -9,8 +9,7 @@
       type="number"
       themeInstance=themeInstance)
     goToPage=goToPage
-    visiblePageNumbers=visiblePageNumbers
-    themeInstance=themeInstance) as |Pagination|}}
+    visiblePageNumbers=visiblePageNumbers) as |Pagination|}}
   {{#if (has-block)}}
     {{yield Pagination}}
   {{else}}

--- a/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/pagination-numeric.hbs
@@ -8,7 +8,6 @@
       value=currentPageNumber
       type="number"
       themeInstance=themeInstance)
-    goToPage=goToPage
     visiblePageNumbers=visiblePageNumbers) as |Pagination|}}
   {{#if (has-block)}}
     {{yield Pagination}}

--- a/addon/templates/components/models-table/themes/ember-paper/pagination-simple.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/pagination-simple.hbs
@@ -10,13 +10,12 @@
       themeInstance=themeInstance
     )
     goToPage=goToPage
-    gotoFirst=(action "gotoFirst")
-    gotoPrev=(action "gotoPrev")
-    gotoNext=(action "gotoNext")
-    gotoLast=(action "gotoLast")
-    gotoBackEnabled=gotoBackEnabled
-    gotoForwardEnabled=gotoForwardEnabled
-    themeInstance=themeInstance
+    goToFirst=(action "gotoFirst")
+    goToPrev=(action "gotoPrev")
+    goToNext=(action "gotoNext")
+    goToLast=(action "gotoLast")
+    goToBackEnabled=goToBackEnabled
+    goToForwardEnabled=goToForwardEnabled
   )
 as |Pagination|}}
   {{#if (has-block)}}
@@ -29,33 +28,33 @@ as |Pagination|}}
       <div class={{themeInstance.paginationBlock}}>
         <PaperButton
           aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
-          class={{concat themeInstance.buttonDefault (unless gotoBackEnabled " disabled")}}
+          class={{concat themeInstance.buttonDefault (unless goToBackEnabled " disabled")}}
           @onClick={{action "gotoFirst"}}
-          @disabled={{not gotoBackEnabled}}
+          @disabled={{not goToBackEnabled}}
           @iconButton={{true}}>
           {{paper-icon themeInstance.navFirstIcon class=themeInstance.navFirstIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
-          class={{concat themeInstance.buttonDefault (unless gotoBackEnabled " disabled")}}
+          class={{concat themeInstance.buttonDefault (unless goToBackEnabled " disabled")}}
           @onClick={{action "gotoPrev"}}
-          @disabled={{not gotoBackEnabled}}
+          @disabled={{not goToBackEnabled}}
           @iconButton={{true}}>
           {{paper-icon themeInstance.navPrevIcon class=themeInstance.navPrevIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToNextPageButtonTextMsg}}
-          class={{concat themeInstance.buttonDefault (unless gotoForwardEnabled " disabled")}}
+          class={{concat themeInstance.buttonDefault (unless goToForwardEnabled " disabled")}}
           @onClick={{action "gotoNext"}}
-          @disabled={{not gotoForwardEnabled}}
+          @disabled={{not goToForwardEnabled}}
           @iconButton={{true}}>
           {{paper-icon themeInstance.navNextIcon class=themeInstance.navNextIcon}}
         </PaperButton>
         <PaperButton
           aria-label={{themeInstance.goToLastPageButtonTextMsg}}
-          class={{concat themeInstance.buttonDefault (unless gotoForwardEnabled " disabled")}}
+          class={{concat themeInstance.buttonDefault (unless goToForwardEnabled " disabled")}}
           @onClick={{action "gotoLast"}}
-          @disabled={{not gotoForwardEnabled}}
+          @disabled={{not goToForwardEnabled}}
           @iconButton={{true}}>
           {{paper-icon themeInstance.navLastIcon class=themeInstance.navLastIcon}}
         </PaperButton>

--- a/addon/templates/components/models-table/themes/ember-paper/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/row-filtering-cell.hbs
@@ -1,29 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
+      <CellContent/>
+    {{/if}}
+  {{/let}}
 {{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection
-    ) as |FilterCellContent|}}
-      <FilterCellContent/>
-    {{/let}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       <div class={{themeInstance.filteringCellInternalWrapper}}>

--- a/addon/templates/components/models-table/themes/ember-paper/row-sorting-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/row-sorting-cell.hbs
@@ -18,18 +18,7 @@
   {{/let}}
 {{else}}
   {{#if (has-block)}}
-    {{yield
-      (hash
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        data=data
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        toggleAllSelection=toggleAllSelection
-        collapseAllRows=collapseAllRows
-      )
-    }}
+    {{yield}}
   {{else}}
     {{column.title}}
     {{#if column.useSorting}}

--- a/addon/templates/components/models-table/themes/ember-paper/summary.hbs
+++ b/addon/templates/components/models-table/themes/ember-paper/summary.hbs
@@ -1,12 +1,7 @@
 {{#if (has-block)}}
   {{yield
     (hash
-      anyFilterUsed=anyFilterUsed
       summary=summary
-      clearFilters=doClearFilters
-      firstIndex=firstIndex
-      lastIndex=lastIndex
-      recordsCount=recordsCount
     )}}
 {{else}}
   {{summary}}

--- a/addon/templates/components/models-table/themes/ember-semanticui/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/ember-semanticui/row-filtering-cell.hbs
@@ -1,31 +1,27 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
-{{else}}
-  <div class="ui form">
-    {{#if column.componentForFilterCell}}
-      {{#let
-        (component
-          column.componentForFilterCell
-          column=column
-          selectedItems=selectedItems
-          expandedItems=expandedItems
-          themeInstance=themeInstance
-          expandAllRows=expandAllRows
-          collapseAllRows=collapseAllRows
-          toggleAllSelection=toggleAllSelection
-        ) as |FilterCellContent|}}
-        <FilterCellContent/>
-      {{/let}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
     {{else}}
+      <CellContent/>
+    {{/if}}
+  {{/let}}
+{{else}}
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    <div class="ui form">
       {{#if column.useFilter}}
         {{#if column.filterWithSelect}}
           <label for={{inputId}} class="ui label emt-sr-only">{{column.title}}</label>
@@ -66,6 +62,6 @@
           </div>
         {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
+    </div>
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/models-table/themes/semanticui/columns-dropdown.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/columns-dropdown.hbs
@@ -1,15 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-      columnDropdownOptions=columnDropdownOptions
-      processedColumns=processedColumns
-      showAllColumns=(action "doShowAllColumns")
-      hideAllColumns=(action "doHideAllColumns")
-      restoreDefaultVisibility=(action "doRestoreDefaultVisibility")
-      toggleColumnSet=(action "doToggleColumnSet")
-      toggleHidden=(action "doToggleHidden")
-    )}}
+  {{yield}}
 {{else}}
   <div class={{themeInstance.columnsDropdownWrapper}}>
     <div class="ui simple dropdown item">

--- a/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
@@ -7,9 +7,6 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
-    themeInstance=themeInstance
-    sortByGroupedFieldDirection=sortByGroupedFieldDirection
-    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}

--- a/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
@@ -7,24 +7,23 @@
       themeInstance=themeInstance
       class=themeInstance.changeGroupByField
     )
+    sort=doSort
   )
 as |DataGroupBySelect|}}
   {{#if (has-block)}}
     {{yield DataGroupBySelect}}
   {{else}}
-    <div class={{themeInstance.dataGroupBySelectWrapper}}>
-      <div class="ui label">{{themeInstance.groupByLabelMsg}}</div>
-      <DataGroupBySelect.Select/>
-      <button
-        class={{themeInstance.sortGroupedPropertyBtn}}
-        onclick={{action "doSort"}}>
-        <i
-          class={{if
-            (is-equal "asc" sortByGroupedFieldDirection)
-            themeInstance.sortAscIcon
-            themeInstance.sortDescIcon}}>
-        </i>
-      </button>
-    </div>
+    <div class="ui label">{{themeInstance.groupByLabelMsg}}</div>
+    <DataGroupBySelect.Select/>
+    <button
+      class={{themeInstance.sortGroupedPropertyBtn}}
+      onclick={{action "doSort"}}>
+      <i
+        class={{if
+          (is-equal "asc" sortByGroupedFieldDirection)
+          themeInstance.sortAscIcon
+          themeInstance.sortDescIcon}}>
+      </i>
+    </button>
   {{/if}}
 {{/let}}

--- a/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/data-group-by-select.hbs
@@ -8,6 +8,7 @@
       class=themeInstance.changeGroupByField
     )
     themeInstance=themeInstance
+    sortByGroupedFieldDirection=sortByGroupedFieldDirection
     sort=doSort
   )
 as |DataGroupBySelect|}}

--- a/addon/templates/components/models-table/themes/semanticui/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/global-filter.hbs
@@ -1,7 +1,7 @@
-{{#if (has-block)}}
-  {{yield}}
-{{else}}
-  <div class="globalSearch {{themeInstance.globalFilterWrapper}}">
+<div class="globalSearch">
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
     <label for={{inputId}} class="ui label">
       {{themeInstance.searchLabelMsg}}
     </label>
@@ -20,5 +20,5 @@
         onclick={{action (mut value) ""}}>
       </i>
     {{/if}}
-  </div>
-{{/if}}
+  {{/if}}
+</div>

--- a/addon/templates/components/models-table/themes/semanticui/global-filter.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/global-filter.hbs
@@ -1,8 +1,5 @@
 {{#if (has-block)}}
-  {{yield
-    (hash
-      themeInstance=themeInstance
-    )}}
+  {{yield}}
 {{else}}
   <div class="globalSearch {{themeInstance.globalFilterWrapper}}">
     <label for={{inputId}} class="ui label">

--- a/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
@@ -1,49 +1,47 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
-      gotoCustomPage=(action "gotoCustomPage")
-      visiblePageNumbers=visiblePageNumbers
-      themeInstance=themeInstance
-    )}}
-{{else}}
-  <div class={{themeInstance.currentPageSizeSelectWrapper}}>
-    <div class="inline fields">
-      {{#if showCurrentPageNumberSelect}}
-        <label for={{inputId}}>{{themeInstance.currentPageNumberMsg}}</label>
+{{#let
+  (hash
+    PageNumberSelect=(
+      component themeInstance.selectComponent
+      id=inputId
+      options=currentPageNumberOptions
+      value=currentPageNumber
+      type="number"
+      themeInstance=themeInstance)
+    goToPage=goToPage
+    visiblePageNumbers=visiblePageNumbers
+    themeInstance=themeInstance) as |Pagination|}}
+  {{#if (has-block)}}
+    {{yield Pagination}}
+  {{else}}
+    <div class={{themeInstance.currentPageSizeSelectWrapper}}>
+      <div class="inline fields">
+        {{#if showCurrentPageNumberSelect}}
+          <label for={{inputId}}>{{themeInstance.currentPageNumberMsg}}</label>
+          <div class="field">
+            <Pagination.PageNumberSelect/>
+          </div>
+        {{/if}}
         <div class="field">
-          {{#let
-            (component
-              themeInstance.selectComponent
-              id=inputId
-              options=currentPageNumberOptions
-              value=currentPageNumber
-              type="number"
-              themeInstance=themeInstance)
-          as |DefaultSelect|}}
-            <DefaultSelect/>
-          {{/let}}
-        </div>
-      {{/if}}
-      <div class="field">
-        <div class={{themeInstance.paginationBlock}}>
-          {{#each visiblePageNumbers as |page|}}
-            {{#if page.isLink}}
-              <button
-                class="{{themeInstance.buttonDefault}} {{if page.isActive "active"}}"
-                {{action "gotoCustomPage" page.label}}>
-                {{page.label}}
-              </button>
-            {{else}}
-              <button
-                disabled="disabled"
-                class={{themeInstance.buttonDefault}}
-                {{action "gotoCustomPage" page.label}}>
-                {{page.label}}
-              </button>
-            {{/if}}
-          {{/each}}
+          <div class={{themeInstance.paginationBlock}}>
+            {{#each visiblePageNumbers as |page|}}
+              {{#if page.isLink}}
+                <button
+                  class="{{themeInstance.buttonDefault}} {{if page.isActive "active"}}"
+                  {{action "gotoCustomPage" page.label}}>
+                  {{page.label}}
+                </button>
+              {{else}}
+                <button
+                  disabled="disabled"
+                  class={{themeInstance.buttonDefault}}
+                  {{action "gotoCustomPage" page.label}}>
+                  {{page.label}}
+                </button>
+              {{/if}}
+            {{/each}}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-{{/if}}
+  {{/if}}
+{{/let}}

--- a/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
@@ -7,7 +7,6 @@
       value=currentPageNumber
       type="number"
       themeInstance=themeInstance)
-    goToPage=goToPage
     visiblePageNumbers=visiblePageNumbers) as |Pagination|}}
   {{#if (has-block)}}
     {{yield Pagination}}

--- a/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-numeric.hbs
@@ -8,8 +8,7 @@
       type="number"
       themeInstance=themeInstance)
     goToPage=goToPage
-    visiblePageNumbers=visiblePageNumbers
-    themeInstance=themeInstance) as |Pagination|}}
+    visiblePageNumbers=visiblePageNumbers) as |Pagination|}}
   {{#if (has-block)}}
     {{yield Pagination}}
   {{else}}

--- a/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
@@ -8,13 +8,12 @@
       type="number"
       themeInstance=themeInstance)
     goToPage=goToPage
-    gotoFirst=(action "gotoFirst")
-    gotoPrev=(action "gotoPrev")
-    gotoNext=(action "gotoNext")
-    gotoLast=(action "gotoLast")
-    gotoBackEnabled=gotoBackEnabled
-    gotoForwardEnabled=gotoForwardEnabled
-    themeInstance=themeInstance
+    goToFirst=(action "gotoFirst")
+    goToPrev=(action "gotoPrev")
+    goToNext=(action "gotoNext")
+    goToLast=(action "gotoLast")
+    goToBackEnabled=goToBackEnabled
+    goToForwardEnabled=goToForwardEnabled
   )
 as |Pagination|}}
   {{#if (has-block)}}
@@ -31,25 +30,25 @@ as |Pagination|}}
         <div class="field">
           <div class={{themeInstance.paginationBlock}}>
             <button
-              class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
+              class="{{themeInstance.buttonDefault}} {{if goToBackEnabled "enabled" "disabled"}}"
               aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
               {{action "gotoFirst"}}>
               <i class={{themeInstance.navFirstIcon}}></i>
             </button>
             <button
-              class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
+              class="{{themeInstance.buttonDefault}} {{if goToBackEnabled "enabled" "disabled"}}"
               aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
               {{action "gotoPrev"}}>
               <i class={{themeInstance.navPrevIcon}}></i>
             </button>
             <button
-              class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
+              class="{{themeInstance.buttonDefault}} {{if goToForwardEnabled "enabled" "disabled"}}"
               aria-label={{themeInstance.goToNextPageButtonTextMsg}}
               {{action "gotoNext"}}>
               <i class={{themeInstance.navNextIcon}}></i>
             </button>
             <button
-              class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
+              class="{{themeInstance.buttonDefault}} {{if goToForwardEnabled "enabled" "disabled"}}"
               aria-label={{themeInstance.goToLastPageButtonTextMsg}}
               {{action "gotoLast"}}>
               <i class={{themeInstance.navLastIcon}}></i>

--- a/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/pagination-simple.hbs
@@ -1,63 +1,62 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
-      goToPage=goToPage
-      gotoFirst=(action "gotoFirst")
-      gotoPrev=(action "gotoPrev")
-      gotoNext=(action "gotoNext")
-      gotoLast=(action "gotoLast")
-      gotoBackEnabled=gotoBackEnabled
-      gotoForwardEnabled=gotoForwardEnabled
-      themeInstance=themeInstance
-    )}}
-{{else}}
-  <div class={{themeInstance.currentPageSizeSelectWrapper}}>
-    <div class="inline fields">
-      {{#if showCurrentPageNumberSelect}}
-        <label for={{inputId}}>{{themeInstance.currentPageNumberMsg}}</label>
+{{#let
+  (hash
+    PageNumberSelect=(component
+      themeInstance.selectComponent
+      id=inputId
+      options=currentPageNumberOptions
+      value=currentPageNumber
+      type="number"
+      themeInstance=themeInstance)
+    goToPage=goToPage
+    gotoFirst=(action "gotoFirst")
+    gotoPrev=(action "gotoPrev")
+    gotoNext=(action "gotoNext")
+    gotoLast=(action "gotoLast")
+    gotoBackEnabled=gotoBackEnabled
+    gotoForwardEnabled=gotoForwardEnabled
+    themeInstance=themeInstance
+  )
+as |Pagination|}}
+  {{#if (has-block)}}
+    {{yield Pagination}}
+  {{else}}
+    <div class={{themeInstance.currentPageSizeSelectWrapper}}>
+      <div class="inline fields">
+        {{#if showCurrentPageNumberSelect}}
+          <label for={{inputId}}>{{themeInstance.currentPageNumberMsg}}</label>
+          <div class="field">
+            <Pagination.PageNumberSelect/>
+          </div>
+        {{/if}}
         <div class="field">
-          {{#let
-            (component
-              themeInstance.selectComponent
-              id=inputId
-              options=currentPageNumberOptions
-              value=currentPageNumber
-              type="number"
-              themeInstance=themeInstance)
-          as |DefaultSelect|}}
-            <DefaultSelect/>
-          {{/let}}
-        </div>
-      {{/if}}
-      <div class="field">
-        <div class={{themeInstance.paginationBlock}}>
-          <button
-            class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
-            aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
-            {{action "gotoFirst"}}>
-            <i class={{themeInstance.navFirstIcon}}></i>
-          </button>
-          <button
-            class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
-            aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
-            {{action "gotoPrev"}}>
-            <i class={{themeInstance.navPrevIcon}}></i>
-          </button>
-          <button
-            class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
-            aria-label={{themeInstance.goToNextPageButtonTextMsg}}
-            {{action "gotoNext"}}>
-            <i class={{themeInstance.navNextIcon}}></i>
-          </button>
-          <button
-            class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
-            aria-label={{themeInstance.goToLastPageButtonTextMsg}}
-            {{action "gotoLast"}}>
-            <i class={{themeInstance.navLastIcon}}></i>
-          </button>
+          <div class={{themeInstance.paginationBlock}}>
+            <button
+              class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
+              aria-label={{themeInstance.goToFirstPageButtonTextMsg}}
+              {{action "gotoFirst"}}>
+              <i class={{themeInstance.navFirstIcon}}></i>
+            </button>
+            <button
+              class="{{themeInstance.buttonDefault}} {{if gotoBackEnabled "enabled" "disabled"}}"
+              aria-label={{themeInstance.goToPrevPageButtonTextMsg}}
+              {{action "gotoPrev"}}>
+              <i class={{themeInstance.navPrevIcon}}></i>
+            </button>
+            <button
+              class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
+              aria-label={{themeInstance.goToNextPageButtonTextMsg}}
+              {{action "gotoNext"}}>
+              <i class={{themeInstance.navNextIcon}}></i>
+            </button>
+            <button
+              class="{{themeInstance.buttonDefault}} {{if gotoForwardEnabled "enabled" "disabled"}}"
+              aria-label={{themeInstance.goToLastPageButtonTextMsg}}
+              {{action "gotoLast"}}>
+              <i class={{themeInstance.navLastIcon}}></i>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-{{/if}}
+  {{/if}}
+{{/let}}

--- a/addon/templates/components/models-table/themes/semanticui/row-filtering-cell.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/row-filtering-cell.hbs
@@ -1,29 +1,25 @@
-{{#if (has-block)}}
-  {{yield
-    (hash
+{{#if column.componentForFilterCell}}
+  {{#let
+    (component
+      column.componentForFilterCell
       column=column
+      data=data
       selectedItems=selectedItems
       expandedItems=expandedItems
       themeInstance=themeInstance
       expandAllRows=expandAllRows
       collapseAllRows=collapseAllRows
-      toggleAllSelection=toggleAllSelection
-    )}}
+      toggleAllSelection=toggleAllSelection)
+  as |CellContent|}}
+    {{#if (has-block)}}
+      {{yield CellContent}}
+    {{else}}
+      <CellContent/>
+    {{/if}}
+  {{/let}}
 {{else}}
-  {{#if column.componentForFilterCell}}
-    {{#let
-      (component
-        column.componentForFilterCell
-        column=column
-        selectedItems=selectedItems
-        expandedItems=expandedItems
-        themeInstance=themeInstance
-        expandAllRows=expandAllRows
-        collapseAllRows=collapseAllRows
-        toggleAllSelection=toggleAllSelection
-      ) as |FilterCellContent|}}
-      <FilterCellContent/>
-    {{/let}}
+  {{#if (has-block)}}
+    {{yield}}
   {{else}}
     {{#if column.useFilter}}
       {{#if column.filterWithSelect}}

--- a/addon/templates/components/models-table/themes/semanticui/summary.hbs
+++ b/addon/templates/components/models-table/themes/semanticui/summary.hbs
@@ -1,12 +1,7 @@
 {{#if (has-block)}}
   {{yield
     (hash
-      anyFilterUsed=anyFilterUsed
       summary=summary
-      clearFilters=doClearFilters
-      firstIndex=firstIndex
-      lastIndex=lastIndex
-      recordsCount=recordsCount
     )}}
 {{else}}
   <form class={{themeInstance.form}}>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,7 @@ module.exports = function(defaults) {
       }
     },
     'ember-composable-helpers': {
-      only: ['intersect', 'filter-by', 'object-at', 'map-by']
+      only: ['intersect', 'filter-by', 'object-at', 'map-by', 'inc']
     }
   };
   if (process.env.EMT_UI === 'paper') {

--- a/package.json
+++ b/package.json
@@ -73,9 +73,7 @@
     "eslint-plugin-ember": "^7.4.0",
     "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.9.0",
-    "bootstrap": "3.4.0",
-    "ember-bootstrap": "^2.7.1"
+    "qunit-dom": "^0.9.0"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
     "eslint-plugin-ember": "^7.4.0",
     "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.9.0"
+    "qunit-dom": "^0.9.0",
+    "bootstrap": "3.4.0",
+    "ember-bootstrap": "^2.7.1"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -23,6 +23,7 @@ Router.map(function() {
     this.route('filtering');
     this.route('grouped-rows');
     this.route('in-line-edit');
+    this.route('block-usage');
   });
 
   this.route('users', function() {

--- a/tests/dummy/app/routes/examples/block-usage.js
+++ b/tests/dummy/app/routes/examples/block-usage.js
@@ -28,6 +28,8 @@ export default class BlockUsageRoute extends ExampleRoute {
       mayBeHidden: false,
       componentForSortCell: theme.rowSelectAllCheckboxComponent
     });
+    controller.columns[5].filterWithSelect = true; // Age
+    controller.columns[5].sortFilterOptions = true;
     set(controller, 'useDataGrouping', true);
     set(controller, 'dataGroupProperties', ['age', 'city', 'country']);
     set(controller, 'currentGroupingPropertyName', 'country');

--- a/tests/dummy/app/routes/examples/block-usage.js
+++ b/tests/dummy/app/routes/examples/block-usage.js
@@ -1,0 +1,36 @@
+import ExampleRoute from './example';
+import {getOwner} from '@ember/application';
+import {set} from '@ember/object';
+
+export default class BlockUsageRoute extends ExampleRoute {
+  setupController(controller) {
+    super.setupController(...arguments);
+    controller.set('groupedHeaders', [
+      [
+        {title: 'Big Title', colspan: 7}
+      ],
+      [
+        {title: '', colspan: 2},
+        {title: 'Subtitle 1', colspan: 3},
+        {title: 'Subtitle 2', colspan: 2}
+      ]
+    ]);
+    const owner = getOwner(this);
+    const theme = owner.lookup('component:models-table').themeInstance;
+    controller.columns.unshiftObject({
+      component: theme.expandToggleComponent,
+      componentForFilterCell: theme.expandAllToggleComponent,
+      mayBeHidden: false
+    });
+    controller.columns.unshiftObject({
+      component: theme.rowSelectCheckboxComponent,
+      useFilter: false,
+      mayBeHidden: false,
+      componentForSortCell: theme.rowSelectAllCheckboxComponent
+    });
+    set(controller, 'useDataGrouping', true);
+    set(controller, 'dataGroupProperties', ['age', 'city', 'country']);
+    set(controller, 'currentGroupingPropertyName', 'country');
+    set(controller, 'displayGroupedValueAs', 'row');
+  }
+}

--- a/tests/dummy/app/templates/examples/block-usage.hbs
+++ b/tests/dummy/app/templates/examples/block-usage.hbs
@@ -3,6 +3,55 @@
   <small>simple table</small>
 </h4>
 
+<ModelsTable
+  @data={{data}}
+  @columns={{columns}}
+  @multipleExpand={{true}}
+  @multipleSelect={{true}} as |MT|>
+  <MT.GlobalFilter/>
+  <MT.ColumnsDropdown/>
+  <MT.Table as |Table|>
+    <Table.Header as |Header|>
+      <Header.RowSorting as |RowSorting|>
+        {{#each MT.visibleProcessedColumns as |column|}}
+          <RowSorting.RowSortingCell @column={{column}} />
+        {{/each}}
+      </Header.RowSorting>
+      <Header.RowFiltering as |RowFiltering|>
+        {{#each MT.visibleProcessedColumns as |column|}}
+          <RowFiltering.RowFilteringCell @column={{column}} />
+        {{/each}}
+      </Header.RowFiltering>
+    </Table.Header>
+    <Table.Body as |Body|>
+      {{#if MT.allColumnsAreHidden}}
+        <Body.ColumnsHidden/>
+      {{else}}
+        {{#each MT.visibleContent as |record index|}}
+          <Body.Row @record={{record}} @index={{index}}/>
+          {{#if (exists-in MT.expandedItems record)}}
+            <Body.RowExpand @record={{record}} @index={{index}}>
+              Row for Record #{{record.id}} is expanded. Row index is {{index}}
+            </Body.RowExpand>
+          {{/if}}
+        {{else}}
+          <Body.NoData/>
+        {{/each}}
+      {{/if}}
+    </Table.Body>
+  </MT.Table>
+  <MT.Footer as |Footer|>
+    <Footer.Summary/>
+    <Footer.PageSizeSelect/>
+    <Footer.PaginationSimple/>
+  </MT.Footer>
+</ModelsTable>
+
+<h4>
+  Block usage
+  <small>complex table</small>
+</h4>
+
 <p>Check source code to see how components are used with block form</p>
 
 <p>{{input type="checkbox" name="useDataGrouping" checked=useDataGrouping}} Use Data Grouping</p>
@@ -27,7 +76,7 @@
   <MT.ColumnsDropdown/>
   <MT.Table as |Table|>
     <Table.Header as |Header|>
-      {{#each groupedHeaders as |groupedHeader|}}
+      {{#each MT.groupedHeaders as |groupedHeader|}}
         <Header.GroupedHeader @groupedHeader={{groupedHeader}} as |GroupedHeader|>
           {{#if GroupedHeader.shouldAddExtraColumn}}
             <th></th>
@@ -41,7 +90,7 @@
         {{#if RowSorting.shouldAddExtraColumn}}
           <th></th>
         {{/if}}
-        {{#each RowSorting.visibleProcessedColumns as |column|}}
+        {{#each MT.visibleProcessedColumns as |column|}}
           <RowSorting.RowSortingCell @column={{column}} />
         {{/each}}
       </Header.RowSorting>
@@ -49,7 +98,7 @@
         {{#if RowFiltering.shouldAddExtraColumn}}
           <th></th>
         {{/if}}
-        {{#each RowFiltering.visibleProcessedColumns as |column|}}
+        {{#each MT.visibleProcessedColumns as |column|}}
           <RowFiltering.RowFilteringCell @column={{column}} />
         {{/each}}
       </Header.RowFiltering>
@@ -98,7 +147,7 @@
             {{/let}}
           {{/each}}
         {{else}}
-          {{#each Body.visibleContent as |record index|}}
+          {{#each MT.visibleContent as |record index|}}
             <Body.Row @record={{record}} @index={{index}}/>
             {{#if (exists-in MT.expandedItems record)}}
               <Body.RowExpand @record={{record}} @index={{index}}>
@@ -113,7 +162,7 @@
     </Table.Body>
     <Table.Footer as |Footer|>
       <tr>
-        <td colspan={{if shouldAddExtraColumn Footer.visibleProcessedColumns.length (inc Footer.visibleProcessedColumns.length)}}>
+        <td colspan={{if Footer.shouldAddExtraColumn (inc MT.visibleProcessedColumns.length) MT.visibleProcessedColumns.length}}>
           Some custom summary for table can be shown in the <code>tfoot</code>
         </td>
       </tr>
@@ -125,7 +174,7 @@
       <button disabled={{unless MT.anyFilterUsed "disabled"}} {{action MT.clearFilters}}>Clear All Filters</button>
     </MT.Summary>
     <div class={{MT.themeInstance.pageSizeWrapper}}>
-      <MT.SizeSelect/>
+      <MT.PageSizeSelect/>
     </div>
     {{#if useNumericPagination}}
       <MT.PaginationNumeric as |Pagination|>
@@ -149,16 +198,16 @@
     {{else}}
       <MT.PaginationSimple as |Pagination|>
         <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
-          <button disabled={{unless Pagination.gotoBackEnabled "disabled"}} {{action Pagination.gotoFirst}}>
+          <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToFirst}}>
             <i class={{MT.themeInstance.navFirstIcon}}></i>
           </button>
-          <button disabled={{unless Pagination.gotoBackEnabled "disabled"}} {{action Pagination.gotoPrev}}>
+          <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToPrev}}>
             <i class={{MT.themeInstance.navPrevIcon}}></i>
           </button>
-          <button disabled={{unless Pagination.gotoForwardEnabled "disabled"}} {{action Pagination.gotoNext}}>
+          <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToNext}}>
             <i class={{MT.themeInstance.navNextIcon}}></i>
           </button>
-          <button disabled={{unless Pagination.gotoForwardEnabled "disabled"}} {{action Pagination.gotoLast}}>
+          <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToLast}}>
             <i class={{MT.themeInstance.navLastIcon}}></i>
           </button>
         </div>

--- a/tests/dummy/app/templates/examples/block-usage.hbs
+++ b/tests/dummy/app/templates/examples/block-usage.hbs
@@ -1,0 +1,171 @@
+<h4>
+  Block usage
+  <small>simple table</small>
+</h4>
+
+<p>Check source code to see how components are used with block form</p>
+
+<p>{{input type="checkbox" name="useDataGrouping" checked=useDataGrouping}} Use Data Grouping</p>
+<p>{{input type="checkbox" name="useNumericPagination" checked=useNumericPagination}} Use Numeric Pagination</p>
+
+<ModelsTable
+  @data={{data}}
+  @columns={{columns}}
+  @groupedHeaders={{groupedHeaders}}
+  @multipleExpand={{true}}
+  @multipleSelect={{true}}
+  @useDataGrouping={{useDataGrouping}}
+  @dataGroupProperties={{dataGroupProperties}}
+  @currentGroupingPropertyName={{currentGroupingPropertyName}}
+  @useNumericPagination={{useNumericPagination}}
+  @displayGroupedValueAs="column"
+  @pageSize={{25}} as |MT|>
+  <MT.GlobalFilter/>
+  {{#if MT.useDataGrouping}}
+    <MT.DataGroupBySelect/>
+  {{/if}}
+  <MT.ColumnsDropdown/>
+  <MT.Table as |Table|>
+    <Table.Header as |Header|>
+      {{#each groupedHeaders as |groupedHeader|}}
+        <Header.GroupedHeader @groupedHeader={{groupedHeader}} as |GroupedHeader|>
+          {{#if GroupedHeader.shouldAddExtraColumn}}
+            <th></th>
+          {{/if}}
+          {{#each GroupedHeader.groupedHeader as |cell|}}
+            <th colspan={{cell.colspan}} rowspan={{cell.rowspan}}>{{cell.title}}</th>
+          {{/each}}
+        </Header.GroupedHeader>
+      {{/each}}
+      <Header.RowSorting as |RowSorting|>
+        {{#if RowSorting.shouldAddExtraColumn}}
+          <th></th>
+        {{/if}}
+        {{#each RowSorting.visibleProcessedColumns as |column|}}
+          <RowSorting.RowSortingCell @column={{column}} />
+        {{/each}}
+      </Header.RowSorting>
+      <Header.RowFiltering as |RowFiltering|>
+        {{#if RowFiltering.shouldAddExtraColumn}}
+          <th></th>
+        {{/if}}
+        {{#each RowFiltering.visibleProcessedColumns as |column|}}
+          <RowFiltering.RowFilteringCell @column={{column}} />
+        {{/each}}
+      </Header.RowFiltering>
+    </Table.Header>
+    <Table.Body as |Body|>
+      {{#if MT.allColumnsAreHidden}}
+        <Body.ColumnsHidden/>
+      {{else}}
+        {{#if MT.useDataGrouping}}
+          {{#each MT.groupedVisibleContentValuesOrder as |groupedValue groupedIndex|}}
+            {{#let (filter-by MT.currentGroupingPropertyName groupedValue MT.groupedArrangedContent) as |groupedItems|}}
+              {{#let (object-at groupedIndex MT.groupedVisibleContent) as |visibleGroupedItems|}}
+                {{#let
+                  (component Body.RowGrouping
+                    groupedValue=groupedValue
+                    groupedLength=groupedItems.length
+                    groupedItems=groupedItems
+                    visibleGroupedItems=visibleGroupedItems
+                    visibleGroupedLength=visibleGroupedItems.length
+                  )
+                as |RowGrouping|}}
+                  {{#if (is-equal MT.displayGroupedValueAs "row")}}
+                    <RowGrouping @groupIsCollapsed={{exists-in MT.collapsedGroupValues groupedValue}}/>
+                  {{/if}}
+                  {{#if (exists-in MT.collapsedGroupValues groupedValue)}}
+                    {{#if (is-equal MT.displayGroupedValueAs "column")}}
+                      <RowGrouping @groupIsCollapsed={{true}}/>
+                    {{/if}}
+                  {{else}}
+                    {{#each visibleGroupedItems as |record index|}}
+                      <Body.Row
+                        @record={{record}}
+                        @index={{index}}
+                        @groupedValue={{groupedValue}}
+                        @visibleGroupedItems={{visibleGroupedItems}}
+                      />
+                      {{#if (exists-in MT.expandedItems record)}}
+                        <Body.RowExpand @record={{record}} @index={{index}}>
+                          Row for Record #{{record.id}} is expanded. Row index is {{index}}
+                        </Body.RowExpand>
+                      {{/if}}
+                    {{/each}}
+                  {{/if}}
+                {{/let}}
+              {{/let}}
+            {{/let}}
+          {{/each}}
+        {{else}}
+          {{#each Body.visibleContent as |record index|}}
+            <Body.Row @record={{record}} @index={{index}}/>
+            {{#if (exists-in MT.expandedItems record)}}
+              <Body.RowExpand @record={{record}} @index={{index}}>
+                Row for Record #{{record.id}} is expanded. Row index is {{index}}
+              </Body.RowExpand>
+            {{/if}}
+          {{else}}
+            <Body.NoData/>
+          {{/each}}
+        {{/if}}
+      {{/if}}
+    </Table.Body>
+    <Table.Footer as |Footer|>
+      <tr>
+        <td colspan={{if shouldAddExtraColumn Footer.visibleProcessedColumns.length (inc Footer.visibleProcessedColumns.length)}}>
+          Some custom summary for table can be shown in the <code>tfoot</code>
+        </td>
+      </tr>
+    </Table.Footer>
+  </MT.Table>
+  <div class={{MT.themeInstance.tfooterInternalWrapper}}>
+    <MT.Summary as |Summary|>
+      Show: {{Summary.firstIndex}} - {{Summary.lastIndex}} of {{Summary.recordsCount}}
+      <button disabled={{unless MT.anyFilterUsed "disabled"}} {{action MT.clearFilters}}>Clear All Filters</button>
+    </MT.Summary>
+    <div class={{MT.themeInstance.pageSizeWrapper}}>
+      <MT.SizeSelect/>
+    </div>
+    {{#if useNumericPagination}}
+      <MT.PaginationNumeric as |Pagination|>
+        <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+          {{#each Pagination.visiblePageNumbers as |page|}}
+            {{#if page.isLink}}
+              <button {{action MT.goToPage page.label}}>
+                {{page.label}}
+              </button>
+            {{else}}
+              <button disabled="disabled">
+                {{page.label}}
+              </button>
+            {{/if}}
+          {{/each}}
+        </div>
+        <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+          <Pagination.PageNumberSelect/>
+        </div>
+      </MT.PaginationNumeric>
+    {{else}}
+      <MT.PaginationSimple as |Pagination|>
+        <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+          <button disabled={{unless Pagination.gotoBackEnabled "disabled"}} {{action Pagination.gotoFirst}}>
+            <i class={{MT.themeInstance.navFirstIcon}}></i>
+          </button>
+          <button disabled={{unless Pagination.gotoBackEnabled "disabled"}} {{action Pagination.gotoPrev}}>
+            <i class={{MT.themeInstance.navPrevIcon}}></i>
+          </button>
+          <button disabled={{unless Pagination.gotoForwardEnabled "disabled"}} {{action Pagination.gotoNext}}>
+            <i class={{MT.themeInstance.navNextIcon}}></i>
+          </button>
+          <button disabled={{unless Pagination.gotoForwardEnabled "disabled"}} {{action Pagination.gotoLast}}>
+            <i class={{MT.themeInstance.navLastIcon}}></i>
+          </button>
+        </div>
+        <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+          <Pagination.PageNumberSelect/>
+        </div>
+      </MT.PaginationSimple>
+    {{/if}}
+  </div>
+</ModelsTable>

--- a/tests/dummy/app/templates/examples/block-usage.hbs
+++ b/tests/dummy/app/templates/examples/block-usage.hbs
@@ -69,11 +69,42 @@
   @useNumericPagination={{useNumericPagination}}
   @displayGroupedValueAs="column"
   @pageSize={{25}} as |MT|>
-  <MT.GlobalFilter/>
+  <MT.GlobalFilter>
+    {{input value=MT.globalFilter}}
+    <button disabled={{unless MT.globalFilterUsed "disabled"}} {{action (mut MT.globalFilter) ""}}>&times;</button>
+  </MT.GlobalFilter>
   {{#if MT.useDataGrouping}}
-    <MT.DataGroupBySelect/>
+    <MT.DataGroupBySelect as |DGBS|>
+      <span>&nbsp;Group By:</span>
+      <ModelsTable::Select
+        @value={{MT.currentGroupingPropertyName}}
+        @options={{MT.dataGroupOptions}}/>
+      <button {{action DGBS.sort}}>
+        {{#if (is-equal MT.sortByGroupedFieldDirection "asc")}}
+          &uarr;
+        {{else}}
+          &darr;
+        {{/if}}
+      </button>
+    </MT.DataGroupBySelect>
   {{/if}}
-  <MT.ColumnsDropdown/>
+  <MT.ColumnsDropdown>
+    <button {{action MT.showAllColumns}}>Show All</button>
+    <button {{action MT.hideAllColumns}}>Hide All</button>
+    <button {{action MT.restoreDefaultVisibility}}>Restore defaults</button>
+    {{#each MT.processedColumns as |column|}}
+      {{#if column.mayBeHidden}}
+        <button {{action MT.toggleColumnVisibility column}}>
+          {{#if column.isVisible}}
+            &#9745;
+          {{else}}
+            &#9744;
+          {{/if}}
+          {{column.title}}
+        </button>
+      {{/if}}
+    {{/each}}
+  </MT.ColumnsDropdown>
   <MT.Table as |Table|>
     <Table.Header as |Header|>
       {{#each MT.groupedHeaders as |groupedHeader|}}
@@ -99,7 +130,23 @@
           <th></th>
         {{/if}}
         {{#each MT.visibleProcessedColumns as |column|}}
-          <RowFiltering.RowFilteringCell @column={{column}} />
+          <RowFiltering.RowFilteringCell @column={{column}} as |RowFilteringCell|>
+            {{#if column.componentForFilterCell}}
+              <RowFilteringCell/>
+            {{else}}
+              {{#if column.useFilter}}
+                {{#if column.filterWithSelect}}
+                  <ModelsTable::Select
+                    @type="number"
+                    @value={{column.filterString}}
+                    @options={{column.filterOptions}}/>
+                {{else}}
+                  {{input value=column.filterString}}
+                {{/if}}
+                <button disabled={{unless column.filterUsed "disabled"}} {{action (mut column.filterString) ""}}>&times;</button>
+              {{/if}}
+            {{/if}}
+          </RowFiltering.RowFilteringCell>
         {{/each}}
       </Header.RowFiltering>
     </Table.Header>
@@ -169,12 +216,16 @@
     </Table.Footer>
   </MT.Table>
   <div class={{MT.themeInstance.tfooterInternalWrapper}}>
-    <MT.Summary as |Summary|>
-      Show: {{Summary.firstIndex}} - {{Summary.lastIndex}} of {{Summary.recordsCount}}
-      <button disabled={{unless MT.anyFilterUsed "disabled"}} {{action MT.clearFilters}}>Clear All Filters</button>
+    <MT.Summary>
+      Show: {{MT.firstIndex}} - {{MT.lastIndex}} of {{MT.recordsCount}}
+      <button disabled={{unless MT.anyFilterUsed "disabled"}} {{action MT.clearFilters}}>&times;</button>
     </MT.Summary>
     <div class={{MT.themeInstance.pageSizeWrapper}}>
-      <MT.PageSizeSelect/>
+      Rows:
+      <ModelsTable::Select
+        @type="number"
+        @value={{MT.pageSize}}
+        @options={{MT.pageSizeOptions}}/>
     </div>
     {{#if useNumericPagination}}
       <MT.PaginationNumeric as |Pagination|>
@@ -192,27 +243,33 @@
           {{/each}}
         </div>
         <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
-          <Pagination.PageNumberSelect/>
+          <ModelsTable::Select
+            @type="number"
+            @value={{MT.currentPageNumber}}
+            @options={{MT.currentPageNumberOptions}}/>
         </div>
       </MT.PaginationNumeric>
     {{else}}
       <MT.PaginationSimple as |Pagination|>
         <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
           <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToFirst}}>
-            <i class={{MT.themeInstance.navFirstIcon}}></i>
+            &lt;&lt;
           </button>
           <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToPrev}}>
-            <i class={{MT.themeInstance.navPrevIcon}}></i>
+            &lt;
           </button>
           <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToNext}}>
-            <i class={{MT.themeInstance.navNextIcon}}></i>
+            &gt;
           </button>
           <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToLast}}>
-            <i class={{MT.themeInstance.navLastIcon}}></i>
+            &gt;&gt;
           </button>
         </div>
         <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
-          <Pagination.PageNumberSelect/>
+          <ModelsTable::Select
+            @type="number"
+            @value={{MT.currentPageNumber}}
+            @options={{MT.currentPageNumberOptions}}/>
         </div>
       </MT.PaginationSimple>
     {{/if}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -3456,22 +3456,22 @@ module('ModelsTable | Integration', function (hooks) {
     });
 
     await render(hbs`
-      <ModelsTable @data={{data}} @columns={{columns}} as |Wrapper|>
-        <Wrapper.Table as |Table|>
+      <ModelsTable @data={{data}} @columns={{columns}} as |MT|>
+        <MT.Table as |Table|>
           <Table.Body as |Body|>
-            {{#each Body.visibleContent as |record index|}}
+            {{#each MT.visibleContent as |record index|}}
               <Body.Row @record={{record}} @index={{index}} as |Row|>
                 <div class="isEditRow">{{if Row.isEditRow "yes" "no"}}</div>
                 <div class="actionEdit" {{action Row.editRow}}>Edit</div>
                 <div class="actionSave" {{action Row.saveRow}}>Save</div>
                 <div class="actionCancel" {{action Row.cancelEditRow}}>Cancel</div>
-                {{#each Row.visibleProcessedColumns as |column|}}
+                {{#each MT.visibleProcessedColumns as |column|}}
                   <Row.Cell class="cell" @index={{index}} @column={{column}} />
                 {{/each}}
               </Body.Row>
             {{/each}}
           </Table.Body>
-        </Wrapper.Table>
+        </MT.Table>
       </ModelsTable>
     `);
 
@@ -3707,9 +3707,9 @@ module('ModelsTable | Integration', function (hooks) {
     this.set('data', generateContent(50, 1));
     await render(hbs`<ModelsTable @data={{data}} as |MT|>
       <MT.Footer as |Footer|>
-        <Footer.SizeSelect as |SizeSelectBlock|>
+        <Footer.PageSizeSelect as |SizeSelectBlock|>
           <SizeSelectBlock.Select />
-        </Footer.SizeSelect>
+        </Footer.PageSizeSelect>
       </MT.Footer>
     </ModelsTable>`);
     assert.equal(this.ModelsTablePageObject.pageSize, '10');
@@ -3760,23 +3760,23 @@ module('ModelsTable | Integration', function (hooks) {
       <MT.Footer as |Footer|>
         <Footer.PaginationSimple as |PS|>
           <button
-          class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
-          {{action PS.gotoFirst}}>
+          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          {{action PS.goToFirst}}>
           <i class={{themeInstance.navFirstIcon}}></i>
         </button>
         <button
-          class="{{if PS.gotoBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
-          {{action PS.gotoPrev}}>
+          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          {{action PS.goToPrev}}>
           <i class={{themeInstance.navPrevIcon}}></i>
         </button>
         <button
-          class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
-          {{action PS.gotoNext}}>
+          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          {{action PS.goToNext}}>
           <i class={{themeInstance.navNextIcon}}></i>
         </button>
         <button
-          class="{{if PS.gotoForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
-          {{action PS.gotoLast}}>
+          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          {{action PS.goToLast}}>
           <i class={{themeInstance.navLastIcon}}></i>
         </button>
           <PS.PageNumberSelect/>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -596,8 +596,7 @@ module('ModelsTable | Integration', function (hooks) {
         {{#each CD.processedColumns as |column|}}
           {{#if column.mayBeHidden}}
             <button {{action CD.toggleHidden column}}>
-              <i class={{if column.isVisible CD.themeInstance.columnVisibleIcon CD.themeInstance.columnHiddenIcon}}></i>
-              {{column.title}}
+              <i class={{if column.isVisible CD.themeInstance.columnVisibleIcon CD.themeInstance.columnHiddenIcon}}></i>{{column.title}}
             </button>
           {{/if}}
         {{/each}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -581,22 +581,22 @@ module('ModelsTable | Integration', function (hooks) {
 
     await render(hbs`<ModelsTable @data={{data}} @columns={{columns}} as |MT|>
       <MT.ColumnsDropdown as |CD|>
-        {{#if CD.columnDropdownOptions.showAll}}
-          <button {{action CD.showAllColumns}}>{{CD.themeInstance.columnsShowAllMsg}}</button>
+        {{#if MT.columnDropdownOptions.showAll}}
+          <button {{action MT.showAllColumns}}>{{MT.themeInstance.columnsShowAllMsg}}</button>
         {{/if}}
-        {{#if CD.columnDropdownOptions.hideAll}}
-          <button {{action CD.hideAllColumns}}>{{CD.themeInstance.columnsHideAllMsg}}</button>
+        {{#if MT.columnDropdownOptions.hideAll}}
+          <button {{action MT.hideAllColumns}}>{{MT.themeInstance.columnsHideAllMsg}}</button>
         {{/if}}
-        {{#if CD.columnDropdownOptions.restoreDefaults}}
-          <button {{action CD.restoreDefaultVisibility}}>{{CD.themeInstance.columnsRestoreDefaultsMsg}}</button>
+        {{#if MT.columnDropdownOptions.restoreDefaults}}
+          <button {{action MT.restoreDefaultVisibility}}>{{MT.themeInstance.columnsRestoreDefaultsMsg}}</button>
         {{/if}}
-        {{#each CD.columnDropdownOptions.columnSets as |columnSet|}}
-          <button {{action CD.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
+        {{#each MT.columnDropdownOptions.columnSets as |columnSet|}}
+          <button {{action MT.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
         {{/each}}
-        {{#each CD.processedColumns as |column|}}
+        {{#each MT.processedColumns as |column|}}
           {{#if column.mayBeHidden}}
-            <button {{action CD.toggleHidden column}}>
-              <i class={{if column.isVisible CD.themeInstance.columnVisibleIcon CD.themeInstance.columnHiddenIcon}}></i>{{column.title}}
+            <button {{action MT.toggleHidden column}}>
+              <i class={{if column.isVisible MT.themeInstance.columnVisibleIcon MT.themeInstance.columnHiddenIcon}}></i>{{column.title}}
             </button>
           {{/if}}
         {{/each}}
@@ -3420,16 +3420,16 @@ module('ModelsTable | Integration', function (hooks) {
       @pageSize=50
       @dataGroupProperties={{dataGroupProperties}} as |MT|>
         <MT.DataGroupBySelect as |DGBS|>
-          <label>{{DGBS.themeInstance.groupByLabelMsg}}</label>
+          <label>{{MT.themeInstance.groupByLabelMsg}}</label>
           <DGBS.Select />
           <button
-            class={{DGBS.themeInstance.sortGroupedPropertyBtn}}
-            onclick={{action DGBS.sort}}>
+            class={{MT.themeInstance.sortGroupedPropertyBtn}}
+            onclick={{action MT.sort}}>
             <i
               class={{if
-                (is-equal DGBS.sortByGroupedFieldDirection "asc")
-                DGBS.themeInstance.sortAscIcon
-                DGBS.themeInstance.sortDescIcon}}>
+                (is-equal MT.sortByGroupedFieldDirection "asc")
+                MT.themeInstance.sortAscIcon
+                MT.themeInstance.sortDescIcon}}>
             </i>
           </button>
         </MT.DataGroupBySelect>
@@ -3726,23 +3726,22 @@ module('ModelsTable | Integration', function (hooks) {
       <MT.Footer as |Footer|>
         <Footer.PaginationNumeric as |PN|>
           {{#each PN.visiblePageNumbers as |page|}}
-          {{#if page.isLink}}
-            <button
-              class="{{themeInstance.paginationNumericItem}} {{if page.isActive themeInstance.paginationNumericItemActive}} {{themeInstance.buttonDefault}}"
-              {{action "gotoCustomPage" page.label}}>
-              {{page.label}}
-            </button>
-          {{else}}
-            <button
-              type="button"
-              class="{{themeInstance.buttonDefault}} {{themeInstance.paginationNumericItem}}"
-              disabled="disabled"
-              {{action "gotoCustomPage" page.label}}>
-              {{page.label}}
-            </button>
-          {{/if}}
-        {{/each}}
-        <PN.PageNumberSelect />
+            {{#if page.isLink}}
+              <button
+                class="{{MT.themeInstance.paginationNumericItem}} {{if page.isActive MT.themeInstance.paginationNumericItemActive}} {{MT.themeInstance.buttonDefault}}"
+                {{action MT.goToPage page.label}}>
+                {{page.label}}
+              </button>
+            {{else}}
+              <button
+                type="button"
+                class="{{MT.themeInstance.buttonDefault}} {{MT.themeInstance.paginationNumericItem}}"
+                disabled="disabled">
+                {{page.label}}
+              </button>
+            {{/if}}
+          {{/each}}
+          <PN.PageNumberSelect />
         </Footer.PaginationNumeric>
       </MT.Footer>
     </ModelsTable>`);
@@ -3760,24 +3759,24 @@ module('ModelsTable | Integration', function (hooks) {
       <MT.Footer as |Footer|>
         <Footer.PaginationSimple as |PS|>
           <button
-          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
           {{action PS.goToFirst}}>
-          <i class={{themeInstance.navFirstIcon}}></i>
+          <i class={{MT.themeInstance.navFirstIcon}}></i>
         </button>
         <button
-          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if PS.goToBackEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
           {{action PS.goToPrev}}>
-          <i class={{themeInstance.navPrevIcon}}></i>
+          <i class={{MT.themeInstance.navPrevIcon}}></i>
         </button>
         <button
-          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
           {{action PS.goToNext}}>
-          <i class={{themeInstance.navNextIcon}}></i>
+          <i class={{MT.themeInstance.navNextIcon}}></i>
         </button>
         <button
-          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{themeInstance.buttonDefault}}"
+          class="{{if PS.goToForwardEnabled "enabled" "disabled"}} {{MT.themeInstance.buttonDefault}}"
           {{action PS.goToLast}}>
-          <i class={{themeInstance.navLastIcon}}></i>
+          <i class={{MT.themeInstance.navLastIcon}}></i>
         </button>
           <PS.PageNumberSelect/>
         </Footer.PaginationSimple>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -591,11 +591,11 @@ module('ModelsTable | Integration', function (hooks) {
           <button {{action MT.restoreDefaultVisibility}}>{{MT.themeInstance.columnsRestoreDefaultsMsg}}</button>
         {{/if}}
         {{#each MT.columnDropdownOptions.columnSets as |columnSet|}}
-          <button {{action MT.toggleColumnSet columnSet}}>{{columnSet.label}}</button>
+          <button {{action MT.toggleColumnSetVisilibity columnSet}}>{{columnSet.label}}</button>
         {{/each}}
         {{#each MT.processedColumns as |column|}}
           {{#if column.mayBeHidden}}
-            <button {{action MT.toggleHidden column}}>
+            <button {{action MT.toggleColumnVisibility column}}>
               <i class={{if column.isVisible MT.themeInstance.columnVisibleIcon MT.themeInstance.columnHiddenIcon}}></i>{{column.title}}
             </button>
           {{/if}}
@@ -3788,6 +3788,237 @@ module('ModelsTable | Integration', function (hooks) {
     assert.ok(this.ModelsTablePageObject.navigation.goToPrevPageDisabled, 'prev disabled');
     assert.ok(this.ModelsTablePageObject.navigation.goToFirstPageDisabled, 'first disabled');
     assert.ok(this.ModelsTablePageObject.navigation.selectPageNumberExists);
+  });
+
+  test('#block render whole table with custom markup', async function (assert) {
+    this.setProperties({
+      useDataGrouping: true,
+      dataGroupProperties: ['age', 'city', 'country'],
+      currentGroupingPropertyName: 'country',
+      displayGroupedValueAs: 'row',
+      columns: generateColumns(['index', 'index2', 'reversedIndex', 'indexWithHtml', 'someWord']),
+      data: generateContent(50, 1)
+    });
+    this.render(hbs`
+      <ModelsTable
+        @data={{data}}
+        @columns={{columns}}
+        @groupedHeaders={{groupedHeaders}}
+        @multipleExpand={{true}}
+        @multipleSelect={{true}}
+        @useDataGrouping={{useDataGrouping}}
+        @dataGroupProperties={{dataGroupProperties}}
+        @currentGroupingPropertyName={{currentGroupingPropertyName}}
+        @useNumericPagination={{useNumericPagination}}
+        @displayGroupedValueAs="column"
+        @pageSize={{25}} as |MT|>
+        <MT.GlobalFilter>
+          {{input value=MT.globalFilter}}
+          <button disabled={{unless MT.globalFilterUsed "disabled"}} {{action (mut MT.globalFilter) ""}}>&times;</button>
+        </MT.GlobalFilter>
+        {{#if MT.useDataGrouping}}
+          <MT.DataGroupBySelect as |DGBS|>
+            <span>&nbsp;Group By:</span>
+            <ModelsTable::Select
+              @value={{MT.currentGroupingPropertyName}}
+              @options={{MT.dataGroupOptions}}/>
+            <button {{action DGBS.sort}}>
+              {{#if (is-equal MT.sortByGroupedFieldDirection "asc")}}
+                &uarr;
+              {{else}}
+                &darr;
+              {{/if}}
+            </button>
+          </MT.DataGroupBySelect>
+        {{/if}}
+        <MT.ColumnsDropdown>
+          <button {{action MT.showAllColumns}}>Show All</button>
+          <button {{action MT.hideAllColumns}}>Hide All</button>
+          <button {{action MT.restoreDefaultVisibility}}>Restore defaults</button>
+          {{#each MT.processedColumns as |column|}}
+            {{#if column.mayBeHidden}}
+              <button {{action MT.toggleColumnVisibility column}}>
+                {{#if column.isVisible}}
+                  &#9745;
+                {{else}}
+                  &#9744;
+                {{/if}}
+                {{column.title}}
+              </button>
+            {{/if}}
+          {{/each}}
+        </MT.ColumnsDropdown>
+        <MT.Table as |Table|>
+          <Table.Header as |Header|>
+            {{#each MT.groupedHeaders as |groupedHeader|}}
+              <Header.GroupedHeader @groupedHeader={{groupedHeader}} as |GroupedHeader|>
+                {{#if GroupedHeader.shouldAddExtraColumn}}
+                  <th></th>
+                {{/if}}
+                {{#each GroupedHeader.groupedHeader as |cell|}}
+                  <th colspan={{cell.colspan}} rowspan={{cell.rowspan}}>{{cell.title}}</th>
+                {{/each}}
+              </Header.GroupedHeader>
+            {{/each}}
+            <Header.RowSorting as |RowSorting|>
+              {{#if RowSorting.shouldAddExtraColumn}}
+                <th></th>
+              {{/if}}
+              {{#each MT.visibleProcessedColumns as |column|}}
+                <RowSorting.RowSortingCell @column={{column}} />
+              {{/each}}
+            </Header.RowSorting>
+            <Header.RowFiltering as |RowFiltering|>
+              {{#if RowFiltering.shouldAddExtraColumn}}
+                <th></th>
+              {{/if}}
+              {{#each MT.visibleProcessedColumns as |column|}}
+                <RowFiltering.RowFilteringCell @column={{column}} as |RowFilteringCell|>
+                  {{#if column.componentForFilterCell}}
+                    <RowFilteringCell/>
+                  {{else}}
+                    {{#if column.useFilter}}
+                      {{#if column.filterWithSelect}}
+                        <ModelsTable::Select
+                          @type="number"
+                          @value={{column.filterString}}
+                          @options={{column.filterOptions}}/>
+                      {{else}}
+                        {{input value=column.filterString}}
+                      {{/if}}
+                      <button disabled={{unless column.filterUsed "disabled"}} {{action (mut column.filterString) ""}}>&times;</button>
+                    {{/if}}
+                  {{/if}}
+                </RowFiltering.RowFilteringCell>
+              {{/each}}
+            </Header.RowFiltering>
+          </Table.Header>
+          <Table.Body as |Body|>
+            {{#if MT.allColumnsAreHidden}}
+              <Body.ColumnsHidden/>
+            {{else}}
+              {{#if MT.useDataGrouping}}
+                {{#each MT.groupedVisibleContentValuesOrder as |groupedValue groupedIndex|}}
+                  {{#let (filter-by MT.currentGroupingPropertyName groupedValue MT.groupedArrangedContent) as |groupedItems|}}
+                    {{#let (object-at groupedIndex MT.groupedVisibleContent) as |visibleGroupedItems|}}
+                      {{#let
+                        (component Body.RowGrouping
+                          groupedValue=groupedValue
+                          groupedLength=groupedItems.length
+                          groupedItems=groupedItems
+                          visibleGroupedItems=visibleGroupedItems
+                          visibleGroupedLength=visibleGroupedItems.length
+                        )
+                      as |RowGrouping|}}
+                        {{#if (is-equal MT.displayGroupedValueAs "row")}}
+                          <RowGrouping @groupIsCollapsed={{exists-in MT.collapsedGroupValues groupedValue}}/>
+                        {{/if}}
+                        {{#if (exists-in MT.collapsedGroupValues groupedValue)}}
+                          {{#if (is-equal MT.displayGroupedValueAs "column")}}
+                            <RowGrouping @groupIsCollapsed={{true}}/>
+                          {{/if}}
+                        {{else}}
+                          {{#each visibleGroupedItems as |record index|}}
+                            <Body.Row
+                              @record={{record}}
+                              @index={{index}}
+                              @groupedValue={{groupedValue}}
+                              @visibleGroupedItems={{visibleGroupedItems}}
+                            />
+                            {{#if (exists-in MT.expandedItems record)}}
+                              <Body.RowExpand @record={{record}} @index={{index}}>
+                                Row for Record #{{record.id}} is expanded. Row index is {{index}}
+                              </Body.RowExpand>
+                            {{/if}}
+                          {{/each}}
+                        {{/if}}
+                      {{/let}}
+                    {{/let}}
+                  {{/let}}
+                {{/each}}
+              {{else}}
+                {{#each MT.visibleContent as |record index|}}
+                  <Body.Row @record={{record}} @index={{index}}/>
+                  {{#if (exists-in MT.expandedItems record)}}
+                    <Body.RowExpand @record={{record}} @index={{index}}>
+                      Row for Record #{{record.id}} is expanded. Row index is {{index}}
+                    </Body.RowExpand>
+                  {{/if}}
+                {{else}}
+                  <Body.NoData/>
+                {{/each}}
+              {{/if}}
+            {{/if}}
+          </Table.Body>
+          <Table.Footer as |Footer|>
+            <tr>
+              <td colspan={{if Footer.shouldAddExtraColumn (inc MT.visibleProcessedColumns.length) MT.visibleProcessedColumns.length}}>
+                Some custom summary for table can be shown in the <code>tfoot</code>
+              </td>
+            </tr>
+          </Table.Footer>
+        </MT.Table>
+        <div class={{MT.themeInstance.tfooterInternalWrapper}}>
+          <MT.Summary>
+            Show: {{MT.firstIndex}} - {{MT.lastIndex}} of {{MT.recordsCount}}
+            <button disabled={{unless MT.anyFilterUsed "disabled"}} {{action MT.clearFilters}}>&times;</button>
+          </MT.Summary>
+          <div class={{MT.themeInstance.pageSizeWrapper}}>
+            Rows:
+            <ModelsTable::Select
+              @type="number"
+              @value={{MT.pageSize}}
+              @options={{MT.pageSizeOptions}}/>
+          </div>
+          {{#if useNumericPagination}}
+            <MT.PaginationNumeric as |Pagination|>
+              <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+                {{#each Pagination.visiblePageNumbers as |page|}}
+                  {{#if page.isLink}}
+                    <button {{action MT.goToPage page.label}}>
+                      {{page.label}}
+                    </button>
+                  {{else}}
+                    <button disabled="disabled">
+                      {{page.label}}
+                    </button>
+                  {{/if}}
+                {{/each}}
+              </div>
+              <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+                <ModelsTable::Select
+                  @type="number"
+                  @value={{MT.currentPageNumber}}
+                  @options={{MT.currentPageNumberOptions}}/>
+              </div>
+            </MT.PaginationNumeric>
+          {{else}}
+            <MT.PaginationSimple as |Pagination|>
+              <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+                <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToFirst}}>
+                  &lt;&lt;
+                </button>
+                <button disabled={{unless Pagination.goToBackEnabled "disabled"}} {{action Pagination.goToPrev}}>
+                  &lt;
+                </button>
+                <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToNext}}>
+                  &gt;
+                </button>
+                <button disabled={{unless Pagination.goToForwardEnabled "disabled"}} {{action Pagination.goToLast}}>
+                  &gt;&gt;
+                </button>
+              </div>
+              <div class={{MT.themeInstance.currentPageSizeSelectWrapper}}>
+                <ModelsTable::Select
+                  @type="number"
+                  @value={{MT.currentPageNumber}}
+                  @options={{MT.currentPageNumberOptions}}/>
+              </div>
+            </MT.PaginationSimple>
+          {{/if}}
+        </div>
+      </ModelsTable>`);
+    assert.ok(true);
   });
 
 });

--- a/tests/integration/components/models-table/page-size-select-test.js
+++ b/tests/integration/components/models-table/page-size-select-test.js
@@ -30,7 +30,7 @@ module('Integration | Component | models table/page size select', function(hooks
     {{#models-table data=data columns=columns as |ModelsTable|}}
       {{ModelsTable.Table}}
       {{#ModelsTable.Footer as |Footer|}}
-        {{Footer.SizeSelect}}
+        {{Footer.PageSizeSelect}}
       {{/ModelsTable.Footer}}
     {{/models-table}}`);
 
@@ -47,9 +47,9 @@ module('Integration | Component | models table/page size select', function(hooks
     {{#models-table data=data columns=columns as |ModelsTable|}}
       {{ModelsTable.Table}}
       {{#ModelsTable.Footer as |Footer|}}
-        {{#Footer.SizeSelect as |S|}}
+        {{#Footer.PageSizeSelect as |S|}}
           {{S.Select}}
-        {{/Footer.SizeSelect}}
+        {{/Footer.PageSizeSelect}}
       {{/ModelsTable.Footer}}
     {{/models-table}}`);
 

--- a/tests/integration/components/models-table/pagination-numeric-test.js
+++ b/tests/integration/components/models-table/pagination-numeric-test.js
@@ -45,10 +45,9 @@ module('Integration | Component | models table/pagination numeric', function(hoo
           {{#each PN.visiblePageNumbers as |page|}}
             {{#if page.isLink}}
               <button type="button" class="{{if page.isActive "active"}}"
-              {{action PN.goToPage page.label}}>{{page.label}}</button>
+              {{action MT.goToPage page.label}}>{{page.label}}</button>
             {{else}}
-              <button disabled="disabled" type="button"
-                {{action PN.goToPage page.label}}>{{page.label}}</button>
+              <button disabled="disabled" type="button">{{page.label}}</button>
             {{/if}}
           {{/each}}
         </Footer.PaginationNumeric>

--- a/tests/integration/components/models-table/pagination-numeric-test.js
+++ b/tests/integration/components/models-table/pagination-numeric-test.js
@@ -45,10 +45,10 @@ module('Integration | Component | models table/pagination numeric', function(hoo
           {{#each PN.visiblePageNumbers as |page|}}
             {{#if page.isLink}}
               <button type="button" class="{{if page.isActive "active"}}"
-              {{action PN.gotoCustomPage page.label}}>{{page.label}}</button>
+              {{action PN.goToPage page.label}}>{{page.label}}</button>
             {{else}}
               <button disabled="disabled" type="button"
-                {{action PN.gotoCustomPage page.label}}>{{page.label}}</button>
+                {{action PN.goToPage page.label}}>{{page.label}}</button>
             {{/if}}
           {{/each}}
         </Footer.PaginationNumeric>


### PR DESCRIPTION
* All props/events handlers from `models-table` component are yielded only from it and not from nested components (`models-table/*`)
* Some custom props/events handlers from nested components (`models-table/*`) are yielded from them
* Some props and event handlers were renamed
* Docs are updated
* Big block-usage demo is added