### PR TITLE
Use cell component for simple and route cells

### DIFF
--- a/addon/templates/components/models-table/row.hbs
+++ b/addon/templates/components/models-table/row.hbs
@@ -55,25 +55,23 @@ as |Row|}}
     {{/if}}
     {{#each visibleProcessedColumns as |column|}}
       {{#if column.simple}}
-        <td class={{column.className}}>
+        <Row.Cell @column={{column}}>
           {{#if column.propertyName}}
             {{get record column.propertyName}}
           {{/if}}
-        </td>
+        </Row.Cell>
+      {{else if column.routeName}}
+        <Row.Cell @column={{column}}>
+          {{#link-to column.routeName (get record column.routeProperty)}}
+            {{#if column.propertyName}}
+              {{get record column.propertyName}}
+            {{else}}
+              {{record.id}}
+            {{/if}}
+          {{/link-to}}
+        </Row.Cell>
       {{else}}
-        {{#if column.routeName}}
-          <td class={{column.className}}>
-            {{#link-to column.routeName (get record column.routeProperty)}}
-              {{#if column.propertyName}}
-                {{get record column.propertyName}}
-              {{else}}
-                {{record.id}}
-              {{/if}}
-            {{/link-to}}
-          </td>
-        {{else}}
-          <Row.Cell @index={{index}} @column={{column}} />
-        {{/if}}
+        <Row.Cell @index={{index}} @column={{column}} />
       {{/if}}
     {{/each}}
   {{/if}}

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -1295,7 +1295,7 @@ module('ModelsTable | Integration', function (hooks) {
     assert.ok(this.ModelsTablePageObject.navigation.btns.objectAt(3).icon.includes('nav-last'), 'Last-button has valid class');
   });
 
-  test('columns column cell classes', async function (assert) {
+  test('custom column cell classes', async function (assert) {
 
     const columns = generateColumns(['index', 'reversedIndex']);
     columns[0].className = 'custom-column-class';
@@ -1306,6 +1306,12 @@ module('ModelsTable | Integration', function (hooks) {
     await render(hbs`<ModelsTable @data={{data}} @columns={{columns}} />`);
 
     assert.equal(this.element.querySelectorAll('tbody .custom-column-class').length, 10, 'Custom column class exists on each column cell');
+
+    columns[0].simple = true;
+    // force re-render
+    await render(hbs`<ModelsTable @data={{data}} @columns={{columns}} />`);
+
+    assert.equal(this.element.querySelectorAll('tbody .custom-column-class').length, 10, 'Custom class for simple column exists on each column cell');
 
   });
 


### PR DESCRIPTION
Make it easier to customize the `cell` component theme, like extending the classnames for all cell components, that could be applied to simple and route cells.