### PR TITLE
Upgrade to ember-composable-helpers v5

### DIFF
--- a/addon/components/models-table/themes/default/row-expand.ts
+++ b/addon/components/models-table/themes/default/row-expand.ts
@@ -60,7 +60,7 @@ export interface RowExpandArgs {
  *     <Table.Body as |Body|>
  *       {{#each MT.visibleContent as |record index|}}
  *         <Body.Row @record={{record}} @index={{index}} />
- *         {{#if (contains record MT.expandedItems)}} {{! `contains` can be imported from `ember-composable-helpers` }}
+ *         {{#if (includes record MT.expandedItems)}} {{! `includes` can be imported from `ember-composable-helpers` }}
  *           <Body.RowExpand @record={{record}} @index={{index}} />
  *         {{/if}}
  *       {{/each}}

--- a/addon/components/models-table/themes/default/row.hbs
+++ b/addon/components/models-table/themes/default/row.hbs
@@ -75,7 +75,7 @@
           class={{@themeInstance.groupingCell}}>
           <Row.RowGroupToggle
             @groupedValue={{@groupedValue}}
-            @groupIsCollapsed={{contains @groupValue @collapsedGroupValues}} />
+            @groupIsCollapsed={{includes @groupValue @collapsedGroupValues}} />
         </td>
       {{/if}}
       {{#each @visibleProcessedColumns as |column|}}

--- a/addon/components/models-table/themes/default/table-body.hbs
+++ b/addon/components/models-table/themes/default/table-body.hbs
@@ -92,9 +92,9 @@
                 }}
                   {{#if (is-equal @displayGroupedValueAs "row")}}
                     <RowGrouping
-                      @groupIsCollapsed={{contains groupedValue @collapsedGroupValues}} />
+                      @groupIsCollapsed={{includes groupedValue @collapsedGroupValues}} />
                   {{/if}}
-                  {{#if (contains groupedValue @collapsedGroupValues)}}
+                  {{#if (includes groupedValue @collapsedGroupValues)}}
                     {{#if (is-equal @displayGroupedValueAs "column")}}
                       <RowGrouping @groupIsCollapsed={{true}}/>
                     {{/if}}
@@ -108,7 +108,7 @@
                         @groupedItems={{groupedItems}}
                         @groupSummaryRowComponent={{@groupSummaryRowComponent}}
                         @visibleGroupedItems={{visibleGroupedItems}}/>
-                      {{#if (contains record @expandedItems)}}
+                      {{#if (includes record @expandedItems)}}
                         <TableBody.RowExpand
                           @record={{record}}
                           @index={{index}} />
@@ -139,7 +139,7 @@
             <TableBody.Row
               @record={{record}}
               @index={{index}}/>
-            {{#if (contains record @expandedItems)}}
+            {{#if (includes record @expandedItems)}}
               <TableBody.RowExpand
                 @expandedRowComponent={{@expandedRowComponent}}
                 @record={{record}}

--- a/addon/components/models-table/themes/default/table-body.ts
+++ b/addon/components/models-table/themes/default/table-body.ts
@@ -190,7 +190,7 @@ export interface TableBodyArgs {
  *         {{#if MT.visibleContent.length}}
  *           {{#each MT.visibleContent as |record index|}}
  *             <Body.Row @record={{record}} @index={{index}} />
- *             {{#if (contains record MT.expandedItems)}} {{! contains can be imported from `ember-composable-helpers` }}
+ *             {{#if (includes record MT.expandedItems)}} {{! includes can be imported from `ember-composable-helpers` }}
  *               <Body.RowExpand @record={{record}} @index={{index}} />
  *             {{/if}}
  *           {{/each}}

--- a/addon/components/models-table/themes/ember-paper/select.hbs
+++ b/addon/components/models-table/themes/ember-paper/select.hbs
@@ -8,7 +8,7 @@
   @onChange={{this.updateValue}}
   class="{{@themeInstance.input}} {{@themeInstance.select}} {{@cssPropertyName}}"
 as |opt|>
-  {{#if (contains "value" (keys opt))}}
+  {{#if (includes "value" (keys opt))}}
     <span aria-valuetext={{opt.value}}>{{opt.label}}</span>
   {{else}}
     {{opt}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,7 +31,7 @@ module.exports = function (defaults) {
         'object-at',
         'map-by',
         'inc',
-        'contains',
+        'includes',
         'keys',
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11314,13 +11314,13 @@
       }
     },
     "ember-composable-helpers": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-4.2.2.tgz",
-      "integrity": "sha512-gupkBd9nRRUaRuDXqnHj0BozILKpE18TKizDJPU075JL6YD22gP0JtlhtRFYszlljUHfbHMG6r2Ns38md3kyxA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-5.0.0.tgz",
+      "integrity": "sha512-gyUrjiSju4QwNrsCLbBpP0FL6VDFZaELNW7Kbcp60xXhjvNjncYgzm4zzYXhT+i1lLA6WEgRZ3lOGgyBORYD0w==",
       "requires": {
         "@babel/core": "^7.0.0",
         "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "^7.11.1",
+        "ember-cli-babel": "^7.26.3",
         "resolve": "^1.10.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-string-helpers": "^6.1.0",
-    "ember-composable-helpers": "~4.2.2",
+    "ember-composable-helpers": "^5.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ember-cli-typescript": "^4.1.0"
   },

--- a/tests/dummy/app/templates/examples/block-usage.hbs
+++ b/tests/dummy/app/templates/examples/block-usage.hbs
@@ -31,7 +31,7 @@
       {{else}}
         {{#each MT.visibleContent as |record index|}}
           <Body.Row @record={{record}} @index={{index}}/>
-          {{#if (contains record MT.expandedItems)}}
+          {{#if (includes record MT.expandedItems)}}
             <Body.RowExpand @record={{record}} @index={{index}}>
               Row for Record #{{record.id}} is expanded. Row index is {{index}}
             </Body.RowExpand>
@@ -174,10 +174,10 @@
                 }}
                   {{#if (is-equal MT.displayGroupedValueAs "row")}}
                     <RowGrouping
-                      @groupIsCollapsed={{contains groupedValue MT.collapsedGroupValues}}
+                      @groupIsCollapsed={{includes groupedValue MT.collapsedGroupValues}}
                       @additionalColspan={{1}}/>
                   {{/if}}
-                  {{#if (contains groupedValue MT.collapsedGroupValues)}}
+                  {{#if (includes groupedValue MT.collapsedGroupValues)}}
                     {{#if (is-equal MT.displayGroupedValueAs "column")}}
                       <RowGrouping
                         @groupIsCollapsed={{true}}
@@ -196,7 +196,7 @@
                             class={{MT.themeInstance.groupingCell}}>
                             <Row.RowGroupToggle
                               @groupedValue={{groupedValue}}
-                              @groupIsCollapsed={{contains groupedValue MT.collapsedGroupValues}} />
+                              @groupIsCollapsed={{includes groupedValue MT.collapsedGroupValues}} />
                           </td>
                         {{/if}}
                         <td>
@@ -207,7 +207,7 @@
                           <Row.Cell @column={{this.column}} @index={{index}} />
                         {{/each}}
                       </Body.Row>
-                      {{#if (contains record MT.expandedItems)}}
+                      {{#if (includes record MT.expandedItems)}}
                         <Body.RowExpand @record={{record}} @index={{index}} @additionalColspan={{1}}>
                           Row for Record #{{record.id}} is expanded. Row index is {{index}}
                         </Body.RowExpand>
@@ -229,7 +229,7 @@
                 <Row.Cell @column={{this.column}} @index={{index}} />
               {{/each}}
             </Body.Row>
-            {{#if (contains record MT.expandedItems)}}
+            {{#if (includes record MT.expandedItems)}}
               <Body.RowExpand @record={{record}} @index={{index}} @additionalColspan={{1}}>
                 Row for Record #{{record.id}} is expanded. Row index is {{index}}
               </Body.RowExpand>

--- a/tests/dummy/app/templates/examples/nested-table.hbs
+++ b/tests/dummy/app/templates/examples/nested-table.hbs
@@ -50,7 +50,7 @@ as |MT|>
           <Body.Row
             @record={{record}}
             @index={{index}}/>
-          {{#if (contains record MT.expandedItems)}}
+          {{#if (includes record MT.expandedItems)}}
             <Body.RowExpand
               @record={{record}}
               @index={{index}}>

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -5512,10 +5512,10 @@ module('ModelsTable | Integration', function (hooks) {
                       as |RowGrouping|}}
                         {{#if (is-equal MT.displayGroupedValueAs "row")}}
                           <RowGrouping
-                            @groupIsCollapsed={{contains groupedValue MT.collapsedGroupValues}}
+                            @groupIsCollapsed={{includes groupedValue MT.collapsedGroupValues}}
                             @additionalColspan={{1}}/>
                         {{/if}}
-                        {{#if (contains groupedValue MT.collapsedGroupValues)}}
+                        {{#if (includes groupedValue MT.collapsedGroupValues)}}
                           {{#if (is-equal MT.displayGroupedValueAs "column")}}
                             <RowGrouping
                               @groupIsCollapsed={{true}}
@@ -5534,7 +5534,7 @@ module('ModelsTable | Integration', function (hooks) {
                                   class={{MT.themeInstance.groupingCell}}>
                                   <Row.RowGroupToggle
                                     @groupedValue={{groupedValue}}
-                                    @groupIsCollapsed={{contains groupedValue MT.collapsedGroupValues}} />
+                                    @groupIsCollapsed={{includes groupedValue MT.collapsedGroupValues}} />
                                 </td>
                               {{/if}}
                               <td>
@@ -5545,7 +5545,7 @@ module('ModelsTable | Integration', function (hooks) {
                                 <Row.Cell @column={{column}} @index={{index}} />
                               {{/each}}
                             </Body.Row>
-                            {{#if (contains record MT.expandedItems)}}
+                            {{#if (includes record MT.expandedItems)}}
                               <Body.RowExpand @record={{record}} @index={{index}} @additionalColspan={{1}}>
                                 Row for Record #{{record.id}} is expanded. Row index is {{index}}
                               </Body.RowExpand>
@@ -5567,7 +5567,7 @@ module('ModelsTable | Integration', function (hooks) {
                       <Row.Cell @column={{column}} @index={{index}} />
                     {{/each}}
                   </Body.Row>
-                  {{#if (contains record MT.expandedItems)}}
+                  {{#if (includes record MT.expandedItems)}}
                     <Body.RowExpand @record={{record}} @index={{index}} @additionalColspan={{1}}>
                       Row for Record #{{record.id}} is expanded. Row index is {{index}}
                     </Body.RowExpand>


### PR DESCRIPTION
* The only breaking change appears to be removing the already-deprecated `contains` helper, which was renamed to `includes` over a year ago: https://github.com/DockYard/ember-composable-helpers/pull/379

It would be ideal to merge this while `ember-models-table` is still in 4.0 beta, so you don't have to do another 5.0 major release.