### PR TITLE
add `preventDefault` to `<a>` tag action

### DIFF
--- a/addon/components/models-table/themes/default/summary.ts
+++ b/addon/components/models-table/themes/default/summary.ts
@@ -87,6 +87,7 @@ export default class Summary extends Component<SummaryArgs> {
   @action
   protected doClearFilters(e: Event): void {
     e?.stopPropagation?.();
+    e?.preventDefault?.();
     this.args.clearFilters();
   }
 


### PR DESCRIPTION
The `<a>` tag that calls this action uses the `{{on ...}}` modifier. The default action of following the link is triggered and the app navigates to `#` when this tag is clicked. Since this is an `<a>` tag that is actually playing the role of a button I believe we do not want to perform the default action.