### PR TITLE
Improve sort speed on larger tables of static data.

### DIFF
--- a/addon/components/models-table.ts
+++ b/addon/components/models-table.ts
@@ -1361,7 +1361,8 @@ export default class ModelsTableComponent<
    */
   get currentPageNumberOptions(): SelectOption[] {
     const currentPageNumberOptions = A<SelectOption>([]);
-    for (let i = 1; i <= this.pagesCount; i++) {
+    const pageCount = this.pagesCount;
+    for (let i = 1; i <= pageCount; i++) {
       currentPageNumberOptions.push(optionStrToObj(i));
     }
     return currentPageNumberOptions;


### PR DESCRIPTION
I noticed sort performance was very slow for larger sets.  This fixes one of the main reasons.

Previously, `this.pagesCount` was called for every page.  Inside the `pagesCount` property, a calculation is made on `this.arrangedContent.length`.  Retrieving the `arrangedContent` property causes the active sort and filter to be performed.

By taking the page count out of the loop we significantly reduce the number of sorts performed on larger sets (eg, 20+ pages).

This can still be improved - there are still multiple sorts, one every time `arrangedContent` is referenced, but now they are at least not O(N).