### PR TITLE
fix typo in argument name of API docs

### DIFF
--- a/addon/components/models-table-server-paginated.ts
+++ b/addon/components/models-table-server-paginated.ts
@@ -110,7 +110,7 @@ export interface ModelsTableServerPaginatedArgs extends ModelsTableArgs {
  *
  * Here `doQuery` is an action-handler used when user interacts with table by changing page number, page size, global or column filter, sorting etc.
  *
- * `itemsCount` and `pageCount` show how many rows are in the table's page and how many pages are overall.
+ * `itemsCount` and `pagesCount` show how many rows are in the table's page and how many pages are overall.
  *
  * ModelsTableServerPaginated yields same components, actions and properties as a ModelsTable does. Check its docs for more info.
  *


### PR DESCRIPTION
I got confused by this typo. Was wondering why it is not working as expected until I realized it should be `pagesCount` and not `pageCount`. Let's make sure no one else will be confused by this one. :smile_cat: 