### PR TITLE
Allow splattributes in ModelsTable component

### DIFF
--- a/addon/components/models-table.hbs
+++ b/addon/components/models-table.hbs
@@ -1,7 +1,9 @@
 {{!-- template-lint-disable no-invalid-interactive  --}}
 <div
   class="models-table-wrapper"
-  {{on "click" this.onClick}}>
+  {{on "click" this.onClick}}
+  ...attributes
+>
   {{#let
     (hash
       GlobalFilter=(

--- a/tests/integration/components/models-table-test.js
+++ b/tests/integration/components/models-table-test.js
@@ -160,7 +160,7 @@ module('ModelsTable | Integration', function (hooks) {
     });
 
     await render(
-      hbs`<ModelsTable @themeInstance={{this.themeInstance}} @data={{this.data}} @columns={{this.columns}} />`
+      hbs`<ModelsTable @themeInstance={{this.themeInstance}} @data={{this.data}} @columns={{this.columns}} data-test-foo />`
     );
 
     assert.strictEqual(
@@ -189,6 +189,9 @@ module('ModelsTable | Integration', function (hooks) {
       oneTenArrayDig,
       'Content is valid'
     );
+    assert
+      .dom('[data-test-foo]')
+      .exists('attributes can be applied by consumers');
   });
 
   test('basic render with data update', async function (assert) {


### PR DESCRIPTION
Since converting to Octane, the ModelsTable component no longer supports attributes being passed in by consumers. This prevents devs from being able to do things like set HTML attributes or use `ember-test-selectors` to test that ModelsTable is being rendered. This change adds splattributes to the `models-table-wrapper` div and adds a test to confirm it's working as expected.