### PR TITLE
Add Volta Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,10 @@
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },
+  "volta": {
+    "node": "14.21.3",
+    "yarn": "1.22.19"
+  },
   "ember": {
     "edition": "octane"
   },


### PR DESCRIPTION
[Volta](https://volta.sh/) is a JavaScript tool manager that makes it easy to switch between versions of tools like node/yarn/etc between projects. By adding this config, volta users can ensure they are using the expected versions of various tools when working with this project. This has no detrimental effect on non-volta users.

Since the current node range in package.json is backwards compatible to Node 14, I have added the latest Node 14 LTS release in the volta config. When Node 14 is dropped, you can simply update this to the latest Node 16 release, and so on. Additionally, I've pulled in the last yarn 1.x release, so users who have yarn 3 installed don't accidentally overwrite this project's lockfile without the other necessary changes that would be needed to convert to yarn 3.

See also: https://github.com/elwayman02/ember-resize-modifier/blob/master/package.json#L88-L91

Example of testing it in the terminal:

```
volta install yarn
success: installed and set yarn@4.0.0-rc.39 as default
   note: you are using yarn@1.22.19 in the current project
yarn
yarn install v1.22.19
```

As you can see, even though volta had the yarn 4 release candidate installed globally, it still used yarn 1.22.19 when I ran a yarn install within the project, once the config was added.

Importantly, this ensures that local test runs execute in a compatible version of Node. I tested it myself:

```
1..174
# tests 174
# pass  174
# skip  0
# todo  0
# fail  0

# ok
✨  Done in 102.84s.
```