### PR TITLE
Enable sortIcon to be used with ember-fontawesome@v5

### DIFF
--- a/addon/components/models-table/themes/default/row-sorting-cell.hbs
+++ b/addon/components/models-table/themes/default/row-sorting-cell.hbs
@@ -34,8 +34,11 @@
       <span role="button" tabindex="0" {{on "click" this.onClick}}>
         {{@column.columnTitle}}
         {{#if @column.useSorting}}
-          <i class="{{if @column.sortAsc @themeInstance.sortAscIcon}} {{if @column.sortDesc @themeInstance.sortDescIcon}}">
-          </i>
+          {{#if @column.sortAsc}}
+            <i class="{{@themeInstance.sortAscIcon}}" />
+          {{else if @column.sortDesc}}
+            <i class="{{@themeInstance.sortDescIcon}}" />
+          {{/if}}
         {{/if}}
       </span>
     {{/if}}


### PR DESCRIPTION
In the latest [ember-fontawesome](https://github.com/FortAwesome/ember-fontawesome), fontawesome icons must be drawn with `<svg>` tags, not `<i>` tags.

We can replace `<i>` tags with `<svg>` tags by executing `dom.i2svg()`.
https://github.com/FortAwesome/ember-fontawesome/blob/master/UPGRADING.md#mixed-modes-with-automatic-replacement-of-i-tags-to-svg

However, if the `if` conditional branch is in an `<i>` tag, it is not possible to switch between asc and desc when replacing with `dom.i2svg()`