### PR TITLE
Add splattributes to every component that has a clear top-level element

### DIFF
--- a/addon/components/models-table/themes/bootstrap3/row-select-all-checkbox.hbs
+++ b/addon/components/models-table/themes/bootstrap3/row-select-all-checkbox.hbs
@@ -1,7 +1,8 @@
 <button
   onclick={{this.doToggleAllSelection}}
   type="button"
-  class="toggle-all {{@themeInstance.buttonLink}}">
+  class="toggle-all {{@themeInstance.buttonLink}}"
+  ...attributes>
   {{#if (and @selectedItems.length (not-eq @selectedItems.length @data.length))}}
     <span class="emt-icons-stack">
       <i class={{@themeInstance.selectSomeRowsIcon}}></i>

--- a/addon/components/models-table/themes/bootstrap4/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/bootstrap4/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/bootstrap4/data-group-by-select.hbs
+++ b/addon/components/models-table/themes/bootstrap4/data-group-by-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.dataGroupBySelectWrapper}}">
+<div class="{{@themeInstance.dataGroupBySelectWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/bootstrap4/global-filter.hbs
+++ b/addon/components/models-table/themes/bootstrap4/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.globalFilterWrapper}}">
+<div class="{{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/bootstrap4/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (component

--- a/addon/components/models-table/themes/default/cell-column-summary.hbs
+++ b/addon/components/models-table/themes/default/cell-column-summary.hbs
@@ -1,4 +1,4 @@
-<td>
+<td ...attributes>
   {{yield
     (
       hash

--- a/addon/components/models-table/themes/default/cell-content-edit.hbs
+++ b/addon/components/models-table/themes/default/cell-content-edit.hbs
@@ -1,4 +1,4 @@
-<label>
+<label ...attributes>
   <Input
     @type="text"
     class={{@themeInstance.input}}

--- a/addon/components/models-table/themes/default/cell-edit-toggle.hbs
+++ b/addon/components/models-table/themes/default/cell-edit-toggle.hbs
@@ -1,5 +1,5 @@
 {{!-- template-lint-disable no-invalid-interactive  --}}
-<div {{on "click" this.onClick}}>
+<div {{on "click" this.onClick}} ...attributes>
   {{#if @isEditRow}}
     <button
       class="{{@themeInstance.buttonDefault}} {{@themeInstance.cancelRowButton}}"

--- a/addon/components/models-table/themes/default/cell.hbs
+++ b/addon/components/models-table/themes/default/cell.hbs
@@ -1,7 +1,8 @@
 {{!-- template-lint-disable no-invalid-interactive  --}}
 <td
   {{on "click" this.onClick}}
-  class="{{@column.className}}">
+  class="{{@column.className}}"
+  ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash

--- a/addon/components/models-table/themes/default/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/default/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/default/columns-hidden.hbs
+++ b/addon/components/models-table/themes/default/columns-hidden.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr ...attributes>
   <td colspan={{this.columnsCount}} class={{@themeInstance.noDataCell}}>
     {{#if (has-block)}}
       {{yield

--- a/addon/components/models-table/themes/default/data-group-by-select.hbs
+++ b/addon/components/models-table/themes/default/data-group-by-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.dataGroupBySelectWrapper}}">
+<div class="{{@themeInstance.dataGroupBySelectWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/default/expand-toggle.hbs
+++ b/addon/components/models-table/themes/default/expand-toggle.hbs
@@ -2,14 +2,16 @@
   <button
     class="{{@themeInstance.buttonLink}} {{@themeInstance.collapseRow}}"
     type="button"
-    {{on "click" this.doCollapseRow}}>
+    {{on "click" this.doCollapseRow}}
+    ...attributes>
     <i class={{@themeInstance.collapseRowIcon}}></i>
   </button>
 {{else}}
   <button
     class="{{@themeInstance.buttonLink}} {{@themeInstance.expandRow}}"
     type="button"
-    {{on "click" this.doExpandRow}}>
+    {{on "click" this.doExpandRow}}
+    ...attributes>
     <i class={{@themeInstance.expandRowIcon}}></i>
   </button>
 {{/if}}

--- a/addon/components/models-table/themes/default/footer.hbs
+++ b/addon/components/models-table/themes/default/footer.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.tfooterInternalWrapper}}">
+<div class="{{@themeInstance.tfooterInternalWrapper}}" ...attributes>
   {{#let
     (hash
       Summary=(

--- a/addon/components/models-table/themes/default/global-filter.hbs
+++ b/addon/components/models-table/themes/default/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.globalFilterWrapper}}">
+<div class="{{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/default/group-summary-row.hbs
+++ b/addon/components/models-table/themes/default/group-summary-row.hbs
@@ -1,3 +1,3 @@
-<tr class="group-summary-row">
+<tr class="group-summary-row" ...attributes>
   {{yield}}
 </tr>

--- a/addon/components/models-table/themes/default/grouped-header.hbs
+++ b/addon/components/models-table/themes/default/grouped-header.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr ...attributes>
   {{#if (has-block)}}
     {{yield (hash groupedHeader=@groupedHeader shouldAddExtraColumn=this.shouldAddExtraColumn)}}
   {{else}}

--- a/addon/components/models-table/themes/default/no-data.hbs
+++ b/addon/components/models-table/themes/default/no-data.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr ...attributes>
   <td colspan={{this.realColumnsCount}}>
     {{#if (has-block)}}
       {{yield}}

--- a/addon/components/models-table/themes/default/page-size-select.hbs
+++ b/addon/components/models-table/themes/default/page-size-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.pageSizeWrapper}}">
+<div class="{{@themeInstance.pageSizeWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/default/pagination-numeric.hbs
+++ b/addon/components/models-table/themes/default/pagination-numeric.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/default/pagination-simple.hbs
+++ b/addon/components/models-table/themes/default/pagination-simple.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/default/row-expand.hbs
+++ b/addon/components/models-table/themes/default/row-expand.hbs
@@ -1,5 +1,8 @@
 {{!-- template-lint-disable no-invalid-interactive  --}}
-<tr {{on "click" this.onClick}} class="expand-row {{this.indexedClass}} {{if this.isSelected "selected-expand"}}">
+<tr
+  {{on "click" this.onClick}}
+  class="expand-row {{this.indexedClass}} {{if this.isSelected "selected-expand"}}"
+  ...attributes>
   {{#let
     (component (ensure-safe-component @expandedRowComponent)
       record=@record

--- a/addon/components/models-table/themes/default/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/default/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (

--- a/addon/components/models-table/themes/default/row-filtering.hbs
+++ b/addon/components/models-table/themes/default/row-filtering.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr ...attributes>
   {{#let
     (hash
       shouldAddExtraColumn=this.shouldAddExtraColumn

--- a/addon/components/models-table/themes/default/row-group-toggle.hbs
+++ b/addon/components/models-table/themes/default/row-group-toggle.hbs
@@ -1,5 +1,10 @@
 {{#if (has-block)}}
   {{yield}}
 {{else}}
-  <button type="button" class="{{@themeInstance.buttonDefault}}" {{on "click" this.doToggleGroupedRows}}>{{@groupedValue}}</button>
+  <button
+    type="button"
+    class="{{@themeInstance.buttonDefault}}" {{on "click" this.doToggleGroupedRows}}
+    ...attributes>
+    {{@groupedValue}}
+  </button>
 {{/if}}

--- a/addon/components/models-table/themes/default/row-grouping.hbs
+++ b/addon/components/models-table/themes/default/row-grouping.hbs
@@ -1,4 +1,4 @@
-<tr class="{{@themeInstance.groupingRow}}">
+<tr class="{{@themeInstance.groupingRow}}" ...attributes>
   <td
     class={{@themeInstance.groupingCell}}
     colspan={{this.cellColspan}}>

--- a/addon/components/models-table/themes/default/row-select-all-checkbox.hbs
+++ b/addon/components/models-table/themes/default/row-select-all-checkbox.hbs
@@ -1,7 +1,8 @@
 <button
   {{on "click" this.doToggleAllSelection}}
   type="button"
-  class="toggle-all {{@themeInstance.buttonLink}}">
+  class="toggle-all {{@themeInstance.buttonLink}}"
+  ...attributes>
   <i class={{if
     (is-equal @selectedItems.length @data.length)
     @themeInstance.selectAllRowsIcon

--- a/addon/components/models-table/themes/default/row-select-checkbox.hbs
+++ b/addon/components/models-table/themes/default/row-select-checkbox.hbs
@@ -1,7 +1,8 @@
 <button
   class={{@themeInstance.buttonLink}}
   type="button"
-  {{on "click" (fn this.doClickOnRow @index @record)}}>
+  {{on "click" (fn this.doClickOnRow @index @record)}}
+  ...attributes>
   <i class={{if @isSelected @themeInstance.selectRowIcon @themeInstance.deselectRowIcon}}></i>
 </button>
 {{yield}}

--- a/addon/components/models-table/themes/default/row-sorting-cell.hbs
+++ b/addon/components/models-table/themes/default/row-sorting-cell.hbs
@@ -1,6 +1,7 @@
 <th
   class="{{@themeInstance.theadCell}} {{@column.className}}"
-  colspan="{{@column.realColspanForSortCell}}">
+  colspan="{{@column.realColspanForSortCell}}"
+  ...attributes>
   {{#if @column.componentForSortCell}}
     {{#let
       (component (ensure-safe-component @column.componentForSortCell)

--- a/addon/components/models-table/themes/default/row-sorting.hbs
+++ b/addon/components/models-table/themes/default/row-sorting.hbs
@@ -1,4 +1,4 @@
-<tr>
+<tr ...attributes>
   {{#let
     (hash
       shouldAddExtraColumn=this.shouldAddExtraColumn

--- a/addon/components/models-table/themes/default/row.hbs
+++ b/addon/components/models-table/themes/default/row.hbs
@@ -4,7 +4,8 @@
   {{on "mouseenter" this.onEnter}}
   {{on "mouseleave" this.onLeave}}
   {{on "click" this.onClick}}
-  {{on "dblclick" this.onDoubleClick}}>
+  {{on "dblclick" this.onDoubleClick}}
+  ...attributes>
   {{#let
     (hash
       Cell=(

--- a/addon/components/models-table/themes/default/summary.hbs
+++ b/addon/components/models-table/themes/default/summary.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}">
+<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}" ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash

--- a/addon/components/models-table/themes/default/table-body.hbs
+++ b/addon/components/models-table/themes/default/table-body.hbs
@@ -1,4 +1,4 @@
-<tbody>
+<tbody ...attributes>
   {{#let
     (hash
       ColumnsHidden=(

--- a/addon/components/models-table/themes/default/table-footer.hbs
+++ b/addon/components/models-table/themes/default/table-footer.hbs
@@ -1,4 +1,4 @@
-<tfoot>
+<tfoot ...attributes>
   {{#let
     (hash
       shouldAddExtraColumn=this.shouldAddExtraColumn

--- a/addon/components/models-table/themes/default/table-header.hbs
+++ b/addon/components/models-table/themes/default/table-header.hbs
@@ -1,4 +1,6 @@
-<thead class="{{@themeInstance.thead}} {{if @noHeaderFilteringAndSorting "table-header-no-filtering-and-sorting"}}">
+<thead
+  class="{{@themeInstance.thead}} {{if @noHeaderFilteringAndSorting "table-header-no-filtering-and-sorting"}}"
+  ...attributes>
   {{#let
     (hash
       RowSorting=(

--- a/addon/components/models-table/themes/default/table.hbs
+++ b/addon/components/models-table/themes/default/table.hbs
@@ -1,4 +1,4 @@
-<table class="{{@themeInstance.table}}">
+<table class="{{@themeInstance.table}}" ...attributes>
   {{#let
     (hash
       Header=(

--- a/addon/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/data-group-by-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.dataGroupBySelectWrapper}}">
+<div class="{{@themeInstance.dataGroupBySelectWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.globalFilterWrapper}}">
+<div class="{{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (component

--- a/addon/components/models-table/themes/ember-bootstrap-v4/summary.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v4/summary.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}">
+<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}" ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash

--- a/addon/components/models-table/themes/ember-bootstrap-v5/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-bootstrap-v5/data-group-by-select.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/data-group-by-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.dataGroupBySelectWrapper}}">
+<div class="{{@themeInstance.dataGroupBySelectWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/ember-bootstrap-v5/global-filter.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.globalFilterWrapper}}">
+<div class="{{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-bootstrap-v5/page-size-select.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/page-size-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.pageSizeWrapper}}">
+<div class="{{@themeInstance.pageSizeWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/ember-bootstrap-v5/pagination-numeric.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/pagination-numeric.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/ember-bootstrap-v5/pagination-simple.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/pagination-simple.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/ember-bootstrap-v5/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (component

--- a/addon/components/models-table/themes/ember-bootstrap-v5/summary.hbs
+++ b/addon/components/models-table/themes/ember-bootstrap-v5/summary.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}">
+<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}" ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash

--- a/addon/components/models-table/themes/ember-paper/cell-content-edit.hbs
+++ b/addon/components/models-table/themes/ember-paper/cell-content-edit.hbs
@@ -1,4 +1,4 @@
 {{#let (get @record @column.propertyName) as |value|}}
-  <this.PaperInput @value={{this.value}} @onChange={{fn (mut value)}}/>
+  <this.PaperInput @value={{this.value}} @onChange={{fn (mut value)}} ...attributes/>
 {{/let}}
 {{yield}}

--- a/addon/components/models-table/themes/ember-paper/cell-edit-toggle.hbs
+++ b/addon/components/models-table/themes/ember-paper/cell-edit-toggle.hbs
@@ -1,5 +1,5 @@
 {{!-- template-lint-disable no-invalid-interactive  --}}
-<div {{on "click" this.onClick}}>
+<div {{on "click" this.onClick}} ...attributes>
   {{#if this.isEditRow}}
     <this.PaperButton
       class="{{@themeInstance.buttonDefault}} {{@themeInstance.cancelRowButton}}"

--- a/addon/components/models-table/themes/ember-paper/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/ember-paper/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-paper/data-group-by-select.hbs
+++ b/addon/components/models-table/themes/ember-paper/data-group-by-select.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.dataGroupBySelectWrapper}}">
+<div class="{{@themeInstance.dataGroupBySelectWrapper}}" ...attributes>
   {{#let
     (hash
       Select=(

--- a/addon/components/models-table/themes/ember-paper/expand-toggle.hbs
+++ b/addon/components/models-table/themes/ember-paper/expand-toggle.hbs
@@ -1,9 +1,9 @@
 {{#if @isExpanded}}
-  <this.PaperButton @onClick={{fn this.doCollapseRow @index @record}} @iconButton={{true}}>
+  <this.PaperButton @onClick={{fn this.doCollapseRow @index @record}} @iconButton={{true}} ...attributes>
     <this.PaperIcon @icon={{@themeInstance.collapseRowIcon}} class={{@themeInstance.collapseRowIcon}}/>
   </this.PaperButton>
 {{else}}
-  <this.PaperButton @onClick={{fn this.doExpandRow @index @record}} @iconButton={{true}}>
+  <this.PaperButton @onClick={{fn this.doExpandRow @index @record}} @iconButton={{true}} ...attributes>
     <this.PaperIcon @icon={{@themeInstance.expandRowIcon}} class={{@themeInstance.expandRowIcon}}/>
   </this.PaperButton>
 {{/if}}

--- a/addon/components/models-table/themes/ember-paper/global-filter.hbs
+++ b/addon/components/models-table/themes/ember-paper/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="globalSearch {{@themeInstance.globalFilterWrapper}}">
+<div class="globalSearch {{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/ember-paper/pagination-numeric.hbs
+++ b/addon/components/models-table/themes/ember-paper/pagination-numeric.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperNumeric}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/ember-paper/pagination-simple.hbs
+++ b/addon/components/models-table/themes/ember-paper/pagination-simple.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}">
+<div class="{{@themeInstance.paginationWrapper}} {{@themeInstance.paginationWrapperDefault}}" ...attributes>
   {{#let
     (hash
       PageNumberSelect=(

--- a/addon/components/models-table/themes/ember-paper/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/ember-paper/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (

--- a/addon/components/models-table/themes/ember-paper/row-select-all-checkbox.hbs
+++ b/addon/components/models-table/themes/ember-paper/row-select-all-checkbox.hbs
@@ -1,5 +1,6 @@
 <this.PaperCheckbox
   @indeterminate={{and @selectedItems.length (not-eq @selectedItems.length @data.length)}}
   @value={{is-equal @selectedItems.length @data.length}}
-  @onChange={{this.doToggleAllSelection}} />
+  @onChange={{this.doToggleAllSelection}}
+  ...attributes />
 {{yield}}

--- a/addon/components/models-table/themes/ember-paper/row-select-checkbox.hbs
+++ b/addon/components/models-table/themes/ember-paper/row-select-checkbox.hbs
@@ -1,5 +1,6 @@
 <this.PaperCheckbox
   @value={{@isSelected}}
   @bubbles={{false}}
-  @onChange={{fn this.doClickOnRow @index @record}} />
+  @onChange={{fn this.doClickOnRow @index @record}}
+  ...attributes />
 {{yield}}

--- a/addon/components/models-table/themes/ember-paper/row-sorting-cell.hbs
+++ b/addon/components/models-table/themes/ember-paper/row-sorting-cell.hbs
@@ -1,6 +1,7 @@
 <th
   class="{{@themeInstance.theadCell}} {{@column.className}}"
-  colspan="{{@column.realColspanForSortCell}}">
+  colspan="{{@column.realColspanForSortCell}}"
+  ...attributes>
   {{#if @column.componentForSortCell}}
     {{#let
       (component (ensure-safe-component @column.componentForSortCell)

--- a/addon/components/models-table/themes/ember-paper/summary.hbs
+++ b/addon/components/models-table/themes/ember-paper/summary.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}">
+<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}" ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash

--- a/addon/components/models-table/themes/plain-html/columns-dropdown.hbs
+++ b/addon/components/models-table/themes/plain-html/columns-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.columnsDropdownWrapper}}">
+<div class="{{@themeInstance.columnsDropdownWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/plain-html/global-filter.hbs
+++ b/addon/components/models-table/themes/plain-html/global-filter.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.globalFilterWrapper}}">
+<div class="{{@themeInstance.globalFilterWrapper}}" ...attributes>
   {{#if (has-block)}}
     {{yield}}
   {{else}}

--- a/addon/components/models-table/themes/plain-html/row-filtering-cell.hbs
+++ b/addon/components/models-table/themes/plain-html/row-filtering-cell.hbs
@@ -1,4 +1,7 @@
-<th class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}" colspan="{{@column.realColspanForFilterCell}}">
+<th
+  class="{{@themeInstance.theadCell}} {{@column.className}} {{this.filteringClassName}}"
+  colspan="{{@column.realColspanForFilterCell}}"
+  ...attributes>
   {{#if @column.componentForFilterCell}}
     {{#let
       (component

--- a/addon/components/models-table/themes/plain-html/summary.hbs
+++ b/addon/components/models-table/themes/plain-html/summary.hbs
@@ -1,4 +1,4 @@
-<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}">
+<div class="{{@themeInstance.footerSummary}} {{this.paginationTypeClass}}" ...attributes>
   {{#if (has-block)}}
     {{yield
       (hash


### PR DESCRIPTION
I don't think we need 66 individual tests for splattributes on every component, as that seems overkill.

Also, if you feel any of these components shouldn't have splattributes or should have them on another element, feel free to edit this PR as needed.

There were a handful of components I didn't touch, mostly because they didn't have a clear wrapping element around the entire template. This will get you most of the way to full splattributes usage, though, and you can decide how to handle edge-cases like `expand-all-toggle` in a separate PR if needed.