### PR TITLE
Add `@tracked` to `isLoading` and `isError`

### DIFF
--- a/addon/components/models-table-server-paginated.ts
+++ b/addon/components/models-table-server-paginated.ts
@@ -164,12 +164,14 @@ export default class ModelsTableServerPaginated extends ModelsTable<ModelsTableS
    * True if data is currently being loaded from the server.
    * Can be used in the template to e.g. display a loading spinner.
    */
+  @tracked
   isLoading = false;
 
   /**
    * True if last data query promise has been rejected.
    * Can be used in the template to e.g. indicate stale data or to e.g. show error state.
    */
+  @tracked
   isError = false;
 
   /**


### PR DESCRIPTION
Add `@tracked` to `isLoading` and `isError`.

Previously `isLoading` and `isError` were not tracked, which means that the template was never updated, thus, not able to render loading and error states.

Added tests to ensure that it works.