### PR TITLE
Fix: Update updateProperty to extract value from event target

### DIFF
--- a/addon/components/models-table/themes/default/cell-content-edit.ts
+++ b/addon/components/models-table/themes/default/cell-content-edit.ts
@@ -9,10 +9,11 @@ import { action, set } from '@ember/object';
  */
 export default class CellContentEdit extends Component<CellContentEditSignature> {
   @action
-  updateProperty(value: string): void {
+  updateProperty(e: Event): void {
     if (!this.args.column.propertyName) {
       return;
     }
-    set(this.args.record, this.args.column.propertyName, value);
+    const target = e.target as HTMLButtonElement;
+    set(this.args.record, this.args.column.propertyName, target.value);
   }
 }


### PR DESCRIPTION
The edit function passes the "input" event rather than the value
When you edit, you end up with [object InputEvent] rather than the modified string

Example here :
https://onechiporenko.github.io/ember-models-table/v.5/plain-html/#/examples/in-line-edit